### PR TITLE
feat(lazy-component): add `unmountOnExit` alias and deprecate `unloadable`

### DIFF
--- a/.changeset/calm-badgers-teach.md
+++ b/.changeset/calm-badgers-teach.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/lynx-ui-lazy-component': patch
+---
+
+Add `unmountOnExit` as a clearer alias for lazy content unmount behavior and deprecate `unloadable` while keeping backward compatibility.

--- a/packages/lynx-ui-lazy-component/SKILL.md
+++ b/packages/lynx-ui-lazy-component/SKILL.md
@@ -59,7 +59,7 @@ function App() {
               scene={'scene'}
               pid={`pid_${index}`}
               estimatedStyle={{ width: '100%', height: '100px' }} // make sure the estimated size is equal to the real size
-              unloadable
+              unmountOnExit
             >
               <view
                 style={{
@@ -110,4 +110,5 @@ function App() {
 - **MUST**: The `estimatedStyle` prop is required. It is an object that specifies the estimated size of the content of the item. The estimated size could be equal to or smaller than the real size of the content.
 - **MUST**: The `scene` and `pid` props are required. They are used to identify the item. Their combination must be unique.
 - **NOTICE**: The rule of `bottom`, `top`, `left`, and `right` props is that to expand the exposure margin of the item. The default value is `0px`.
-- **NOTICE**: The `unloadable` prop is used to specify whether the content of the item is unloadable. If it is set to `true`, the content of the item will be unloaded when it is out of the viewport.
+- **NOTICE**: Use `unmountOnExit` to specify whether the content of the item should be unmounted when it is out of the viewport.
+- **NOTICE**: `unloadable` is deprecated and kept only for backward compatibility. Prefer `unmountOnExit`.

--- a/packages/lynx-ui-lazy-component/src/index.tsx
+++ b/packages/lynx-ui-lazy-component/src/index.tsx
@@ -44,9 +44,11 @@ function LazyComponentImpl(
     bottom = '10px',
     left = '10px',
     right = '10px',
+    unmountOnExit,
     unloadable = false,
     children,
   } = props
+  const shouldUnmountOnExit = unmountOnExit ?? unloadable
   const [show, setShow] = useState<boolean>(false)
   const cacheSizeRef = useRef<{ width: string, height: string }>(undefined)
 
@@ -84,7 +86,7 @@ function LazyComponentImpl(
     (events: unknown[]) => {
       'background-only'
 
-      if (unloadable) {
+      if (shouldUnmountOnExit) {
         events.forEach(event => {
           if (
             // @ts-expect-error exposure-scene and exposure-id is currently not declared in eventProps
@@ -97,10 +99,10 @@ function LazyComponentImpl(
         })
       }
     },
-    [unloadable],
+    [shouldUnmountOnExit],
   )
 
-  if (unloadable) {
+  if (shouldUnmountOnExit) {
     const { width, height, ...restsStyles } = estimatedStyle
     return (
       <view

--- a/packages/lynx-ui-lazy-component/src/types/index.docs.ts
+++ b/packages/lynx-ui-lazy-component/src/types/index.docs.ts
@@ -69,8 +69,17 @@ export interface LazyComponentProps {
    */
   right?: `${number}px` | `${number}rpx`
   /**
+   * Unmount child when dis-exposure to save mem-usage
+   * @zh 当元素不可见时卸载子元素以节省内存使用
+   * @defaultValue false
+   * @Android
+   * @iOS
+   */
+  unmountOnExit?: boolean
+  /**
    * Unload child when dis-exposure to save mem-usage
    * @zh 当元素不可见时卸载子元素以节省内存使用
+   * @deprecated Please use unmountOnExit instead.
    * @defaultValue false
    * @Android
    * @iOS


### PR DESCRIPTION
### Motivation
- The prop name `unloadable` is ambiguous about the exact behavior (it reads like an adjective rather than an action triggered on leaving viewport), so a clearer name is needed while preserving backward compatibility.

### Description
- Add a new `unmountOnExit?: boolean` prop to `LazyComponent` and keep `unloadable?: boolean` marked as `@deprecated` in the types (`packages/lynx-ui-lazy-component/src/types/index.docs.ts`).
- Update runtime logic to prefer `unmountOnExit` and fall back to `unloadable` via `const shouldUnmountOnExit = unmountOnExit ?? unloadable`, and use `shouldUnmountOnExit` in the `disexposure` listener and render branches (`packages/lynx-ui-lazy-component/src/index.tsx`).
- Update documentation and examples to use `unmountOnExit` and note that `unloadable` is deprecated (`packages/lynx-ui-lazy-component/SKILL.md`).
- Add a changeset for the package (`.changeset/calm-badgers-teach.md`).

### Testing
- Ran `pnpm install` to ensure workspace deps were present and up to date, which completed successfully.
- Attempted `pnpm --filter @lynx-js/lynx-ui-lazy-component build`, which initially failed due to missing declarations from `@lynx-js/lynx-ui-common` when built in isolation (expected in a monorepo build order).
- Ran `pnpm --filter @lynx-js/lynx-ui-common --filter @lynx-js/lynx-ui-lazy-component build`, which succeeded and produced declaration files for both packages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7df83c1c48331a9ed8a29734fb7ea)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `unmountOnExit` prop to LazyComponent for configuring component behavior.

* **Documentation**
  * Updated documentation to recommend the new `unmountOnExit` prop; the `unloadable` option is now deprecated but remains supported for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->