### PR TITLE
chore: point eslint cspell rule to root cspell.jsonc, fix false-positive cspell warnings

### DIFF
--- a/.cspell/misc.txt
+++ b/.cspell/misc.txt
@@ -34,6 +34,7 @@ laggy
 layoutchange
 lepusjs
 lepusng
+lintignore
 loadmore
 Lynxview
 manypkg

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,6 +58,16 @@ export default tseslint.config(
   },
   js.configs.recommended,
   cspellESLintPluginRecommended,
+  {
+    rules: {
+      '@cspell/spellchecker': [
+        'warn',
+        {
+          configFile: path.resolve(import.meta.dirname, 'cspell.jsonc'),
+        },
+      ],
+    },
+  },
   ...jsoncPlugin.configs['flat/recommended-with-jsonc'],
   regexpPlugin.configs['flat/recommended'],
   // // Rules from eslint-plugin-jsdoc

--- a/tools/typedoc/plugins/expand-union-plugin.js
+++ b/tools/typedoc/plugins/expand-union-plugin.js
@@ -7,13 +7,14 @@ import { Serializer } from 'typedoc'
 /**
  * A type guard to check if a JSON reflection is a declaration (like an interface or type alias).
  * - 1 : Project
-- 256 : Interface
-- 512 : Constructor
-- 1024 : Property
-- 2048 : Method
-- 4096 : Call Signature
-- 2097152 : Type alias
- * @param refl
+ * - 256 : Interface
+ * - 512 : Constructor
+ * - 1024 : Property
+ * - 2048 : Method
+ * - 4096 : Call Signature
+ * - 2097152 : Type alias
+ * @param {object} refl The reflection to check.
+ * @returns {boolean} True if the reflection is a declaration, False otherwise
  */
 function isDeclaration(
   refl,
@@ -34,7 +35,7 @@ function isDeclaration(
  * 4. Removing the original Type Alias and the now-merged member interfaces from the final output.
  * This "flattens" the union type into a single interface with a discriminator,
  * which is often easier for documentation tools to parse and display.
- * @param app
+ * @param {import('typedoc').Application} app The TypeDoc application instance.
  */
 export function load(app) {
   app.serializer.on(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured spell-checking integration with ESLint at warning severity.
  * Updated spell-checker word list.

* **Documentation**
  * Improved type annotations in documentation comments for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->