### PR TITLE
docs: standardize README structure across component packages

### DIFF
--- a/.changeset/green-pots-exist.md
+++ b/.changeset/green-pots-exist.md
@@ -1,0 +1,24 @@
+---
+"@lynx-js/lynx-ui-button": patch
+"@lynx-js/lynx-ui-checkbox": patch
+"@lynx-js/lynx-ui-common": patch
+"@lynx-js/lynx-ui-dialog": patch
+"@lynx-js/lynx-ui-draggable": patch
+"@lynx-js/lynx-ui-feed-list": patch
+"@lynx-js/lynx-ui-form": patch
+"@lynx-js/lynx-ui-input": patch
+"@lynx-js/lynx-ui-lazy-component": patch
+"@lynx-js/lynx-ui-list": patch
+"@lynx-js/lynx-ui-overlay": patch
+"@lynx-js/lynx-ui-popover": patch
+"@lynx-js/lynx-ui-presence": patch
+"@lynx-js/lynx-ui-radio-group": patch
+"@lynx-js/lynx-ui-scroll-view": patch
+"@lynx-js/lynx-ui-sheet": patch
+"@lynx-js/lynx-ui-sortable": patch
+"@lynx-js/lynx-ui-swipe-action": patch
+"@lynx-js/lynx-ui-swiper": patch
+"@lynx-js/lynx-ui-switch": patch
+---
+
+docs: keep README Introduction headings consistent across package docs.

--- a/packages/lynx-ui-button/README.md
+++ b/packages/lynx-ui-button/README.md
@@ -1,10 +1,12 @@
 # @lynx-js/lynx-ui-button
 
-`@lynx-js/lynx-ui-button` provides the **Button** primitives in lynx-ui.
+`@lynx-js/lynx-ui-button` provides the `Button` component in lynx-ui.
 
 ## Introduction
 
-Headless button primitive for tap/click interactions and disabled state handling.
+`Button` is a headless press primitive. The `Basic` example uses a render prop
+to react to the pressed state, while `Disabled` and `PropagateTapEvent` show
+disabled handling and how button clicks interact with outer tap handlers.
 
 ## Installation
 
@@ -18,9 +20,22 @@ pnpm add @lynx-js/lynx-ui-button
 import { Button } from '@lynx-js/lynx-ui-button'
 
 export function BasicButton() {
-  return <Button onTap={() => {}}>Save</Button>
+  return (
+    <Button onClick={() => console.info('clicked')}>
+      {({ active, disabled }) => (
+        <view>
+          <text>
+            {disabled ? 'Disabled' : active ? 'Pressed' : 'Button'}
+          </text>
+        </view>
+      )}
+    </Button>
+  )
 }
 ```
+
+Pass a plain `ReactNode` when you only need a button, or use the render-prop
+form when the pressed and disabled states should affect your UI.
 
 ## Public exports
 

--- a/packages/lynx-ui-button/README.md
+++ b/packages/lynx-ui-button/README.md
@@ -1,93 +1,36 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-button
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-button` provides the **Button** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Headless button primitive for tap/click interactions and disabled state handling.
 
 ## Installation
-
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
-```bash
-pnpm add @lynx-js/lynx-ui
-```
-
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-### Option 2: Importing Individual Components
-
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
 
 ```bash
 pnpm add @lynx-js/lynx-ui-button
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
 import { Button } from '@lynx-js/lynx-ui-button'
 
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
+export function BasicButton() {
+  return <Button onTap={() => {}}>Save</Button>
 }
 ```
 
-## Configuration
+## Public exports
 
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
+```ts
+export { Button, ButtonContext } from './Button'
+export type { ButtonProps } from './types'
 ```
 
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-checkbox/README.md
+++ b/packages/lynx-ui-checkbox/README.md
@@ -1,93 +1,41 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-checkbox
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-checkbox` provides the **Checkbox** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Composable checkbox primitives with indicator support for checked and indeterminate states.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-checkbox
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { Checkbox, CheckboxIndicator } from '@lynx-js/lynx-ui-checkbox'
 
-export default function App() {
+export function BasicCheckbox() {
   return (
-    <view>
-      <Button>Hello</Button>
-    </view>
+    <Checkbox checked={true} onCheckedChange={() => {}}>
+      <CheckboxIndicator>✓</CheckboxIndicator>
+    </Checkbox>
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export { Checkbox } from './Checkbox'
+export { CheckboxIndicator } from './CheckboxIndicator'
+export type { CheckboxProps, CheckboxIndicatorProps } from './types'
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-checkbox/README.md
+++ b/packages/lynx-ui-checkbox/README.md
@@ -1,10 +1,13 @@
 # @lynx-js/lynx-ui-checkbox
 
-`@lynx-js/lynx-ui-checkbox` provides the **Checkbox** primitives in lynx-ui.
+`@lynx-js/lynx-ui-checkbox` provides the `Checkbox` primitives in lynx-ui.
 
 ## Introduction
 
-Composable checkbox primitives with indicator support for checked and indeterminate states.
+`Checkbox` supports uncontrolled and controlled usage, plus an
+`indeterminate` state for "select all" patterns. The examples cover basic
+selection, controlled updates, disabled items, and an indeterminate parent
+checkbox that drives a group.
 
 ## Installation
 
@@ -15,16 +18,27 @@ pnpm add @lynx-js/lynx-ui-checkbox
 ## Usage
 
 ```tsx
+import { useState } from '@lynx-js/react'
 import { Checkbox, CheckboxIndicator } from '@lynx-js/lynx-ui-checkbox'
 
 export function BasicCheckbox() {
+  const [checked, setChecked] = useState(false)
+
   return (
-    <Checkbox checked={true} onCheckedChange={() => {}}>
-      <CheckboxIndicator>✓</CheckboxIndicator>
-    </Checkbox>
+    <view>
+      <Checkbox checked={checked} onChange={setChecked}>
+        <CheckboxIndicator>
+          <text>{checked ? '✓' : ''}</text>
+        </CheckboxIndicator>
+      </Checkbox>
+      <text>{checked ? 'Checked' : 'Unchecked'}</text>
+    </view>
   )
 }
 ```
+
+Set `indeterminate={true}` on the parent checkbox to match the "some children
+selected" state shown in the `Indeterminate` example.
 
 ## Public exports
 

--- a/packages/lynx-ui-common/README.md
+++ b/packages/lynx-ui-common/README.md
@@ -1,10 +1,13 @@
 # @lynx-js/lynx-ui-common
 
-`@lynx-js/lynx-ui-common` provides the **Common** primitives in lynx-ui.
+`@lynx-js/lynx-ui-common` provides shared hooks, helpers, and reactive
+utilities for lynx-ui packages.
 
 ## Introduction
 
-Shared hooks, constants, event helpers, and reactive utilities used across lynx-ui packages.
+This package is the shared foundation for components such as `list`,
+`scroll-view`, `dialog`, and `sheet`. It includes common event and prop types,
+utility hooks, and the reactive value helpers used for main-thread state.
 
 ## Installation
 
@@ -15,11 +18,36 @@ pnpm add @lynx-js/lynx-ui-common
 ## Usage
 
 ```tsx
-import { useReactiveValue, updateReactiveValue } from '@lynx-js/lynx-ui-common'
+import { runOnMainThread } from '@lynx-js/react'
+import {
+  useReactiveValue,
+  useReactiveValueChange,
+  updateReactiveValue,
+} from '@lynx-js/lynx-ui-common'
 
