### PR TITLE
chore: prevent publishing @lynx-js/luna-* packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,5 +12,11 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [
+    "@lynx-js/luna-*"
+  ],
+  "privatePackages": {
+    "tag": false,
+    "version": false
+  }
 }

--- a/.changeset/good-birds-tickle.md
+++ b/.changeset/good-birds-tickle.md
@@ -1,9 +1,0 @@
----
-"@lynx-js/luna-reactlynx": patch
-"@lynx-js/luna-tailwind": patch
-"@lynx-js/luna-styles": patch
-"@lynx-js/luna-tokens": patch
-"@lynx-js/luna-core": patch
----
-
-Add @lynx-js/luna-\* shim packages synced from lunarium.

--- a/luna/packages/luna-core/package.json
+++ b/luna/packages/luna-core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lynx-js/luna-core",
   "version": "0.1.0",
+  "private": true,
   "description": "Core constants, types, and utilities for the L.U.N.A project.",
   "keywords": [
     "luna",

--- a/luna/packages/luna-reactlynx/package.json
+++ b/luna/packages/luna-reactlynx/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lynx-js/luna-reactlynx",
   "version": "0.1.0",
+  "private": true,
   "description": "Reactlynx theming primitives (provider/hooks) and optional runtime wrappers for the L.U.N.A project.",
   "keywords": [
     "luna",

--- a/luna/packages/luna-styles/package.json
+++ b/luna/packages/luna-styles/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lynx-js/luna-styles",
   "version": "0.1.0",
+  "private": true,
   "description": "CSS theme variables for the L.U.N.A project.",
   "license": "Apache-2.0",
   "author": "The Lynx Authors",

--- a/luna/packages/luna-tailwind/package.json
+++ b/luna/packages/luna-tailwind/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lynx-js/luna-tailwind",
   "version": "0.1.0",
+  "private": true,
   "description": "TailwindCSS preset for the L.U.N.A project.",
   "keywords": [
     "luna",

--- a/luna/packages/luna-tokens/package.json
+++ b/luna/packages/luna-tokens/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lynx-js/luna-tokens",
   "version": "0.1.0",
+  "private": true,
   "description": "Design tokens for the L.U.N.A project.",
   "keywords": [
     "luna",


### PR DESCRIPTION
- Add `private: true` to all `@lynx-js/luna-*` packages
- Add `@lynx-js/luna-*` pattern to changeset ignore list
- Delete existing changeset file for `@lynx-js/luna-*` packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked internal packages as private to prevent accidental publication.
  * Updated changeset configuration to manage private packages appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->