### PR TITLE
chore(examples): set noEmit and disable declaration output for demo apps

### DIFF
--- a/apps/examples/tsconfig.json
+++ b/apps/examples/tsconfig.json
@@ -1,3 +1,8 @@
 {
   "extends": "../../tools/configs/tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+  },
 }

--- a/tools/configs/rslib.base.ts
+++ b/tools/configs/rslib.base.ts
@@ -27,7 +27,6 @@ export const baseConfig: RslibConfig = {
         },
         sourceMap: true,
         emitCss: true,
-        overrideBrowserslist: 'esnext',
       },
       dts: true,
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compilation settings for the examples project (enabled noEmit; disabled declaration and declaration maps).
  * Removed an obsolete browser-target override from build tooling to standardize compatibility configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->