### PR TITLE
fix: rslib browserlist config bundles web css

### DIFF
--- a/tools/configs/rslib.base.ts
+++ b/tools/configs/rslib.base.ts
@@ -17,7 +17,7 @@ export const baseConfig: RslibConfig = {
     {
       bundle: false,
       format: 'esm',
-      syntax: 'es6',
+      syntax: 'esnext',
       output: {
         distPath: {
           root: './dist',


### PR DESCRIPTION
Fix an issue that rslib bundles web prefix in CSS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library build configuration settings to support newer JavaScript syntax standards in ESM output compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->