-const counter = useReactiveValue('counter', 0)
-updateReactiveValue('counter', value => value + 1)
+export function ReactiveCounter() {
+  const counterRef = useReactiveValue(0, { label: 'counter' })
+
+  useReactiveValueChange(counterRef, (value) => {
+    console.info('counter changed', value)
+  })
+
+  const increment = runOnMainThread(() => {
+    'main thread'
+    if (!counterRef.current) return
+    updateReactiveValue(counterRef, counterRef.current.value + 1)
+  })
+
+  return (
+    <view bindtap={increment}>
+      <text>Increment counter</text>
+    </view>
+  )
+}
 ```
+
+Call `updateReactiveValue` from a main-thread function. The hook returns a
+main-thread ref rather than a plain JS value.
 
 ## Public exports
 

--- a/packages/lynx-ui-common/README.md
+++ b/packages/lynx-ui-common/README.md
@@ -1,93 +1,51 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-common
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-common` provides the **Common** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Shared hooks, constants, event helpers, and reactive utilities used across lynx-ui packages.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-common
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { useReactiveValue, updateReactiveValue } from '@lynx-js/lynx-ui-common'
 
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
+const counter = useReactiveValue('counter', 0)
+updateReactiveValue('counter', value => value + 1)
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export * from './hooks'
+export * from './utils'
+export * from './const'
+export type * from './types'
+export type {
+  ReactiveValueOptions,
+  ReactiveValueAPI,
+  ReactiveValueType,
+  Subscriber,
+  Unsubscribe,
+} from './reactive'
+export {
+  useReactiveValue,
+  useReactiveValueEvent,
+  updateReactiveValue,
+  useReactiveValueChange,
+} from './reactive'
+export { useMainThreadImperativeHandle } from '@lynx-js/react-use'
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-dialog/README.md
+++ b/packages/lynx-ui-dialog/README.md
@@ -1,10 +1,13 @@
 # @lynx-js/lynx-ui-dialog
 
-`@lynx-js/lynx-ui-dialog` provides the **Dialog** primitives in lynx-ui.
+`@lynx-js/lynx-ui-dialog` provides the `Dialog` primitives in lynx-ui.
 
 ## Introduction
 
-Headless dialog primitives for trigger/content/backdrop composition and open-state control.
+`Dialog` is composed from `DialogRoot`, `DialogTrigger`, `DialogView`,
+`DialogBackdrop`, `DialogContent`, and `DialogClose`. The examples cover
+controlled and uncontrolled open state, force-mounted content, and animation
+status via render props.
 
 ## Installation
 
@@ -15,26 +18,41 @@ pnpm add @lynx-js/lynx-ui-dialog
 ## Usage
 
 ```tsx
+import { useState } from '@lynx-js/react'
 import {
+  DialogBackdrop,
+  DialogClose,
+  DialogContent,
   DialogRoot,
   DialogTrigger,
-  DialogBackdrop,
-  DialogContent,
-  DialogClose,
+  DialogView,
 } from '@lynx-js/lynx-ui-dialog'
 
 export function BasicDialog() {
+  const [show, setShow] = useState(false)
+
   return (
-    <DialogRoot>
-      <DialogTrigger>Open</DialogTrigger>
-      <DialogBackdrop />
-      <DialogContent>
-        <DialogClose>Close</DialogClose>
-      </DialogContent>
+    <DialogRoot show={show} onShowChange={setShow}>
+      <DialogTrigger>
+        <text>Open Dialog</text>
+      </DialogTrigger>
+
+      <DialogView>
+        <DialogBackdrop />
+        <DialogContent>
+          <text>Dialog content</text>
+          <DialogClose>
+            <text>Close</text>
+          </DialogClose>
+        </DialogContent>
+      </DialogView>
     </DialogRoot>
   )
 }
 ```
+
+Use `defaultShow` for uncontrolled dialogs, and `forceMount` when the dialog
+content should stay mounted even while hidden.
 
 ## Public exports
 

--- a/packages/lynx-ui-dialog/README.md
+++ b/packages/lynx-ui-dialog/README.md
@@ -1,93 +1,65 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-dialog
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-dialog` provides the **Dialog** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Headless dialog primitives for trigger/content/backdrop composition and open-state control.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-dialog
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import {
+  DialogRoot,
+  DialogTrigger,
+  DialogBackdrop,
+  DialogContent,
+  DialogClose,
+} from '@lynx-js/lynx-ui-dialog'
 
-export default function App() {
+export function BasicDialog() {
   return (
-    <view>
-      <Button>Hello</Button>
-    </view>
+    <DialogRoot>
+      <DialogTrigger>Open</DialogTrigger>
+      <DialogBackdrop />
+      <DialogContent>
+        <DialogClose>Close</DialogClose>
+      </DialogContent>
+    </DialogRoot>
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export {
+  DialogView,
+  DialogRoot,
+  DialogContent,
+  DialogTrigger,
+  DialogClose,
+  DialogBackdrop,
+} from './Dialog'
+export type { PresenceAnimationStatus } from '@lynx-js/lynx-ui-presence'
+export type {
+  DialogBackdropProps,
+  DialogContentProps,
+  DialogRootProps,
+  DialogTriggerProps,
+  DialogCloseProps,
+  DialogViewProps,
+} from './types'
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-draggable/README.md
+++ b/packages/lynx-ui-draggable/README.md
@@ -1,93 +1,51 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-draggable
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-draggable` provides the **Draggable** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Drag-and-drop primitives and hook for movable elements with optional draggable boundaries.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-draggable
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import {
+  DraggableRoot,
+  DraggableArea,
+  Draggable,
+} from '@lynx-js/lynx-ui-draggable'
 
