### PR TITLE
chore: remove deprecated `baseUrl`, drop `@/` alias imports, add `.npmrc`

### DIFF
--- a/.changeset/hungry-mice-relate.md
+++ b/.changeset/hungry-mice-relate.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-common": patch
+---
+
+Migrate away from `@/` imports.

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+# We are using flatten config of eslint and not using prettier
+# Disable the default public-hoist-pattern(*-eslint-*, *-prettier-*)
+public-hoist-pattern=
+hoist-workspace-packages=true
+strict-peer-dependencies=true
+engine-strict=true
+registry=https://registry.npmjs.org/

--- a/packages/lynx-ui-button/tsconfig.json
+++ b/packages/lynx-ui-button/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-checkbox/tsconfig.json
+++ b/packages/lynx-ui-checkbox/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-common/src/hooks/useRefresh.ts
+++ b/packages/lynx-ui-common/src/hooks/useRefresh.ts
@@ -4,6 +4,10 @@
 
 import { runOnBackground, useMainThreadRef } from '@lynx-js/react'
 
+import { NativeGesture, useGesture } from '@lynx-js/gesture-runtime'
+import type { GestureChangeEvent, StateManager } from '@lynx-js/gesture-runtime'
+import type { MainThread, ScrollEvent } from '@lynx-js/types'
+
 import type {
   BounceableBasicProps,
   RefreshEvent,
@@ -12,12 +16,7 @@ import type {
   headerReleased,
   refreshOffsetEvent,
   scrollToBouncesInfo,
-} from '@/types'
-
-import { NativeGesture, useGesture } from '@lynx-js/gesture-runtime'
-import type { GestureChangeEvent, StateManager } from '@lynx-js/gesture-runtime'
-import type { MainThread, ScrollEvent } from '@lynx-js/types'
-
+} from '../types'
 import { RefreshState } from '../types/interfaces/RefreshInterface'
 import { selectorMT } from '../utils/selector'
 import { mtsNativeLynxSDKVersionLessThan } from '../utils/version'

--- a/packages/lynx-ui-common/tsconfig.json
+++ b/packages/lynx-ui-common/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-dialog/tsconfig.json
+++ b/packages/lynx-ui-dialog/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-draggable/tsconfig.json
+++ b/packages/lynx-ui-draggable/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-feed-list/tsconfig.json
+++ b/packages/lynx-ui-feed-list/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-form/tsconfig.json
+++ b/packages/lynx-ui-form/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-input/tsconfig.json
+++ b/packages/lynx-ui-input/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-lazy-component/tsconfig.json
+++ b/packages/lynx-ui-lazy-component/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-list/tsconfig.json
+++ b/packages/lynx-ui-list/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-overlay/tsconfig.json
+++ b/packages/lynx-ui-overlay/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-popover/tsconfig.json
+++ b/packages/lynx-ui-popover/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-presence/tsconfig.json
+++ b/packages/lynx-ui-presence/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-radio-group/tsconfig.json
+++ b/packages/lynx-ui-radio-group/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-scroll-view/tsconfig.json
+++ b/packages/lynx-ui-scroll-view/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-sheet/tsconfig.json
+++ b/packages/lynx-ui-sheet/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-sortable/tsconfig.json
+++ b/packages/lynx-ui-sortable/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-swipe-action/tsconfig.json
+++ b/packages/lynx-ui-swipe-action/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-swiper/tsconfig.json
+++ b/packages/lynx-ui-swiper/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui-switch/tsconfig.json
+++ b/packages/lynx-ui-switch/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/packages/lynx-ui/tsconfig.json
+++ b/packages/lynx-ui/tsconfig.json
@@ -1,13 +1,7 @@
 {
   "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/tools/configs/tsconfig.base.json
+++ b/tools/configs/tsconfig.base.json
@@ -13,6 +13,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "declarationMap": true,
-    "incremental": true
+    "incremental": true,
+    "forceConsistentCasingInFileNames": true
   }
 }

--- a/tools/configs/tsconfig.lib.json
+++ b/tools/configs/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "emitDeclarationOnly": true,
+    "forceConsistentCasingInFileNames": true,
     "types": [
       "@lynx-js/types"
     ]

--- a/tools/make-new-component/template/tsconfig.json
+++ b/tools/make-new-component/template/tsconfig.json
@@ -1,13 +1,7 @@
 {
-  "extends": "../../tools/configs/tsconfig.lib.json",
+  "extends": "../../configs/tsconfig.lib.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src",
-    "paths": {
-      "@/*": [
-        "./src/*",
-      ],
-    },
   },
   "include": [
     "src",

--- a/tools/make-new-component/tsconfig.json
+++ b/tools/make-new-component/tsconfig.json
@@ -1,10 +1,7 @@
 {
-  "extends": [
-    "../../tsconfig.json",
-  ],
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "baseUrl": "./",
     "rootDir": "./",
     "noEmit": true,
     "allowJs": true,

--- a/tools/rsbuild-plugin-select-entry/tsconfig.json
+++ b/tools/rsbuild-plugin-select-entry/tsconfig.json
@@ -1,10 +1,7 @@
 {
-  "extends": [
-    "../../tsconfig.json",
-  ],
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "baseUrl": "./",
     "rootDir": "./",
     "noEmit": true,
   },

--- a/tools/typedoc/tsconfig.json
+++ b/tools/typedoc/tsconfig.json
@@ -1,10 +1,7 @@
 {
-  "extends": [
-    "../../tsconfig.json",
-  ],
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "baseUrl": "./",
     "rootDir": "./",
     "noEmit": true,
   },

--- a/tools/vitestSetup/tsconfig.json
+++ b/tools/vitestSetup/tsconfig.json
@@ -1,10 +1,7 @@
 {
-  "extends": [
-    "../../tsconfig.json",
-  ],
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "baseUrl": "./",
     "rootDir": "./",
     "noEmit": true,
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,6 +50,9 @@
     {
       "path": "./packages/lynx-ui-scroll-view"
     },
+        {
+      "path": "./packages/lynx-ui-sheet"
+    },
     {
       "path": "./packages/lynx-ui-sortable"
     },
@@ -58,9 +61,6 @@
     },
     {
       "path": "./packages/lynx-ui-swiper"
-    },
-    {
-      "path": "./packages/lynx-ui-sheet"
     },
     {
       "path": "./packages/lynx-ui-switch"


### PR DESCRIPTION
- remove `baseUrl` and `paths` from package tsconfigs
- remove `@/` alias imports in package source code (`lynx-ui-common`)
- add `.npmrc` to ensure consistent OSS npm registry