### PR TITLE
fix(swipe-action): allow ref in SwipeAction props typings

### DIFF
--- a/.changeset/shy-corners-wish.md
+++ b/.changeset/shy-corners-wish.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-swipe-action": patch
+---
+
+Fix `SwipeAction` typings to accept `ref`.

--- a/packages/lynx-ui-swipe-action/src/types/index.docs.ts
+++ b/packages/lynx-ui-swipe-action/src/types/index.docs.ts
@@ -2,13 +2,14 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { ReactElement } from '@lynx-js/react'
+import type { ForwardedRef, ReactElement } from '@lynx-js/react'
 
 import type { ComponentBasicProps } from '@lynx-js/lynx-ui-common'
 
 export type SwipeAction = (props: SwipeActionProps) => ReactElement
 
 export interface SwipeActionProps extends ComponentBasicProps {
+  ref?: ForwardedRef<SwipeActionRef>
   /**
    * Whether allow swipe action. When it set to false, this item can only be used to display content.
    * @zh 是否允许滑动操作。当设置为 false 时，SwipeAction 只能用来显示内容。


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SwipeAction component now supports React ref forwarding, enabling direct access to component instances and improving composability with wrapper components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->