### PR TITLE
chore: fix tsconfig extends path

### DIFF
--- a/tools/make-new-component/template/tsconfig.json
+++ b/tools/make-new-component/template/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../configs/tsconfig.lib.json",
+  "extends": "../../tools/configs/tsconfig.lib.json",
   "compilerOptions": {
     "rootDir": "./src",
   },


### PR DESCRIPTION
Fix path error in tsconfig.json when creating component examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the component template TypeScript configuration source reference for better configuration organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->