### PR TITLE
chore(ts): add asset module typings and align eslint tsconfig

### DIFF
--- a/.cspell/misc.txt
+++ b/.cspell/misc.txt
@@ -25,6 +25,7 @@ dprint
 esbenp
 GCMT
 hasdir
+hintrc
 inittime
 jank
 jsnext

--- a/.hintrc
+++ b/.hintrc
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "development"
+  ],
+  "hints": {
+    "no-inline-styles": "off"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,10 @@
   "files.associations": {
     "renovate.json5": "jsonc",
     "OWNERS": "yaml",
+    ".hintrc": "json",
   },
   "editor.formatOnSave": true,
+  "files.insertFinalNewline": true,
   "eslint.nodePath": "node_modules",
   "eslint.trace.server": "verbose",
   "eslint.workingDirectories": [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,7 @@ export default tseslint.config(
       'packages/**/vitest.config.ts',
       'website/**',
       'tools/configs/**',
+      'tools/typings/**/*.d.ts',
       '**/tools/make-new-component/examplesTemplate/**',
       '**/tools/make-new-component/template/**',
 
@@ -267,7 +268,10 @@ export default tseslint.config(
         sourceType: 'module',
         projectService: {
           allowDefaultProject: ['*.js'],
-          defaultProject: path.resolve(import.meta.dirname, 'tsconfig.json'),
+          defaultProject: path.resolve(
+            import.meta.dirname,
+            'tsconfig.eslint.json',
+          ),
         },
       },
     },

--- a/tools/configs/tsconfig.base.json
+++ b/tools/configs/tsconfig.base.json
@@ -16,5 +16,8 @@
     "declarationMap": true,
     "incremental": true,
     "forceConsistentCasingInFileNames": true
-  }
+  },
+  "files": [
+    "../typings/asset.d.ts"
+  ]
 }

--- a/tools/typings/asset.d.ts
+++ b/tools/typings/asset.d.ts
@@ -1,0 +1,41 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Ambient module declarations for static assets imported in library code.
+// This mirrors what @rsbuild/core/types provides for rspeedy apps.
+
+/** Side-effect CSS import */
+declare module '*.css' {}
+/** Side-effect SCSS import */
+declare module '*.scss' {}
+/** Side-effect Less import */
+declare module '*.less' {}
+
+/** SVG imported as URL string */
+declare module '*.svg' {
+  const src: string
+  export default src
+}
+
+/** Image assets */
+declare module '*.png' {
+  const src: string
+  export default src
+}
+declare module '*.jpg' {
+  const src: string
+  export default src
+}
+declare module '*.jpeg' {
+  const src: string
+  export default src
+}
+declare module '*.webp' {
+  const src: string
+  export default src
+}
+declare module '*.gif' {
+  const src: string
+  export default src
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,30 @@
+{
+  "extends": "./tools/configs/tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+  },
+  "include": [
+    "apps/**/*.ts",
+    "apps/**/*.tsx",
+    "packages/**/*.ts",
+    "packages/**/*.tsx",
+    "tools/**/*.ts",
+    "tools/**/*.tsx",
+    "tools/**/*.d.ts",
+    "*.ts",
+    "*.tsx",
+    "*.d.ts",
+  ],
+  "exclude": [
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/lib/**",
+    "**/.turbo/**",
+    "coverage/**",
+    "output/**",
+    "website/**",
+    "lunarium/**",
+  ],
+}


### PR DESCRIPTION
## Intention
Ensure TypeScript and ESLint consistently recognize side-effect imports of static assets (e.g. `*.css`) across `apps/examples` and `packages` by centralizing ambient asset module typings in the shared base tsconfig, while keeping the root `tsconfig.json` as a solution-style reference graph and using a dedicated ESLint tsconfig to avoid project-reference constraints.
## Changes
- Add ambient module declarations for static assets in `tools/typings/asset.d.ts`
- Include `asset.d.ts` via `tools/configs/tsconfig.base.json` so all extending projects pick it up
- Add `tsconfig.eslint.json` for ESLint type-aware linting (no project references)
- Point ESLint `projectService.defaultProject` to `tsconfig.eslint.json`
- Ignore `tools/typings/**/*.d.ts` in ESLint to avoid linting ambient declarations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated linting and editor settings to ignore additional generated files and recognize a new config file format.
  * Added typing support so stylesheet, image, and SVG imports are handled cleanly during development.
  * Introduced a dedicated TypeScript configuration for linting with broader include/exclude patterns and non-emitting compiler options.
  * Added miscellaneous spellcheck and editor tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->