-export default function App() {
+export function BasicDraggable() {
   return (
-    <view>
-      <Button>Hello</Button>
-    </view>
+    <DraggableRoot>
+      <DraggableArea>
+        <Draggable>Drag me</Draggable>
+      </DraggableArea>
+    </DraggableRoot>
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export { Draggable, DraggableRoot, DraggableArea } from './Draggable'
+export { useDraggable } from './useDraggable'
+export type {
+  DraggableProps,
+  DraggableAreaProps,
+  DraggableRef,
+} from './types/index.docs'
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-draggable/README.md
+++ b/packages/lynx-ui-draggable/README.md
@@ -1,10 +1,13 @@
 # @lynx-js/lynx-ui-draggable
 
-`@lynx-js/lynx-ui-draggable` provides the **Draggable** primitives in lynx-ui.
+`@lynx-js/lynx-ui-draggable` provides the `Draggable` primitives in lynx-ui.
 
 ## Introduction
 
-Drag-and-drop primitives and hook for movable elements with optional draggable boundaries.
+`Draggable` can make an entire node movable, while `DraggableRoot` with
+`DraggableArea` lets you restrict dragging to a handle. The examples also show
+bounded dragging with `minTranslateX`, `maxTranslateX`, `minTranslateY`, and
+`maxTranslateY`.
 
 ## Installation
 
@@ -15,22 +18,21 @@ pnpm add @lynx-js/lynx-ui-draggable
 ## Usage
 
 ```tsx
-import {
-  DraggableRoot,
-  DraggableArea,
-  Draggable,
-} from '@lynx-js/lynx-ui-draggable'
+import { DraggableArea, DraggableRoot } from '@lynx-js/lynx-ui-draggable'
 
 export function BasicDraggable() {
   return (
-    <DraggableRoot>
+    <DraggableRoot resetOnEnd={true} trigger='immediate'>
       <DraggableArea>
-        <Draggable>Drag me</Draggable>
+        <text>Drag here</text>
       </DraggableArea>
     </DraggableRoot>
   )
 }
 ```
+
+Use `Draggable` directly when the whole node is draggable. Add translation
+limits when you need the bounded behavior from the `WithBounds` example.
 
 ## Public exports
 

--- a/packages/lynx-ui-feed-list/README.md
+++ b/packages/lynx-ui-feed-list/README.md
@@ -1,10 +1,13 @@
 # @lynx-js/lynx-ui-feed-list
 
-`@lynx-js/lynx-ui-feed-list` provides the **FeedList** primitives in lynx-ui.
+`@lynx-js/lynx-ui-feed-list` provides the `FeedList` component in lynx-ui.
 
 ## Introduction
 
-List wrapper that combines list virtualization with pull-to-refresh and bounce behavior options.
+`FeedList` builds on top of `List` and adds pull-to-refresh, load-more
+footers, and no-more-data handling. The `Basic` example shows the full flow:
+refreshing, appending more items when the list reaches the bottom, and
+switching to a no-more-data footer.
 
 ## Installation
 
@@ -15,19 +18,48 @@ pnpm add @lynx-js/lynx-ui-feed-list
 ## Usage
 
 ```tsx
+import { useRef, useState } from '@lynx-js/react'
 import { FeedList } from '@lynx-js/lynx-ui-feed-list'
+import type { FeedListRef } from '@lynx-js/lynx-ui-feed-list'
 
-export function BasicFeedList({ children }) {
+const initialItems = [
+  { itemKey: 'A', label: 'A' },
+  { itemKey: 'B', label: 'B' },
+]
+
+export function BasicFeedList() {
+  const feedListRef = useRef<FeedListRef>(null)
+  const [items, setItems] = useState(initialItems)
+
   return (
     <FeedList
-      refreshOptions={{ enableRefresh: true }}
-      bounceableOptions={{ enableBounces: true }}
+      ref={feedListRef}
+      listId='feedListBasic'
+      listType='single'
+      spanCount={1}
+      scrollOrientation='vertical'
+      refreshOptions={{
+        enableRefresh: true,
+        onStartRefresh: () => {
+          setTimeout(() => {
+            setItems([...initialItems].reverse())
+            feedListRef.current?.finishRefresh()
+          }, 1000)
+        },
+      }}
     >
-      {children}
+      {items.map((item) => (
+        <list-item key={item.itemKey} item-key={item.itemKey}>
+          <text>{item.label}</text>
+        </list-item>
+      ))}
     </FeedList>
   )
 }
 ```
+
+Use `loadMoreFooter`, `noMoreDataFooter`, `finishRefresh`, and
+`changeHasMoreStatus` to match the complete flow from the `Basic` example.
 
 ## Public exports
 

--- a/packages/lynx-ui-feed-list/README.md
+++ b/packages/lynx-ui-feed-list/README.md
@@ -1,93 +1,47 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-feed-list
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-feed-list` provides the **FeedList** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+List wrapper that combines list virtualization with pull-to-refresh and bounce behavior options.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-feed-list
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { FeedList } from '@lynx-js/lynx-ui-feed-list'
 
-export default function App() {
+export function BasicFeedList({ children }) {
   return (
-    <view>
-      <Button>Hello</Button>
-    </view>
+    <FeedList
+      refreshOptions={{ enableRefresh: true }}
+      bounceableOptions={{ enableBounces: true }}
+    >
+      {children}
+    </FeedList>
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export type { FeedListRef, FeedListProps }
+export type {
+  BounceableBasicProps,
+  RefreshProps,
+} from '@lynx-js/lynx-ui-common'
+export const FeedList = memo(forwardRef(FeedListImpl)) as FeedListType
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-form/README.md
+++ b/packages/lynx-ui-form/README.md
@@ -1,10 +1,14 @@
 # @lynx-js/lynx-ui-form
 
-`@lynx-js/lynx-ui-form` provides the **Form** primitives in lynx-ui.
+`@lynx-js/lynx-ui-form` provides the `Form` primitives in lynx-ui.
 
 ## Introduction
 
-Headless form primitives for root, field registration, and submit button coordination.
+`FormRoot` owns the form values, `FormField` binds individual fields to Lynx UI
+components such as `Input`, `TextArea`, `Checkbox`, `Switch`, and
+`RadioGroupRoot`, and `FormSubmitButton` submits the collected values. The
+examples cover both a standard form flow and a keyboard-aware form inside a
+scrollable layout.
 
 ## Installation
 
@@ -15,17 +19,49 @@ pnpm add @lynx-js/lynx-ui-form
 ## Usage
 
 ```tsx
-import { FormRoot, FormField, FormSubmitButton } from '@lynx-js/lynx-ui-form'
+import { CheckboxIndicator } from '@lynx-js/lynx-ui-checkbox'
+import { FormField, FormRoot, FormSubmitButton } from '@lynx-js/lynx-ui-form'
+import { Radio, RadioIndicator } from '@lynx-js/lynx-ui-radio-group'
 
 export function BasicForm() {
   return (
-    <FormRoot>
-      <FormField name='email'>{() => <input />}</FormField>
-      <FormSubmitButton>Submit</FormSubmitButton>
+    <FormRoot
+      initialValues={{ workspaceType: '', workspaceName: 'My Workspace' }}
+      onChanged={(values) => console.info(values)}
+    >
+      <FormField as='RadioGroupRoot' name='workspaceType'>
+        <Radio value='team'>
+          <RadioIndicator />
+          <text>Team</text>
+        </Radio>
+        <Radio value='personal'>
+          <RadioIndicator />
+          <text>Personal</text>
+        </Radio>
+      </FormField>
+
+      <FormField
+        as='Input'
+        name='workspaceName'
+        placeholder='Workspace name'
+      />
+
+      <FormField as='Checkbox' name='agreement'>
+        <CheckboxIndicator />
+        <text>I agree to the terms</text>
+      </FormField>
+
+      <FormSubmitButton onSubmit={(values) => console.info(values)}>
+        <text>Submit</text>
+      </FormSubmitButton>
     </FormRoot>
   )
 }
 ```
+
+Wrap the form with `KeyboardAwareRoot`, `KeyboardAwareResponder`, and
+`KeyboardAwareTrigger` when the focused field should stay visible inside a long
+scroll, as shown in the `KeyboardAware` example.
 
 ## Public exports
 

--- a/packages/lynx-ui-form/README.md
+++ b/packages/lynx-ui-form/README.md
@@ -1,93 +1,46 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-form
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-form` provides the **Form** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Headless form primitives for root, field registration, and submit button coordination.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-form
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { FormRoot, FormField, FormSubmitButton } from '@lynx-js/lynx-ui-form'
 
-export default function App() {
+export function BasicForm() {
   return (
-    <view>
-      <Button>Hello</Button>
-    </view>
+    <FormRoot>
+      <FormField name='email'>{() => <input />}</FormField>
+      <FormSubmitButton>Submit</FormSubmitButton>
+    </FormRoot>
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export { FormRoot, FormSubmitButton, FormField } from './Form'
+export { FormContext } from './FormContext'
+export type {
+  FormRootProps,
+  FormSubmitButtonProps,
+  FormFieldProps,
+} from './types'
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-input/README.md
+++ b/packages/lynx-ui-input/README.md
@@ -1,10 +1,14 @@
 # @lynx-js/lynx-ui-input
 
-`@lynx-js/lynx-ui-input` provides the **Input** primitives in lynx-ui.
+`@lynx-js/lynx-ui-input` provides input primitives and keyboard-aware helpers
+in lynx-ui.
 
 ## Introduction
 
-Input primitives including Input, TextArea, and keyboard-aware helpers.
+The `Basic` example covers uncontrolled and controlled `Input`, plus
+multi-line `TextArea`. The keyboard-aware examples show how
+`KeyboardAwareRoot`, `KeyboardAwareResponder`, and `KeyboardAwareTrigger` keep
+focused fields visible in regular layouts and inside `ScrollView`.
 
 ## Installation
 
@@ -15,17 +19,28 @@ pnpm add @lynx-js/lynx-ui-input
 ## Usage
 
 ```tsx
+import { useState } from '@lynx-js/react'
 import { Input, TextArea } from '@lynx-js/lynx-ui-input'
 
 export function BasicInput() {
+  const [value, setValue] = useState('controlledValue')
+
   return (
     <view>
-      <Input placeholder='Title' />
-      <TextArea placeholder='Description' />
+      <Input placeholder='Type here' />
+      <Input
+        value={value}
+        onInput={setValue}
+        placeholder='Controlled'
+      />
+      <TextArea placeholder='Write something...' />
     </view>
   )
 }
 ```
+
+For long forms or scrollers, wrap the layout with `KeyboardAwareRoot` and
+`KeyboardAwareResponder`, then place each field inside `KeyboardAwareTrigger`.
 
 ## Public exports
 

--- a/packages/lynx-ui-input/README.md
+++ b/packages/lynx-ui-input/README.md
@@ -1,93 +1,57 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-input
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-input` provides the **Input** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Input primitives including Input, TextArea, and keyboard-aware helpers.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-input
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { Input, TextArea } from '@lynx-js/lynx-ui-input'
 
-export default function App() {
+export function BasicInput() {
   return (
     <view>
-      <Button>Hello</Button>
+      <Input placeholder='Title' />
+      <TextArea placeholder='Description' />
     </view>
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export { Input } from './Input'
+export { TextArea } from './TextArea'
+export { KeyboardAwareRoot } from './KeyboardAwareRoot'
+export { KeyboardAwareTrigger } from './KeyboardAwareTrigger'
+export { KeyboardAwareResponder } from './KeyboardAwareResponder'
+export {
+  KeyboardAwareRootContext,
+  KeyboardAwareTriggerContext,
+} from './KeyboardAwareContext'
+export type {
+  InputProps,
+  InputRef,
+  TextAreaProps,
+  TextAreaRef,
+  KeyboardAwareTriggerProps,
+  KeyboardAwareResponderProps,
+  KeyboardAwareRootProps,
+} from './types'
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-lazy-component/README.md
+++ b/packages/lynx-ui-lazy-component/README.md
@@ -1,10 +1,18 @@
 # @lynx-js/lynx-ui-lazy-component
 
-`@lynx-js/lynx-ui-lazy-component` provides the **LazyComponent** primitives in lynx-ui.
+`@lynx-js/lynx-ui-lazy-component` provides the `LazyComponent` component in lynx-ui.
 
 ## Introduction
 
-Exposure-driven lazy mounting utility component with optional unmount-on-exit behavior.
+`LazyComponent` delays mounting its children until the placeholder node is exposed.
+The `Basic` example uses it to defer rendering a large block of content, so the
+layout can keep its reserved space before the child tree mounts.
+
+`estimatedStyle` is required to reserve that space before exposure, and no
+external styling dependency is required in order to use it. In
+scrollable content, you can also widen the exposure area with `top`, `bottom`,
+`left`, and `right`. The `VisibilityMargin` example uses `bottom='200px'` to
+preload items before they enter the viewport.
 
 ## Installation
 
@@ -17,14 +25,71 @@ pnpm add @lynx-js/lynx-ui-lazy-component
 ```tsx
 import { LazyComponent } from '@lynx-js/lynx-ui-lazy-component'
 
+function HeavyContent() {
+  return (
+    <view style={{ width: '100%', height: '100%' }}>
+      {Array.from({ length: 1000 }).map((_, index) => (
+        <view
+          key={index}
+          style={{
+            width: '100%',
+            height: '2px',
+            backgroundColor: '#d6d8dd',
+          }}
+        />
+      ))}
+    </view>
+  )
+}
+
 export function BasicLazyComponent() {
   return (
+    <view style={{ width: '100%', height: '240px' }}>
+      <LazyComponent
+        scene='scene'
+        pid='pid'
+        estimatedStyle={{ width: '100%', height: '100%' }}
+      >
+        <HeavyContent />
+      </LazyComponent>
+    </view>
+  )
+}
+```
+
+`scene` and `pid` identify the exposure target. Keep them unique within the
+page.
+
+Use `bottom='0px'` to mount only when the item becomes visible, or increase it
+to preload earlier:
+
+```tsx
+import { LazyComponent } from '@lynx-js/lynx-ui-lazy-component'
+
+function FeedItem() {
+  return (
+    <view
+      style={{
+        width: '100%',
+        height: '300px',
+        borderBottomWidth: '1px',
+        borderBottomStyle: 'solid',
+        borderBottomColor: '#d6d8dd',
+        backgroundColor: '#f5f6f8',
+      }}
+    />
+  )
+}
+
+export function VisibilityMarginLazyComponent() {
+  return (
     <LazyComponent
-      scene='home'
-      pid='hero_card'
-      estimatedStyle={{ width: '100px', height: '100px' }}
+      scene='feed'
+      pid='item_1'
+      bottom='200px'
+      estimatedStyle={{ width: '100%', height: '300px' }}
     >
-      <text>Rendered when exposed</text>
+      <FeedItem />
     </LazyComponent>
   )
 }

--- a/packages/lynx-ui-lazy-component/README.md
+++ b/packages/lynx-ui-lazy-component/README.md
@@ -1,93 +1,46 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-lazy-component
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-lazy-component` provides the **LazyComponent** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Exposure-driven lazy mounting utility component with optional unmount-on-exit behavior.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-lazy-component
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { LazyComponent } from '@lynx-js/lynx-ui-lazy-component'
 
-export default function App() {
+export function BasicLazyComponent() {
   return (
-    <view>
-      <Button>Hello</Button>
-    </view>
+    <LazyComponent
+      scene='home'
+      pid='hero_card'
+      estimatedStyle={{ width: '100px', height: '100px' }}
+    >
+      <text>Rendered when exposed</text>
+    </LazyComponent>
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export type { LazyComponentRef, LazyComponentProps }
+export const LazyComponent = memo(
+  forwardRef(LazyComponentImpl),
+) as LazyComponentType
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-list/README.md
+++ b/packages/lynx-ui-list/README.md
@@ -1,93 +1,47 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-list
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-list` provides the **List** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Virtualized list primitive with orientation, events, and imperative list controls.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-list
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { List } from '@lynx-js/lynx-ui-list'
 
-export default function App() {
+export function BasicList({ data }) {
   return (
-    <view>
-      <Button>Hello</Button>
-    </view>
+    <List scrollOrientation='vertical'>
+      {data.map(item => (
+        <list-item item-key={item.id} key={item.id}>{item.label}</list-item>
+      ))}
+    </List>
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
-```
-
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
+```ts
+export type { ListRef, ListProps }
+export const List = memo(forwardRef(ListImpl)) as ListType
+export const ListEventMapping: Record<string, string> = {
+  onLayoutComplete: 'bindlayoutcomplete',
+  onScrollStateChange: 'bindscrollstatechange',
+  onSnapToItem: 'bindsnap',
 }
 ```
 
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-list/README.md
+++ b/packages/lynx-ui-list/README.md
@@ -1,10 +1,12 @@
 # @lynx-js/lynx-ui-list
 
-`@lynx-js/lynx-ui-list` provides the **List** primitives in lynx-ui.
+`@lynx-js/lynx-ui-list` provides the `List` component in lynx-ui.
 
 ## Introduction
 
-Virtualized list primitive with orientation, events, and imperative list controls.
+`List` is the virtualized list primitive used by higher-level components such
+as `FeedList`. The `Basic` example shows item rendering together with
+imperative APIs like `scrollTo`, `autoScroll`, and `getVisibleCells`.
 
 ## Installation
 
@@ -15,18 +17,46 @@ pnpm add @lynx-js/lynx-ui-list
 ## Usage
 
 ```tsx
+import { useRef } from '@lynx-js/react'
 import { List } from '@lynx-js/lynx-ui-list'
+import type { ListRef } from '@lynx-js/lynx-ui-list'
 
-export function BasicList({ data }) {
+const items = Array.from({ length: 16 }, (_, index) => ({
+  id: String(index),
+  label: String(index),
+}))
+
+export function BasicList() {
+  const listRef = useRef<ListRef>(null)
+
   return (
-    <List scrollOrientation='vertical'>
-      {data.map(item => (
-        <list-item item-key={item.id} key={item.id}>{item.label}</list-item>
-      ))}
-    </List>
+    <view>
+      <List
+        listId='ListBasic'
+        ref={listRef}
+        listType='single'
+        spanCount={1}
+        scrollOrientation='vertical'
+        useRefactorList={true}
+        bounces={false}
+      >
+        {items.map((item) => (
+          <list-item key={item.id} item-key={item.id}>
+            <text>{item.label}</text>
+          </list-item>
+        ))}
+      </List>
+
+      <view bindtap={() => listRef.current?.scrollTo(true, 'middle', 7, 0)}>
+        <text>Scroll to item 7</text>
+      </view>
+    </view>
   )
 }
 ```
+
+The same ref can also call `autoScroll` and `getVisibleCells`, matching the
+controls shown in the `Basic` example.
 
 ## Public exports
 

--- a/packages/lynx-ui-overlay/README.md
+++ b/packages/lynx-ui-overlay/README.md
@@ -1,93 +1,36 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-overlay
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-overlay` provides the **Overlay** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Overlay view primitive for layering content above the base UI tree.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-overlay
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { OverlayView } from '@lynx-js/lynx-ui-overlay'
 
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
+export function BasicOverlay() {
+  return <OverlayView>Overlay content</OverlayView>
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export { OverlayView } from './OverlayView'
+export type { OverlayViewProps, OverlayViewRef } from './types'
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-overlay/README.md
+++ b/packages/lynx-ui-overlay/README.md
@@ -1,10 +1,13 @@
 # @lynx-js/lynx-ui-overlay
 
-`@lynx-js/lynx-ui-overlay` provides the **Overlay** primitives in lynx-ui.
+`@lynx-js/lynx-ui-overlay` provides the `OverlayView` component in lynx-ui.
 
 ## Introduction
 
-Overlay view primitive for layering content above the base UI tree.
+`OverlayView` renders content above the normal UI tree and is used internally
+by components such as `dialog`, `popover`, and `sheet`. Use it directly when
+you need to manage overlay layering yourself or place content in a native
+container.
 
 ## Installation
 
@@ -18,9 +21,18 @@ pnpm add @lynx-js/lynx-ui-overlay
 import { OverlayView } from '@lynx-js/lynx-ui-overlay'
 
 export function BasicOverlay() {
-  return <OverlayView>Overlay content</OverlayView>
+  return (
+    <OverlayView>
+      <view>
+        <text>Overlay content</text>
+      </view>
+    </OverlayView>
+  )
 }
 ```
+
+Set `container` and `overlayLevel` only when the overlay should be rendered in
+a specific native container.
 
 ## Public exports
 

--- a/packages/lynx-ui-popover/README.md
+++ b/packages/lynx-ui-popover/README.md
@@ -1,10 +1,13 @@
 # @lynx-js/lynx-ui-popover
 
-`@lynx-js/lynx-ui-popover` provides the **Popover** primitives in lynx-ui.
+`@lynx-js/lynx-ui-popover` provides the `Popover` primitives in lynx-ui.
 
 ## Introduction
 
-Composable popover primitives with anchor, trigger, backdrop, positioner, and arrow support.
+`Popover` anchors floating content to a trigger or custom anchor. The examples
+cover basic positioning, controlled visibility with `show` and
+`onVisibleChange`, optional backdrops, custom arrows, extra anchors, and usage
+inside scrollable containers.
 
 ## Installation
 
@@ -16,29 +19,34 @@ pnpm add @lynx-js/lynx-ui-popover
 
 ```tsx
 import {
+  PopoverContent,
+  PopoverPositioner,
   PopoverRoot,
   PopoverTrigger,
-  PopoverBackdrop,
-  PopoverPositioner,
-  PopoverContent,
-  PopoverArrow,
 } from '@lynx-js/lynx-ui-popover'
 
 export function BasicPopover() {
   return (
     <PopoverRoot>
-      <PopoverTrigger>Open</PopoverTrigger>
-      <PopoverBackdrop />
-      <PopoverPositioner>
-        <PopoverContent>
-          <PopoverArrow />
-          Content
-        </PopoverContent>
-      </PopoverPositioner>
+      <PopoverTrigger>
+        <text>Show Popover</text>
+
+        <PopoverPositioner
+          placement='bottom-end'
+          placementOffset={12}
+        >
+          <PopoverContent>
+            <text>Popover content</text>
+          </PopoverContent>
+        </PopoverPositioner>
+      </PopoverTrigger>
     </PopoverRoot>
   )
 }
 ```
+
+Add `PopoverBackdrop` for outside-click dismissal, or switch to a controlled
+`PopoverRoot` when the parent owns visibility state.
 
 ## Public exports
 

--- a/packages/lynx-ui-popover/README.md
+++ b/packages/lynx-ui-popover/README.md
@@ -1,93 +1,73 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-popover
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-popover` provides the **Popover** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Composable popover primitives with anchor, trigger, backdrop, positioner, and arrow support.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-popover
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import {
+  PopoverRoot,
+  PopoverTrigger,
+  PopoverBackdrop,
+  PopoverPositioner,
+  PopoverContent,
+  PopoverArrow,
+} from '@lynx-js/lynx-ui-popover'
 
-export default function App() {
+export function BasicPopover() {
   return (
-    <view>
-      <Button>Hello</Button>
-    </view>
+    <PopoverRoot>
+      <PopoverTrigger>Open</PopoverTrigger>
+      <PopoverBackdrop />
+      <PopoverPositioner>
+        <PopoverContent>
+          <PopoverArrow />
+          Content
+        </PopoverContent>
+      </PopoverPositioner>
+    </PopoverRoot>
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export { PopoverContext, useElementInfoReducer } from './useElementInfoReducer'
+export {
+  PopoverArrow,
+  PopoverAnchor,
+  PopoverBackdrop,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverPositioner,
+  PopoverRoot,
+} from './Popover'
+export type { PresenceAnimationStatus } from '@lynx-js/lynx-ui-presence'
+export type {
+  PopoverOverlayProps,
+  PopoverArrowProps,
+  PopoverAnchorProps,
+  PopoverBackdropProps,
+  PopoverContentProps,
+  PopoverPositionerProps,
+  PopoverRootProps,
+  PopoverTriggerProps,
+} from './types'
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-presence/README.md
+++ b/packages/lynx-ui-presence/README.md
@@ -1,93 +1,43 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-presence
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-presence` provides the **Presence** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Presence and animation-state helpers for mounting transitions and enter/exit orchestration.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-presence
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { Presence } from '@lynx-js/lynx-ui-presence'
 
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
+export function BasicPresence({ visible, children }) {
+  return <Presence present={visible}>{children}</Presence>
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export { Presence, PresenceContext, renderPresenceChildren } from './Presence'
+export {
+  PresenceState,
+  resolveAnimationStatus,
+  presenceClassVariants,
+} from './utils'
+export { usePresenceGroup } from './usePresenceGroup'
+export { useVisibilityFromPresence } from './useVisibilityFromPresence'
+export type * from './types'
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-presence/README.md
+++ b/packages/lynx-ui-presence/README.md
@@ -1,10 +1,14 @@
 # @lynx-js/lynx-ui-presence
 
-`@lynx-js/lynx-ui-presence` provides the **Presence** primitives in lynx-ui.
+`@lynx-js/lynx-ui-presence` provides mount and animation-state helpers in
+lynx-ui.
 
 ## Introduction
 
-Presence and animation-state helpers for mounting transitions and enter/exit orchestration.
+`Presence` drives enter and exit lifecycle for overlay-style components such as
+`dialog` and `popover`. It accepts a single `show` state, can keep nodes
+mounted with `forceMount`, and exposes render-prop status fields like `open`,
+`closed`, `entering`, and `leaving`.
 
 ## Installation
 
@@ -17,10 +21,24 @@ pnpm add @lynx-js/lynx-ui-presence
 ```tsx
 import { Presence } from '@lynx-js/lynx-ui-presence'
 
-export function BasicPresence({ visible, children }) {
-  return <Presence present={visible}>{children}</Presence>
+export function BasicPresence({ show }: { show: boolean }) {
+  return (
+    <Presence show={show}>
+      {({ entering, leaving }) => (
+        <view>
+          <text>
+            {entering ? 'Entering' : leaving ? 'Leaving' : 'Visible'}
+          </text>
+        </view>
+      )}
+    </Presence>
+  )
 }
 ```
+
+Use `forceMount` when hidden content still needs to stay mounted, or
+`useVisibilityFromPresence` when other components need a derived visibility
+signal.
 
 ## Public exports
 

--- a/packages/lynx-ui-radio-group/README.md
+++ b/packages/lynx-ui-radio-group/README.md
@@ -1,10 +1,13 @@
 # @lynx-js/lynx-ui-radio-group
 
-`@lynx-js/lynx-ui-radio-group` provides the **RadioGroup** primitives in lynx-ui.
+`@lynx-js/lynx-ui-radio-group` provides the `RadioGroup` primitives in
+lynx-ui.
 
 ## Introduction
 
-Headless radio group primitives for controlled option selection.
+`RadioGroupRoot` owns the selected value, while each `Radio` registers an
+option and `RadioIndicator` renders the selected marker. The examples cover
+controlled selection and disabled states.
 
 ## Installation
 
@@ -15,25 +18,37 @@ pnpm add @lynx-js/lynx-ui-radio-group
 ## Usage
 
 ```tsx
+import { useState } from '@lynx-js/react'
 import {
-  RadioGroupRoot,
   Radio,
+  RadioGroupRoot,
   RadioIndicator,
 } from '@lynx-js/lynx-ui-radio-group'
 
 export function BasicRadioGroup() {
+  const [value, setValue] = useState('light')
+
   return (
-    <RadioGroupRoot value='a' onValueChange={() => {}}>
-      <Radio value='a'>
-        <RadioIndicator />A
+    <RadioGroupRoot value={value} onValueChange={setValue}>
+      <Radio value='light'>
+        <RadioIndicator>
+          <text>•</text>
+        </RadioIndicator>
+        <text>Light</text>
       </Radio>
-      <Radio value='b'>
-        <RadioIndicator />B
+      <Radio value='dark'>
+        <RadioIndicator>
+          <text>•</text>
+        </RadioIndicator>
+        <text>Dark</text>
       </Radio>
     </RadioGroupRoot>
   )
 }
 ```
+
+Set `defaultValue` for uncontrolled usage, or mark the whole group or
+individual radios as `disabled`.
 
 ## Public exports
 

--- a/packages/lynx-ui-radio-group/README.md
+++ b/packages/lynx-ui-radio-group/README.md
@@ -1,93 +1,53 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-radio-group
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-radio-group` provides the **RadioGroup** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Headless radio group primitives for controlled option selection.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-radio-group
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import {
+  RadioGroupRoot,
+  Radio,
+  RadioIndicator,
+} from '@lynx-js/lynx-ui-radio-group'
 
-export default function App() {
+export function BasicRadioGroup() {
   return (
-    <view>
-      <Button>Hello</Button>
-    </view>
+    <RadioGroupRoot value='a' onValueChange={() => {}}>
+      <Radio value='a'>
+        <RadioIndicator />A
+      </Radio>
+      <Radio value='b'>
+        <RadioIndicator />B
+      </Radio>
+    </RadioGroupRoot>
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export { RadioIndicator, Radio, RadioGroupRoot } from './RadioGroup'
+export type {
+  RadioGroupRootProps,
+  RadioIndicatorProps,
+  RadioProps,
+} from './types'
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-scroll-view/README.md
+++ b/packages/lynx-ui-scroll-view/README.md
@@ -1,93 +1,40 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-scroll-view
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-scroll-view` provides the **ScrollView** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Scroll view primitive with optional lazy rendering and bounce handling.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-scroll-view
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { ScrollView } from '@lynx-js/lynx-ui-scroll-view'
 
-export default function App() {
+export function BasicScrollView() {
   return (
-    <view>
-      <Button>Hello</Button>
-    </view>
+    <ScrollView scrollOrientation='vertical' style={{ height: '100%' }}>
+      <text>Scrollable content</text>
+    </ScrollView>
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export type { ScrollViewProps, ScrollViewRef }
+export const ScrollView = memo(forwardRef(ScrollViewImpl)) as ScrollViewType
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-scroll-view/README.md
+++ b/packages/lynx-ui-scroll-view/README.md
@@ -1,10 +1,13 @@
 # @lynx-js/lynx-ui-scroll-view
 
-`@lynx-js/lynx-ui-scroll-view` provides the **ScrollView** primitives in lynx-ui.
+`@lynx-js/lynx-ui-scroll-view` provides the `ScrollView` component in lynx-ui.
 
 ## Introduction
 
-Scroll view primitive with optional lazy rendering and bounce handling.
+`ScrollView` supports horizontal and vertical scrolling, optional lazy
+rendering, bounce behavior, and scroll-propagation control. The examples show a
+horizontal card rail and how flex children behave inside the scrollable
+content area.
 
 ## Installation
 
@@ -17,14 +20,25 @@ pnpm add @lynx-js/lynx-ui-scroll-view
 ```tsx
 import { ScrollView } from '@lynx-js/lynx-ui-scroll-view'
 
+const items = ['L', 'Y', 'N', 'X']
+
 export function BasicScrollView() {
   return (
-    <ScrollView scrollOrientation='vertical' style={{ height: '100%' }}>
-      <text>Scrollable content</text>
+    <ScrollView scrollOrientation='horizontal' style={{ height: '120px' }}>
+      <view style={{ display: 'flex', flexDirection: 'row' }}>
+        {items.map((item) => (
+          <view key={item} style={{ width: '80px' }}>
+            <text>{item}</text>
+          </view>
+        ))}
+      </view>
     </ScrollView>
   )
 }
 ```
+
+Tune lazy rendering through `lazyOptions`, and use `bounceableOptions` when you
+need bounce behavior outside the default iOS handling.
 
 ## Public exports
 

--- a/packages/lynx-ui-sheet/README.md
+++ b/packages/lynx-ui-sheet/README.md
@@ -1,10 +1,16 @@
 # @lynx-js/lynx-ui-sheet
 
-`@lynx-js/lynx-ui-sheet` provides the **Sheet** primitives in lynx-ui.
+`@lynx-js/lynx-ui-sheet` provides the `Sheet` primitives in lynx-ui.
 
 ## Introduction
 
-Bottom sheet primitives for backdrop/content/handle composition and snap control.
+`Sheet` is a bottom-sheet primitive built from `SheetRoot`, `SheetView`,
+`SheetBackdrop`, `SheetContent`, and `SheetHandle`.
+
+The examples in `apps/examples/Sheet` cover the main usage patterns:
+uncontrolled opening through a ref, controlled visibility with `show` and
+`onShowChange`, and multiple snap points driven by `snapTo`, `expand`, and
+`collapse`.
 
 ## Installation
 
@@ -15,24 +21,44 @@ pnpm add @lynx-js/lynx-ui-sheet
 ## Usage
 
 ```tsx
+import { useRef } from '@lynx-js/react'
 import {
-  SheetRoot,
   SheetBackdrop,
   SheetContent,
   SheetHandle,
+  SheetRoot,
+  SheetView,
 } from '@lynx-js/lynx-ui-sheet'
+import type { SheetRootRef } from '@lynx-js/lynx-ui-sheet'
 
 export function BasicSheet() {
+  const sheetRef = useRef<SheetRootRef>(null)
+
   return (
-    <SheetRoot>
-      <SheetBackdrop />
-      <SheetContent>
-        <SheetHandle />
-      </SheetContent>
-    </SheetRoot>
+    <view>
+      <view bindtap={() => sheetRef.current?.show()}>
+        <text>Open Sheet</text>
+      </view>
+
+      <SheetRoot ref={sheetRef} snapPoints={['50%']} initialSnap={0}>
+        <SheetView>
+          <SheetBackdrop clickToClose={true} />
+          <SheetContent>
+            <SheetHandle />
+            <view style={{ padding: '16px' }}>
+              <text>Sheet content</text>
+            </view>
+          </SheetContent>
+        </SheetView>
+      </SheetRoot>
+    </view>
   )
 }
 ```
+
+Use `show` and `onShowChange` when the parent owns visibility state. For
+imperative control, the ref exposes methods such as `show`, `close`, `snapTo`,
+`expand`, and `collapse`.
 
 ## Public exports
 

--- a/packages/lynx-ui-sheet/README.md
+++ b/packages/lynx-ui-sheet/README.md
@@ -1,47 +1,61 @@
-# Sheet
+# @lynx-js/lynx-ui-sheet
 
-An extension of the Dialog.
+`@lynx-js/lynx-ui-sheet` provides the **Sheet** primitives in lynx-ui.
+
+## Introduction
+
+Bottom sheet primitives for backdrop/content/handle composition and snap control.
 
 ## Installation
 
 ```bash
-npm install @lynx-js/lynx-ui-sheet
+pnpm add @lynx-js/lynx-ui-sheet
 ```
 
-## Basic Usage
+## Usage
 
-```jsx
-import { useState } from '@lynx-js/react'
-import { SheetRoot, SheetHandle, SheetContent } from '@lynx-js/lynx-ui-sheet'
+```tsx
+import {
+  SheetRoot,
+  SheetBackdrop,
+  SheetContent,
+  SheetHandle,
+} from '@lynx-js/lynx-ui-sheet'
 
-function App() {
-  const [show, setShow] = useState(false)
-
+export function BasicSheet() {
   return (
-    <view>
-      <text bindtap={() => setShow(true)}>Open Sheet</text>
-      <SheetRoot show={show} onShowChange={setShow}>
-        <SheetContent>
-          <SheetHandle />
-          <text>Hello World</text>
-        </SheetContent>
-      </SheetRoot>
-    </view>
+    <SheetRoot>
+      <SheetBackdrop />
+      <SheetContent>
+        <SheetHandle />
+      </SheetContent>
+    </SheetRoot>
   )
 }
 ```
 
-## Structure
+## Public exports
 
-```jsx
-<SheetRoot>
-  <SheetView>
-    <SheetBackdrop />
-    <SheetContent />
-  </SheetView>
-</SheetRoot>
+```ts
+export { SheetRoot } from './SheetRoot'
+export type { SheetRootRef } from './SheetRoot'
+export { SheetBackdrop } from './SheetBackdrop'
+export { SheetContent } from './SheetContent'
+export { SheetHandle } from './SheetHandle'
+export { SheetView } from './SheetView'
+export { useSnap } from './hooks'
+export type {
+  SheetBackdropProps,
+  SheetContentProps,
+  SheetRootProps,
+  SheetViewProps,
+  SheetHandleProps,
+  SheetTransition,
+} from './types'
 ```
 
-## API
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
-For detailed API reference, please check the source code or generated documentation.
+## License
+
+Apache-2.0

--- a/packages/lynx-ui-sortable/README.md
+++ b/packages/lynx-ui-sortable/README.md
@@ -1,93 +1,45 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-sortable
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-sortable` provides the **Sortable** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Sortable list primitives for drag-to-reorder interactions.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-sortable
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { SortableRoot, SortableItem } from '@lynx-js/lynx-ui-sortable'
 
-export default function App() {
+export function BasicSortable() {
   return (
-    <view>
-      <Button>Hello</Button>
-    </view>
+    <SortableRoot>
+      <SortableItem id='item-1'>Item 1</SortableItem>
+      <SortableItem id='item-2'>Item 2</SortableItem>
+    </SortableRoot>
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export { SortableRoot, SortableItem, SortableItemArea } from './Sortable'
+export type {
+  SortableItemProps,
+  SortableRootProps,
+  SortableData,
+} from './types'
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-sortable/README.md
+++ b/packages/lynx-ui-sortable/README.md
@@ -1,10 +1,13 @@
 # @lynx-js/lynx-ui-sortable
 
-`@lynx-js/lynx-ui-sortable` provides the **Sortable** primitives in lynx-ui.
+`@lynx-js/lynx-ui-sortable` provides the `Sortable` primitives in lynx-ui.
 
 ## Introduction
 
-Sortable list primitives for drag-to-reorder interactions.
+`SortableRoot` renders a sortable data set, `SortableItem` wraps each rendered
+node, and `SortableItemArea` can act as a dedicated drag handle when
+`SortableItem` uses `as='DraggableRoot'`. The examples cover boundary
+confinement, scroll-view integration, and temporarily disabling sorting.
 
 ## Installation
 
@@ -15,17 +18,48 @@ pnpm add @lynx-js/lynx-ui-sortable
 ## Usage
 
 ```tsx
-import { SortableRoot, SortableItem } from '@lynx-js/lynx-ui-sortable'
+import { useState } from '@lynx-js/react'
+import type { SortableData } from '@lynx-js/lynx-ui-sortable'
+import {
+  SortableItem,
+  SortableItemArea,
+  SortableRoot,
+} from '@lynx-js/lynx-ui-sortable'
+
+const initialData: SortableData<{ label: string }>[] = [
+  { getSortingKey: () => 'item-1', dataItem: { label: 'Item 1' } },
+  { getSortingKey: () => 'item-2', dataItem: { label: 'Item 2' } },
+]
 
 export function BasicSortable() {
+  const [data, setData] = useState(initialData)
+
   return (
-    <SortableRoot>
-      <SortableItem id='item-1'>Item 1</SortableItem>
-      <SortableItem id='item-2'>Item 2</SortableItem>
-    </SortableRoot>
+    <view id='sortableRoot' style={{ zIndex: '0' }}>
+      <SortableRoot
+        data={data}
+        boundaryId='sortableRoot'
+        onSortEnd={setData}
+      >
+        {(item) => (
+          <SortableItem
+            as='DraggableRoot'
+            sortingKey={item.getSortingKey()}
+          >
+            <SortableItemArea>
+              <text>{item.dataItem.label}</text>
+            </SortableItemArea>
+          </SortableItem>
+        )}
+      </SortableRoot>
+    </view>
   )
 }
 ```
+
+Use a plain `SortableItem` when the whole item should drag, or combine
+`onSortStart` with a surrounding scroll container as shown in
+`WithScrollView`.
 
 ## Public exports
 

--- a/packages/lynx-ui-swipe-action/README.md
+++ b/packages/lynx-ui-swipe-action/README.md
@@ -1,10 +1,13 @@
 # @lynx-js/lynx-ui-swipe-action
 
-`@lynx-js/lynx-ui-swipe-action` provides the **SwipeAction** primitives in lynx-ui.
+`@lynx-js/lynx-ui-swipe-action` provides the `SwipeAction` component in
+lynx-ui.
 
 ## Introduction
 
-Swipe action container for exposing contextual actions via horizontal gestures.
+`SwipeAction` reveals an action area with horizontal gestures or imperative ref
+methods. The examples show single-item usage, integration inside a scroll view,
+and programmatic toggling through `showActionArea` and `closeActionArea`.
 
 ## Installation
 
@@ -15,25 +18,42 @@ pnpm add @lynx-js/lynx-ui-swipe-action
 ## Usage
 
 ```tsx
+import { useRef } from '@lynx-js/react'
 import { SwipeAction } from '@lynx-js/lynx-ui-swipe-action'
+import type { SwipeActionRef } from '@lynx-js/lynx-ui-swipe-action'
 
 export function BasicSwipeAction() {
+  const swipeActionRef = useRef<SwipeActionRef>(null)
+
   return (
-    <SwipeAction
-      displayArea={
-        <view>
-          <text>Item</text>
-        </view>
-      }
-      actionArea={
-        <view>
-          <text>Delete</text>
-        </view>
-      }
-    />
+    <view>
+      <SwipeAction
+        ref={swipeActionRef}
+        swipeActionId='item-1'
+        enableSwipe={true}
+        displayArea={
+          <view>
+            <text>Item</text>
+          </view>
+        }
+        actionArea={
+          <view>
+            <text>Delete</text>
+          </view>
+        }
+        onAction={(id) => console.info('action', id)}
+      />
+
+      <view bindtap={() => swipeActionRef.current?.showActionArea(true)}>
+        <text>Show actions</text>
+      </view>
+    </view>
   )
 }
 ```
+
+Use `onSwipeStart` and `onSwipeEnd` to react to gesture state, or set
+`estimatedActionAreaSize` when the action area lives inside a reused list item.
 
 ## Public exports
 

--- a/packages/lynx-ui-swipe-action/README.md
+++ b/packages/lynx-ui-swipe-action/README.md
@@ -1,93 +1,49 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-swipe-action
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-swipe-action` provides the **SwipeAction** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Swipe action container for exposing contextual actions via horizontal gestures.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-swipe-action
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { SwipeAction } from '@lynx-js/lynx-ui-swipe-action'
 
-export default function App() {
+export function BasicSwipeAction() {
   return (
-    <view>
-      <Button>Hello</Button>
-    </view>
+    <SwipeAction
+      displayArea={
+        <view>
+          <text>Item</text>
+        </view>
+      }
+      actionArea={
+        <view>
+          <text>Delete</text>
+        </view>
+      }
+    />
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export type { SwipeActionProps, SwipeActionRef }
+export const SwipeAction = memo(forwardRef(SwipeActionImpl)) as swipeActionType
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-swiper/README.md
+++ b/packages/lynx-ui-swiper/README.md
@@ -1,10 +1,13 @@
 # @lynx-js/lynx-ui-swiper
 
-`@lynx-js/lynx-ui-swiper` provides the **Swiper** primitives in lynx-ui.
+`@lynx-js/lynx-ui-swiper` provides the `Swiper` primitives in lynx-ui.
 
 ## Introduction
 
-Swiper/carousel primitives with item composition and imperative controls.
+`Swiper` renders items from a data array through a render function and wraps
+each slide with `SwiperItem`. The examples cover imperative navigation,
+different alignments and gaps, indicators, looping, bounce items, and lazy
+slide content through `LazyComponent`.
 
 ## Installation
 
@@ -15,17 +18,45 @@ pnpm add @lynx-js/lynx-ui-swiper
 ## Usage
 
 ```tsx
+import { useRef, useState } from '@lynx-js/react'
 import { Swiper, SwiperItem } from '@lynx-js/lynx-ui-swiper'
+import type { SwiperRef } from '@lynx-js/lynx-ui-swiper'
+
+const items = [1, 2, 3, 4]
 
 export function BasicSwiper() {
+  const [current, setCurrent] = useState(0)
+  const swiperRef = useRef<SwiperRef>(null)
+
   return (
-    <Swiper>
-      <SwiperItem>Slide 1</SwiperItem>
-      <SwiperItem>Slide 2</SwiperItem>
-    </Swiper>
+    <view>
+      <Swiper
+        ref={swiperRef}
+        data={items}
+        itemWidth={250}
+        itemHeight={200}
+        initialIndex={0}
+        onChange={setCurrent}
+        mode='normal'
+        modeConfig={{ align: 'center', spaceBetween: 16 }}
+      >
+        {({ item, index, realIndex }) => (
+          <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+            <text>{item}</text>
+          </SwiperItem>
+        )}
+      </Swiper>
+
+      <view bindtap={() => swiperRef.current?.swipeNext()}>
+        <text>Current slide: {current}</text>
+      </view>
+    </view>
   )
 }
 ```
+
+Combine `Swiper` with `LazyComponent` when off-screen slides should mount on
+demand, matching the `Lazy` example.
 
 ## Public exports
 

--- a/packages/lynx-ui-swiper/README.md
+++ b/packages/lynx-ui-swiper/README.md
@@ -1,93 +1,43 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-swiper
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-swiper` provides the **Swiper** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Swiper/carousel primitives with item composition and imperative controls.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-swiper
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { Swiper, SwiperItem } from '@lynx-js/lynx-ui-swiper'
 
-export default function App() {
+export function BasicSwiper() {
   return (
-    <view>
-      <Button>Hello</Button>
-    </view>
+    <Swiper>
+      <SwiperItem>Slide 1</SwiperItem>
+      <SwiperItem>Slide 2</SwiperItem>
+    </Swiper>
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export { Swiper } from './Swiper'
+export { SwiperItem } from './SwiperItem'
+export type { SwiperItemProps } from './SwiperItem'
+export type { SwiperProps, SwiperRef } from './types'
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0

--- a/packages/lynx-ui-switch/README.md
+++ b/packages/lynx-ui-switch/README.md
@@ -1,10 +1,12 @@
 # @lynx-js/lynx-ui-switch
 
-`@lynx-js/lynx-ui-switch` provides the **Switch** primitives in lynx-ui.
+`@lynx-js/lynx-ui-switch` provides the `Switch` primitives in lynx-ui.
 
 ## Introduction
 
-Headless switch primitives with track/thumb composition and render props.
+`Switch` is composed from `Switch`, `SwitchTrack`, and `SwitchThumb`. The
+examples cover uncontrolled and controlled state, disabled behavior, and
+different visual themes built on top of the same headless structure.
 
 ## Installation
 
@@ -15,18 +17,23 @@ pnpm add @lynx-js/lynx-ui-switch
 ## Usage
 
 ```tsx
-import { Switch, SwitchTrack, SwitchThumb } from '@lynx-js/lynx-ui-switch'
+import { useState } from '@lynx-js/react'
+import { Switch, SwitchThumb, SwitchTrack } from '@lynx-js/lynx-ui-switch'
 
 export function BasicSwitch() {
+  const [checked, setChecked] = useState(true)
+
   return (
-    <Switch checked={true} onCheckedChange={() => {}}>
-      <SwitchTrack>
-        <SwitchThumb />
-      </SwitchTrack>
+    <Switch checked={checked} onChange={setChecked}>
+      <SwitchTrack />
+      <SwitchThumb />
     </Switch>
   )
 }
 ```
+
+Set `defaultChecked` for uncontrolled usage, or pass `disabled` to prevent
+interaction while keeping the current visual state.
 
 ## Public exports
 

--- a/packages/lynx-ui-switch/README.md
+++ b/packages/lynx-ui-switch/README.md
@@ -1,93 +1,47 @@
-# @lynx-js/lynx-ui
+# @lynx-js/lynx-ui-switch
 
-`@lynx-js/lynx-ui` is the component library officially maintained by Lynx. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui-switch` provides the **Switch** primitives in lynx-ui.
 
 ## Introduction
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
-
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
-
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+Headless switch primitives with track/thumb composition and render props.
 
 ## Installation
 
-`lynx-ui` supports both full-library imports and individual component imports.
-
-### Option 1: Full-Library Import (Recommended)
-
-You can import the entire `lynx-ui` package. `lynx-ui` supports tree-shaking, so unused components won't increase your final build size.
-
 ```bash
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-switch
 ```
 
-**Usage:**
+## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { Switch, SwitchTrack, SwitchThumb } from '@lynx-js/lynx-ui-switch'
 
-export default function App() {
+export function BasicSwitch() {
   return (
-    <view>
-      <Button>Hello</Button>
-    </view>
+    <Switch checked={true} onCheckedChange={() => {}}>
+      <SwitchTrack>
+        <SwitchThumb />
+      </SwitchTrack>
+    </Switch>
   )
 }
 ```
 
-### Option 2: Importing Individual Components
+## Public exports
 
-Each `lynx-ui` component is published as a separate package. This method is available for compatibility or specific use cases.
-
-**Example with `<Button>`:**
-
-```bash
-pnpm add @lynx-js/lynx-ui-button
+```ts
+export { Switch, SwitchThumb, SwitchTrack } from './switch'
+export type {
+  SwitchProps,
+  SwitchThumbProps,
+  SwitchTrackProps,
+  SwitchRenderProps,
+} from './types'
 ```
 
-**Usage:**
-
-```tsx
-import { Button } from '@lynx-js/lynx-ui-button'
-
-export default function App() {
-  return (
-    <view>
-      <Button>Hello</Button>
-    </view>
-  )
-}
-```
-
-## Configuration
-
-If you are using `rspeedy`, you might need to configure the `pluginReactLynx`.
-
-```typescript
-// lynx.config.ts
-import { defineConfig } from '@lynx-js/rspeedy'
-
-export default defineConfig({
-  plugins: [
-    pluginReactLynx({
-      targetSdkVersion: '2.14',
-      enableNewGesture: true,
-    }),
-  ],
-})
-```
-
-## Compatibility
-
-- **LynxSDK**: > 2.16
-
-> These are full-library requirements. Individual components may have lower version requirements.
-
-## Development
-
-If you are interested in contributing to `lynx-ui`, please read our [Contributing Guide](./CONTRIBUTING.md).
+> The export list above is generated from `src/index.ts` or `src/index.tsx` in this package.
 
 ## License
 
-[Apache-2.0](./LICENSE)
+Apache-2.0


### PR DESCRIPTION
Relate to #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked many package READMEs into package-specific, usage-first guides with concise component descriptions, simplified installation/import guidance, clear examples, introduced explicit public export lists, and standardized license/formatting; long configuration, compatibility, and development sections removed.
* **Chores**
  * Added a changeset with patch bumps and a docs note to keep README headings consistent across packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->