### PR TITLE
feat: polish Sortable examples

### DIFF
--- a/apps/examples/Sortable/Basic/index.tsx
+++ b/apps/examples/Sortable/Basic/index.tsx
@@ -22,37 +22,37 @@ export function App() {
   )
 
   return (
-    <view className='sortable-root lunaris-dark'>
-      <view
-        id='sortableContainer'
-        // Required: establish a stacking context for sortable drag layers
-        style={{ zIndex: '0' }}
+    <view
+      className='sortable-root lunaris-dark'
+      id='sortableContainer'
+      // Required: establish a stacking context for sortable drag layers
+      style={{ zIndex: '0' }}
+    >
+      <SortableRoot
+        data={data}
+        boundaryId='sortableContainer'
+        onSortEnd={(sortedData: SortableData<SortableDemoItem>[]) =>
+          setData(sortedData)}
       >
-        <SortableRoot
-          data={data}
-          boundaryId='sortableContainer'
-          onSortEnd={(sortedData: SortableData<SortableDemoItem>[]) =>
-            setData(sortedData)}
-        >
-          {(item: SortableData<SortableDemoItem>) => {
-            const { id, tone } = item.dataItem
+        {(item: SortableData<SortableDemoItem>) => {
+          const { id, tone } = item.dataItem
 
-            return (
-              <SortableItem
-                as='DraggableRoot'
-                className={`sortable-item sortable-item--${id}`}
-                sortingKey={item.getSortingKey()}
-              >
-                <SortableItemArea className='sortable-item-area'>
-                  <text className={`drag-here-text drag-here-text--${tone}`}>
-                    Drag Here
-                  </text>
-                </SortableItemArea>
-              </SortableItem>
-            )
-          }}
-        </SortableRoot>
-      </view>
+          return (
+            <SortableItem
+              key={item.getSortingKey()}
+              as='DraggableRoot'
+              className={`sortable-item sortable-item--${id}`}
+              sortingKey={item.getSortingKey()}
+            >
+              <SortableItemArea className='sortable-item-area'>
+                <text className={`drag-here-text drag-here-text--${tone}`}>
+                  Drag Here
+                </text>
+              </SortableItemArea>
+            </SortableItem>
+          )
+        }}
+      </SortableRoot>
     </view>
   )
 }

--- a/apps/examples/Sortable/DisableSorting/index.tsx
+++ b/apps/examples/Sortable/DisableSorting/index.tsx
@@ -18,35 +18,35 @@ export function App() {
   )
 
   return (
-    <view className='sortable-root lunaris-dark'>
-      <view
-        id='sortableContainer'
-        // Required: establish a stacking context for sortable drag layers
-        style={{ zIndex: '0' }}
+    <view
+      className='sortable-root lunaris-dark'
+      id='sortableContainer'
+      // Required: establish a stacking context for sortable drag layers
+      style={{ zIndex: '0' }}
+    >
+      <SortableRoot
+        data={data}
+        boundaryId='sortableContainer'
+        onSortEnd={(sortedData: SortableData<SortableDemoItem>[]) =>
+          setData(sortedData)}
+        enableSorting={false}
       >
-        <SortableRoot
-          data={data}
-          boundaryId='sortableContainer'
-          onSortEnd={(sortedData: SortableData<SortableDemoItem>[]) =>
-            setData(sortedData)}
-          enableSorting={false}
-        >
-          {(item: SortableData<SortableDemoItem>) => {
-            const { id, tone } = item.dataItem
+        {(item: SortableData<SortableDemoItem>) => {
+          const { id, tone } = item.dataItem
 
-            return (
-              <SortableItem
-                className={`sortable-item sortable-item--${id}`}
-                sortingKey={item.getSortingKey()}
-              >
-                <text className={`drag-here-text drag-here-text--${tone}`}>
-                  {id}
-                </text>
-              </SortableItem>
-            )
-          }}
-        </SortableRoot>
-      </view>
+          return (
+            <SortableItem
+              key={item.getSortingKey()}
+              className={`sortable-item sortable-item--${id}`}
+              sortingKey={item.getSortingKey()}
+            >
+              <text className={`drag-here-text drag-here-text--${tone}`}>
+                {id}
+              </text>
+            </SortableItem>
+          )
+        }}
+      </SortableRoot>
     </view>
   )
 }

--- a/apps/examples/Sortable/NoBoundary/index.tsx
+++ b/apps/examples/Sortable/NoBoundary/index.tsx
@@ -29,6 +29,7 @@ export function App() {
           const { id, tone } = item.dataItem
           return (
             <SortableItem
+              key={item.getSortingKey()}
               className={`sortable-item sortable-item--${id}`}
               sortingKey={item.getSortingKey()}
             >

--- a/apps/examples/Sortable/WithScrollView/index.css
+++ b/apps/examples/Sortable/WithScrollView/index.css
@@ -6,14 +6,18 @@
 .scroll-view {
   width: 100%;
   height: 100%;
-  padding-top: 100px;
-  padding-right: 12px;
-  padding-left: 12px;
+  padding-top: 84px;
+  padding-bottom: 84px;
+  padding-right: 16px;
+  padding-left: 16px;
   z-index: 0;
 }
 
 .sortable-root {
   border-radius: 16px;
+  height: calc(100% + 200px);
+  padding-left: 32px;
+  padding-right: 32px;
 }
 
 .luna-gradient-berry {
@@ -22,8 +26,4 @@
     var(--gradient-b),
     var(--gradient-c)
   );
-}
-
-.sortable-root {
-  height: 120vh;
 }

--- a/apps/examples/Sortable/WithScrollView/index.tsx
+++ b/apps/examples/Sortable/WithScrollView/index.tsx
@@ -40,6 +40,7 @@ export function App() {
 
       return (
         <SortableItem
+          key={item.getSortingKey()}
           as='DraggableRoot'
           className={`sortable-item sortable-item--${id}`}
           sortingKey={item.getSortingKey()}

--- a/apps/examples/Sortable/shared/base.css
+++ b/apps/examples/Sortable/shared/base.css
@@ -7,6 +7,8 @@
   justify-content: center;
   width: 100%;
   height: 100%;
+  padding-left: 40px;
+  padding-right: 40px;
   background-color: var(--canvas);
 }
 
@@ -15,7 +17,7 @@
   flex-direction: row;
   justify-content: end;
   align-items: center;
-  width: 320px;
+  width: 100%;
   height: 64px;
 }
 


### PR DESCRIPTION
- Remove `120vh` for better presentation in `Go`/`Stage`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted spacing and sizing in sortable examples for improved layout, padding, and responsiveness.

* **Refactor**
  * Simplified sortable component structure across examples for cleaner rendering and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->