### PR TITLE
chore: update @lynx-js/react version & vitest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
           key: turbo-v4-${{ runner.os }}-${{ github.sha }}
       - name: Install
         run: |
-          git submodule update --init --recursive --remote
+          git submodule update --init --recursive
           npm install -g corepack@latest
           corepack enable
           pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           package-manager-cache: false
       - name: Install
         run: |
-          git submodule update --init --recursive --remote
+          git submodule update --init --recursive
           npm install -g corepack@latest
           corepack enable
           pnpm install --frozen-lockfile

--- a/.github/workflows/common-test.yml
+++ b/.github/workflows/common-test.yml
@@ -46,7 +46,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Install
         run: |
-          git submodule update --init --recursive --remote
+          git submodule update --init --recursive
           npm install -g corepack@latest
           corepack enable
           pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
       - name: Install
         run: |
-          git submodule update --init --recursive --remote
+          git submodule update --init --recursive
           npm install -g corepack@latest
           corepack enable && corepack prepare
           corepack pnpm install --frozen-lockfile
@@ -77,7 +77,7 @@ jobs:
           package-manager-cache: false
       - name: Install
         run: |
-          git submodule update --init --recursive --remote
+          git submodule update --init --recursive
           npm install -g corepack@latest
           corepack enable && corepack prepare
           corepack pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@rslib/core": "catalog:",
     "@svitejs/changesets-changelog-github-compact": "^1.2.0",
     "@types/node": "^18.19.130",
-    "@vitest/coverage-v8": "^2.1.8",
+    "@vitest/coverage-v8": "^2.1.9",
     "@vitest/eslint-plugin": "^1.1.24",
     "cspell": "^8.17.1",
     "dprint": "^0.48.0",
@@ -83,7 +83,7 @@
     "typedoc": "^0.28.0",
     "typescript": "catalog:",
     "typescript-eslint": "^8.19.1",
-    "vitest": "2.1.8"
+    "vitest": "2.1.9"
   },
   "packageManager": "pnpm@9.12.3",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,17 +16,17 @@ catalogs:
       specifier: 0.3.3
       version: 0.3.3
     '@lynx-js/react':
-      specifier: 0.113.0
-      version: 0.113.0
+      specifier: 0.115.1
+      version: 0.115.1
     '@lynx-js/react-rsbuild-plugin':
-      specifier: 0.11.2
-      version: 0.11.2
+      specifier: 0.12.4
+      version: 0.12.4
     '@lynx-js/react-use':
       specifier: 0.0.7
       version: 0.0.7
     '@lynx-js/rspeedy':
-      specifier: 0.11.2
-      version: 0.11.2
+      specifier: 0.12.2
+      version: 0.12.2
     '@lynx-js/types':
       specifier: 3.6.0
       version: 3.6.0
@@ -148,7 +148,7 @@ importers:
         version: 0.3.3
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
         version: 1.4.2(@rsbuild/core@1.6.15)
@@ -162,11 +162,11 @@ importers:
         specifier: ^18.19.130
         version: 18.19.130
       '@vitest/coverage-v8':
-        specifier: ^2.1.8
-        version: 2.1.9(vitest@2.1.8(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1))
+        specifier: ^2.1.9
+        version: 2.1.9(vitest@2.1.9(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1))
       '@vitest/eslint-plugin':
         specifier: ^1.1.24
-        version: 1.6.5(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)(vitest@2.1.8(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1))
+        version: 1.6.5(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)(vitest@2.1.9(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1))
       cspell:
         specifier: ^8.17.1
         version: 8.19.4
@@ -234,8 +234,8 @@ importers:
         specifier: ^8.19.1
         version: 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: 2.1.8
-        version: 2.1.8(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)
+        specifier: 2.1.9
+        version: 2.1.9(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)
 
   apps/examples/Button:
     dependencies:
@@ -247,7 +247,7 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -257,10 +257,10 @@ importers:
         version: 0.3.3
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -278,14 +278,14 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
     devDependencies:
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.27
@@ -300,7 +300,7 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -310,10 +310,10 @@ importers:
         version: link:../../../luna/packages/luna-tailwind
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@lynx-js/tailwind-preset':
         specifier: catalog:tailwind
         version: 0.4.0(tailwindcss@3.4.17)
@@ -337,17 +337,17 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
     devDependencies:
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: 'catalog:'
         version: 0.3.3
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -365,17 +365,17 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
     devDependencies:
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: 'catalog:'
         version: 0.3.3
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -393,14 +393,14 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
     devDependencies:
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.27
@@ -415,14 +415,14 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
     devDependencies:
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.27
@@ -437,14 +437,14 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
     devDependencies:
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -462,17 +462,17 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
     devDependencies:
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: 'catalog:'
         version: 0.3.3
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -490,7 +490,7 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -500,10 +500,10 @@ importers:
         version: link:../../../luna/packages/luna-tailwind
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@lynx-js/tailwind-preset':
         specifier: catalog:tailwind
         version: 0.4.0(tailwindcss@3.4.17)
@@ -530,17 +530,17 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -558,17 +558,17 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
     devDependencies:
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: 'catalog:'
         version: 0.3.3
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -586,7 +586,7 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -596,10 +596,10 @@ importers:
         version: 0.3.3
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -617,17 +617,17 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
     devDependencies:
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: 'catalog:'
         version: 0.3.3
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -645,17 +645,17 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
     devDependencies:
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: 'catalog:'
         version: 0.3.3
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -673,7 +673,7 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -683,10 +683,10 @@ importers:
         version: 0.3.3
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -704,7 +704,7 @@ importers:
         version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -714,10 +714,10 @@ importers:
         version: link:../../../luna/packages/luna-tailwind
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+        version: 0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
       '@lynx-js/tailwind-preset':
         specifier: catalog:tailwind
         version: 0.4.0(tailwindcss@3.4.17)
@@ -1092,7 +1092,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1117,7 +1117,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1145,7 +1145,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1163,14 +1163,14 @@ importers:
     dependencies:
       '@lynx-js/gesture-runtime':
         specifier: 'catalog:'
-        version: 2.1.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)
+        version: 2.1.1(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)
       '@lynx-js/react-use':
         specifier: 'catalog:'
-        version: 0.0.7(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.0.7(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1204,7 +1204,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1225,11 +1225,11 @@ importers:
         version: link:../lynx-ui-common
       '@lynx-js/react-use':
         specifier: 'catalog:'
-        version: 0.0.7(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.0.7(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1247,7 +1247,7 @@ importers:
     dependencies:
       '@lynx-js/gesture-runtime':
         specifier: 'catalog:'
-        version: 2.1.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)
+        version: 2.1.1(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)
       '@lynx-js/lynx-ui-common':
         specifier: workspace:*
         version: link:../lynx-ui-common
@@ -1257,7 +1257,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1294,7 +1294,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1319,7 +1319,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1341,7 +1341,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1359,14 +1359,14 @@ importers:
     dependencies:
       '@lynx-js/gesture-runtime':
         specifier: 'catalog:'
-        version: 2.1.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)
+        version: 2.1.1(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)
       '@lynx-js/lynx-ui-common':
         specifier: workspace:*
         version: link:../lynx-ui-common
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1388,7 +1388,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1422,7 +1422,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1447,7 +1447,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1475,7 +1475,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1493,7 +1493,7 @@ importers:
     dependencies:
       '@lynx-js/gesture-runtime':
         specifier: 'catalog:'
-        version: 2.1.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)
+        version: 2.1.1(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)
       '@lynx-js/lynx-ui-common':
         specifier: workspace:*
         version: link:../lynx-ui-common
@@ -1503,7 +1503,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1533,14 +1533,14 @@ importers:
         version: link:../lynx-ui-presence
       '@lynx-js/motion':
         specifier: 'catalog:'
-        version: 0.0.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.0.2(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1565,7 +1565,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1583,14 +1583,14 @@ importers:
     dependencies:
       '@lynx-js/gesture-runtime':
         specifier: 'catalog:'
-        version: 2.1.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)
+        version: 2.1.1(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)
       '@lynx-js/lynx-ui-common':
         specifier: workspace:*
         version: link:../lynx-ui-common
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1611,11 +1611,11 @@ importers:
         version: link:../lynx-ui-common
       '@lynx-js/react-use':
         specifier: 'catalog:'
-        version: 0.0.7(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.0.7(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1637,7 +1637,7 @@ importers:
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
-        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+        version: 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 3.6.0
@@ -1668,7 +1668,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
 
 packages:
 
@@ -2646,6 +2646,12 @@ packages:
     peerDependencies:
       '@lynx-js/template-webpack-plugin': ^0.9.0
 
+  '@lynx-js/css-extract-webpack-plugin@0.7.0':
+    resolution: {integrity: sha512-sqBEDg4bYPyc/v/ldNPfUsGokPsNlDnwWBKmZ9uDvUaLwfpxxexDxQ7M06q5BXnU+9SFiWoplrKL31c62foa6A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@lynx-js/template-webpack-plugin': ^0.10.0
+
   '@lynx-js/css-serializer@0.1.3':
     resolution: {integrity: sha512-AngMqNr8qvGeejv68MjbVNiuYAjzMm3S/t6lrCbtRn8jwa8gVU0Std2mVCMDeIoWzfjjliyRQMd6AzGydOh8dg==}
 
@@ -2677,12 +2683,12 @@ packages:
     resolution: {integrity: sha512-0Kkr2TWqIicgUrc3VJcCEzhuuaYLdFWdcIXJIZ1shChsuH9nRJCFqG29bfGlqLK5P3KV5WImXvF/+sC93KEPMw==}
     engines: {node: '>=18'}
 
-  '@lynx-js/react-alias-rsbuild-plugin@0.11.2':
-    resolution: {integrity: sha512-3GqrPk+CRUWV9ubIaGZ/zl/7Fxob6BJbOy2n+PqqCKFEJBlJQ9MQ0ee3jEa70UIgXJEwrint+4XxhoFsoUiXMg==}
-    engines: {node: '>=18'}
-
   '@lynx-js/react-alias-rsbuild-plugin@0.11.4':
     resolution: {integrity: sha512-3zqMMG2pF5VSpsQp4qIfGz46gXOJWFe8Tb1yHIcovb3fU3JNosdgE4eJE2+qxco61Yd9I7cS+mtn+T66AbG3dw==}
+    engines: {node: '>=18'}
+
+  '@lynx-js/react-alias-rsbuild-plugin@0.12.4':
+    resolution: {integrity: sha512-H34GGQt4V25C9xOjGX5ajuz9hS7KLmHeVO8o2AdRKgGIkaxYKm8Ob7nkN+hcCountRHNCHDAaQF3QoS+QEwrTA==}
     engines: {node: '>=18'}
 
   '@lynx-js/react-refresh-webpack-plugin@0.3.4':
@@ -2690,15 +2696,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@lynx-js/react-webpack-plugin': ^0.3.0 || ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0
-
-  '@lynx-js/react-rsbuild-plugin@0.11.2':
-    resolution: {integrity: sha512-1FF0u2wtJp01H55QDVlrO5P2/JOkHBAsclQ0pAVTZ+qwQ50ALRaN5I+dDoVKG7KHMcAqBuBDu+7FjqcAgWn9jg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@lynx-js/react': ^0.103.0 || ^0.104.0 || ^0.105.0 || ^0.106.0 || ^0.107.0 || ^0.108.0 || ^0.109.0 || ^0.110.0 || ^0.111.0 || ^0.112.0 || ^0.113.0 || ^0.114.0
-    peerDependenciesMeta:
-      '@lynx-js/react':
-        optional: true
 
   '@lynx-js/react-rsbuild-plugin@0.11.4':
     resolution: {integrity: sha512-ZLTSvPal1NbQVJ69ufPkwT+uapwkNyLdyhiS72V4W1S91l4C9UelFuzjqGGt/x/NGvkwbCcvdLqGTsrA8TMhmg==}
@@ -2709,20 +2706,19 @@ packages:
       '@lynx-js/react':
         optional: true
 
+  '@lynx-js/react-rsbuild-plugin@0.12.4':
+    resolution: {integrity: sha512-Su1nCqpNvXY4ry00P/6zWSlpa/6mH+0vLs9FHdNrxZ3RdIKLjfLOnwcoBdNoPrg9uWCT+BoblLy606dNVMsjMg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@lynx-js/react': ^0.103.0 || ^0.104.0 || ^0.105.0 || ^0.106.0 || ^0.107.0 || ^0.108.0 || ^0.109.0 || ^0.110.0 || ^0.111.0 || ^0.112.0 || ^0.113.0 || ^0.114.0 || ^0.115.0
+    peerDependenciesMeta:
+      '@lynx-js/react':
+        optional: true
+
   '@lynx-js/react-use@0.0.7':
     resolution: {integrity: sha512-L+snt3B4ti3sCPiMg1+0FQxr/KV1CadV0kTUD/Lj8VBhJ5gK5TiI0tRLSCGUrMZyNlzI9enXlk6C3GIquEo8Fw==}
     peerDependencies:
       '@lynx-js/react': '>=0.114.4'
-
-  '@lynx-js/react-webpack-plugin@0.7.1':
-    resolution: {integrity: sha512-OBLSytV64lEHhQtpLlTlMqb17EBRhXQHZ/+J9As+TjuDz79g5Kr03aszCbXd0ygUQGymAP9dmpO8NHCtjTUkHw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@lynx-js/react': '*'
-      '@lynx-js/template-webpack-plugin': ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0
-    peerDependenciesMeta:
-      '@lynx-js/react':
-        optional: true
 
   '@lynx-js/react-webpack-plugin@0.7.2':
     resolution: {integrity: sha512-NfAYBu8hfnvNOVK7CczMg7WIgpsAjz7b5BEFvH7xlmoqIsBL3aOhX5MDmvQ4UiNOlWpMdFHr5/CFOmxVN6Bm4Q==}
@@ -2734,13 +2730,14 @@ packages:
       '@lynx-js/react':
         optional: true
 
-  '@lynx-js/react@0.113.0':
-    resolution: {integrity: sha512-0BRomVrfeHt+c2ovgiRMH3syed0rDM+grp0hE3+SqPFWn3G0yGcYSJ8ikaSXc3H4qLZrCaO5LJSvfQ+reqrB3w==}
+  '@lynx-js/react-webpack-plugin@0.7.3':
+    resolution: {integrity: sha512-gWjkWN5ikXusGljQQ1m6oeZcCBpLI1Okw/PSpjGM7QMe0tCVhBO7YKpEjWRmmq8N9j/sXAG4uE3HuIraUtPZZA==}
+    engines: {node: '>=18'}
     peerDependencies:
-      '@lynx-js/types': '*'
-      '@types/react': ^18
+      '@lynx-js/react': '*'
+      '@lynx-js/template-webpack-plugin': ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0
     peerDependenciesMeta:
-      '@lynx-js/types':
+      '@lynx-js/react':
         optional: true
 
   '@lynx-js/react@0.114.4':
@@ -2752,8 +2749,17 @@ packages:
       '@lynx-js/types':
         optional: true
 
-  '@lynx-js/rspeedy@0.11.2':
-    resolution: {integrity: sha512-v0+Idjfeqr1e9x+kPDjUrT/Ty2AQASt5UKwPNYzsDcgp2hnNYLHDBhVFTQyqbDKvMOF+RTbf/qyisz7QJl8laA==}
+  '@lynx-js/react@0.115.1':
+    resolution: {integrity: sha512-htZXSUmKI/7NI5hPMBcv2zN8CRJ+Yq8TaHX2nk3oJyZzQdIzo+L9IbtVx1GwRRMsC3PmkdKX9Wiqgtjle0MolQ==}
+    peerDependencies:
+      '@lynx-js/types': '*'
+      '@types/react': ^18
+    peerDependenciesMeta:
+      '@lynx-js/types':
+        optional: true
+
+  '@lynx-js/rspeedy@0.11.8':
+    resolution: {integrity: sha512-pQ8iQZa4GgJ1pBuqpPOY6yqURdqADy//xCCubA6U/KSQCHSj0Red8DHbpGUR16FPnh1M4Yf8CROk5cLxZ/7SJg==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -2762,8 +2768,8 @@ packages:
       typescript:
         optional: true
 
-  '@lynx-js/rspeedy@0.11.8':
-    resolution: {integrity: sha512-pQ8iQZa4GgJ1pBuqpPOY6yqURdqADy//xCCubA6U/KSQCHSj0Red8DHbpGUR16FPnh1M4Yf8CROk5cLxZ/7SJg==}
+  '@lynx-js/rspeedy@0.12.2':
+    resolution: {integrity: sha512-Zh1DM1ye+Ku/0xECSmXFnX4vFcfO8ZnN1Kh0T/cwo/OeL3o3FPDTSyoJaZB4cdbVUpIFoFUuTwlA7GVWC+Ea4Q==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -2784,8 +2790,11 @@ packages:
   '@lynx-js/tasm@0.0.18':
     resolution: {integrity: sha512-6Kl1eUxooceWcSLYnCtys38r9KPIouTam/fU81pzOrH/xIal60+WY47nj+MzDXq94i9jbUusM+IQSZAkeRistw==}
 
-  '@lynx-js/template-webpack-plugin@0.9.0':
-    resolution: {integrity: sha512-4HOqIVERYpcQDiF7rG8o1C+wpAbJaIHWeUgUpZInUIdPPwJMF80LKQO2G5zdGK2HEW3SdclhUMrRXt7Ze4SPfw==}
+  '@lynx-js/tasm@0.0.20':
+    resolution: {integrity: sha512-ezMq43s59jqFuQ1YygpsUuZmGXw4XH+00RsB5RVmkYZuHQxEaLt/ECTOixF+9RixvAyhmxzF2eSURvmNckO9xg==}
+
+  '@lynx-js/template-webpack-plugin@0.10.1':
+    resolution: {integrity: sha512-ZMLGjOy2eCEyNZN6IIJhxnmkq4BhP2fOaO87a6EcADOKejO461R+ifJYvzoYdDYmmIyf2eRueJ+zEf5l7zsf3A==}
     engines: {node: '>=18'}
 
   '@lynx-js/template-webpack-plugin@0.9.1':
@@ -2828,6 +2837,9 @@ packages:
 
   '@lynx-js/web-rsbuild-server-middleware@0.18.2':
     resolution: {integrity: sha512-CSksHEmetwL6EpI7LbcRxVKRoOA7it+sZ4hnedV91Si733jKWEMmNhRcl3TVP+WaHZHUgU3b6NNhZS7xBgh0yQ==}
+
+  '@lynx-js/web-rsbuild-server-middleware@0.19.1':
+    resolution: {integrity: sha512-U6swueZZ7J+N9i8MXQAOqFztM5vvYWXXf/mJW+/NIjbrcGqCmvQpV80nSess4SQ3FU1qSHqyWxDg8PiF1jlceA==}
 
   '@lynx-js/web-style-transformer@0.18.1':
     resolution: {integrity: sha512-sum/483fLbNmbkuXkT+AiOlI2wVstaFhfe/btDAJpG2NPNlUyRaTgzi6bsj6CTo9wgaAWdoyJ6o3oKbS/PsLkA==}
@@ -3327,11 +3339,6 @@ packages:
     engines: {node: '>=18.12.0'}
     hasBin: true
 
-  '@rsbuild/core@1.5.4':
-    resolution: {integrity: sha512-iRzq4hEXawL4MVkPKhfGMJxS45XIfwkweAZXEHeaboq6vxbpg0dLRgkbaIuuFyF9hCwI0y3ant/xVXOqDghJNw==}
-    engines: {node: '>=18.12.0'}
-    hasBin: true
-
   '@rsbuild/core@1.6.0-beta.1':
     resolution: {integrity: sha512-UjQnvXDW9m/hS4DP66ubGIMVjK2PzYx8tzgiinrO0kjNCr9i8KWuJSJGUWyczFMpSsXxp20LnuTxtx7kiGiYdA==}
     engines: {node: '>=18.12.0'}
@@ -3339,6 +3346,11 @@ packages:
 
   '@rsbuild/core@1.6.1':
     resolution: {integrity: sha512-zC5Pinm5MpQwlSMQosGgrtXH8zuoHSuxNbnzY702NUYImWDagqmFaUnB5dp5vQRPgYV/5p5hCtz88jUguX0jgQ==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+
+  '@rsbuild/core@1.6.13':
+    resolution: {integrity: sha512-7Isd9G6ufIK5+kPCH8OhvVAVD5clsak9bp9IfhyEWT8SH43cLuXsUpK+4w0a6JA/kM98ea7KJEigIuCHJ5wAag==}
     engines: {node: '>=18.12.0'}
     hasBin: true
 
@@ -3436,11 +3448,6 @@ packages:
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@1.5.2':
-    resolution: {integrity: sha512-aO76T6VQvAFt1LJNRA5aPOJ+szeTLlzC5wubsnxgWWjG53goP+Te35kFjDIDe+9VhKE/XqRId6iNAymaEsN+Uw==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@1.5.8':
     resolution: {integrity: sha512-spJfpOSN3f7V90ic45/ET2NKB2ujAViCNmqb0iGurMNQtFRq+7Kd+jvVKKGXKBHBbsQrFhidSWbbqy2PBPGK8g==}
     cpu: [arm64]
@@ -3456,14 +3463,14 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@1.6.8':
-    resolution: {integrity: sha512-e8CTQtzaeGnf+BIzR7wRMUwKfIg0jd/sxMRc1Vd0bCMHBhSN9EsGoMuJJaKeRrSmy2nwMCNWHIG+TvT1CEKg+A==}
+  '@rspack/binding-darwin-arm64@1.6.6':
+    resolution: {integrity: sha512-vGVDP0rlWa2w/gLba/sncVfkCah0HmhdmK5vGj/7sSX0iViwQneA2xjxDHyCNSQrvfq9GJmj4Kmdq/9tGh0KuA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.5.2':
-    resolution: {integrity: sha512-XNSmUOwdGs2PEdCKTFCC0/vu/7U9nMhAlbHJKlmdt0V4iPvFyaNWxkNdFqzLc05jlJOfgDdwbwRb91y9IcIIFQ==}
-    cpu: [x64]
+  '@rspack/binding-darwin-arm64@1.6.8':
+    resolution: {integrity: sha512-e8CTQtzaeGnf+BIzR7wRMUwKfIg0jd/sxMRc1Vd0bCMHBhSN9EsGoMuJJaKeRrSmy2nwMCNWHIG+TvT1CEKg+A==}
+    cpu: [arm64]
     os: [darwin]
 
   '@rspack/binding-darwin-x64@1.5.8':
@@ -3481,15 +3488,15 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rspack/binding-darwin-x64@1.6.6':
+    resolution: {integrity: sha512-IcdEG2kOmbPPO70Zl7gDnowDjK7d7C1hWew2vU7dPltr2t1JalRIMnS051lhiur0ULkSxV3cW1zXqv0Oi8AnOg==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@1.6.8':
     resolution: {integrity: sha512-ku1XpTEPt6Za11zhpFWhfwrTQogcgi9RJrOUVC4FESiPO9aKyd4hJ+JiPgLY0MZOqsptK6vEAgOip+uDVXrCpg==}
     cpu: [x64]
     os: [darwin]
-
-  '@rspack/binding-linux-arm64-gnu@1.5.2':
-    resolution: {integrity: sha512-rNxRfgC5khlrhyEP6y93+45uQ4TI7CdtWqh5PKsaR6lPepG1rH4L8VE+etejSdhzXH6wQ76Rw4wzb96Hx+5vuQ==}
-    cpu: [arm64]
-    os: [linux]
 
   '@rspack/binding-linux-arm64-gnu@1.5.8':
     resolution: {integrity: sha512-UAWCsOnpkvy8eAVRo0uipbHXDhnoDq5zmqWTMhpga0/a3yzCp2e+fnjZb/qnFNYb5MeL0O1mwMOYgn1M3oHILQ==}
@@ -3506,13 +3513,13 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-gnu@1.6.8':
-    resolution: {integrity: sha512-fvZX6xZPvBT8qipSpvkKMX5M7yd2BSpZNCZXcefw6gA3uC7LI3gu+er0LrDXY1PtPzVuHTyDx+abwWpagV3PiQ==}
+  '@rspack/binding-linux-arm64-gnu@1.6.6':
+    resolution: {integrity: sha512-rIguCCtlTcwoFlwheDiUgdImk27spuCRn43zGJogARpM/ZYRFKIuSwFDGUtJT2g0TSLUAHUhWAUqC36NwvrbMQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@1.5.2':
-    resolution: {integrity: sha512-kTFX+KsGgArWC5q+jJWz0K/8rfVqZOn1ojv1xpCCcz/ogWRC/qhDGSOva6Wandh157BiR93Vfoe1gMvgjpLe5g==}
+  '@rspack/binding-linux-arm64-gnu@1.6.8':
+    resolution: {integrity: sha512-fvZX6xZPvBT8qipSpvkKMX5M7yd2BSpZNCZXcefw6gA3uC7LI3gu+er0LrDXY1PtPzVuHTyDx+abwWpagV3PiQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -3531,14 +3538,14 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@1.6.8':
-    resolution: {integrity: sha512-++XMKcMNrt59HcFBLnRaJcn70k3X0GwkAegZBVpel8xYIAgvoXT5+L8P1ExId/yTFxqedaz8DbcxQnNmMozviw==}
+  '@rspack/binding-linux-arm64-musl@1.6.6':
+    resolution: {integrity: sha512-x6X6Gr0fUw6qrJGxZt3Rb6oIX+jd9pdcyp0VbtofcLaqGVQbzustYsYnuLATPOys0q4J/4kWnmEhkjLJHwkhpQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.5.2':
-    resolution: {integrity: sha512-Lh/6WZGq30lDV6RteQQu7Phw0RH2Z1f4kGR+MsplJ6X4JpnziDow+9oxKdu6FvFHWxHByncpveVeInusQPmL7Q==}
-    cpu: [x64]
+  '@rspack/binding-linux-arm64-musl@1.6.8':
+    resolution: {integrity: sha512-++XMKcMNrt59HcFBLnRaJcn70k3X0GwkAegZBVpel8xYIAgvoXT5+L8P1ExId/yTFxqedaz8DbcxQnNmMozviw==}
+    cpu: [arm64]
     os: [linux]
 
   '@rspack/binding-linux-x64-gnu@1.5.8':
@@ -3556,13 +3563,13 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.6.8':
-    resolution: {integrity: sha512-tv3BWkTE1TndfX+DsE1rSTg8fBevCxujNZ3MlfZ22Wfy9x1FMXTJlWG8VIOXmaaJ1wUHzv8S7cE2YUUJ2LuiCg==}
+  '@rspack/binding-linux-x64-gnu@1.6.6':
+    resolution: {integrity: sha512-gSlVdASszWHosQKn+nzYOInBijdQboUnmNMGgW9/PijVg3433IvQjzviUuJFno8CMGgrACV9yw+ZFDuK0J57VA==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@1.5.2':
-    resolution: {integrity: sha512-CsLC/SIOIFs6CBmusSAF0FECB62+J36alMdwl7j6TgN6nX3UQQapnL1aVWuQaxU6un/1Vpim0V/EZbUYIdJQ4g==}
+  '@rspack/binding-linux-x64-gnu@1.6.8':
+    resolution: {integrity: sha512-tv3BWkTE1TndfX+DsE1rSTg8fBevCxujNZ3MlfZ22Wfy9x1FMXTJlWG8VIOXmaaJ1wUHzv8S7cE2YUUJ2LuiCg==}
     cpu: [x64]
     os: [linux]
 
@@ -3581,14 +3588,15 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-musl@1.6.6':
+    resolution: {integrity: sha512-TZaqVkh7memsTK/hxkOBrbpdzbmBUMea1YnYt++7QjMgco1kWFvAQ+YhAWtIaOaEg8s6C07Lt0Zp8izM2Dja0g==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-linux-x64-musl@1.6.8':
     resolution: {integrity: sha512-DCGgZ5/in1O3FjHWqXnDsncRy+48cMhfuUAAUyl0yDj1NpsZu9pP+xfGLvGcQTiYrVl7IH9Aojf1eShP/77WGA==}
     cpu: [x64]
     os: [linux]
-
-  '@rspack/binding-wasm32-wasi@1.5.2':
-    resolution: {integrity: sha512-cuVbGr1b4q0Z6AtEraI3becZraPMMgZtZPRaIsVLeDXCmxup/maSAR3T6UaGf4Q2SNcFfjw4neGz5UJxPK8uvA==}
-    cpu: [wasm32]
 
   '@rspack/binding-wasm32-wasi@1.5.8':
     resolution: {integrity: sha512-cfg3niNHeJuxuml1Vy9VvaJrI/5TakzoaZvKX2g5S24wfzR50Eyy4JAsZ+L2voWQQp1yMJbmPYPmnTCTxdJQBQ==}
@@ -3602,14 +3610,13 @@ packages:
     resolution: {integrity: sha512-PaKEjXOkYprSFlgdgVm/P3pv2E8nAQx9WSGgPmMVIAtxo3Cyz0wwFf0f1Bp9wCw0KkIWgi+9lz8oXNkgKZilug==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@1.6.6':
+    resolution: {integrity: sha512-W4mWdlLnYrbUaktyHOGNfATblxMTbgF7CBfDw8PhbDtjd2l8e/TnaHgIDkwITHXAOMEF/QEKfo9FtusbcQJNKw==}
+    cpu: [wasm32]
+
   '@rspack/binding-wasm32-wasi@1.6.8':
     resolution: {integrity: sha512-VUwdhl/lI4m6o1OGCZ9JwtMjTV/yLY5VZTQdEPKb40JMTlmZ5MBlr5xk7ByaXXYHr6I+qnqEm73iMKQvg6iknw==}
     cpu: [wasm32]
-
-  '@rspack/binding-win32-arm64-msvc@1.5.2':
-    resolution: {integrity: sha512-4vJQdzRTSuvmvL3vrOPuiA7f9v9frNc2RFWDxqg+GYt0YAjDStssp+lkVbRYyXnTYVJkARSuO6N+BOiI+kLdsQ==}
-    cpu: [arm64]
-    os: [win32]
 
   '@rspack/binding-win32-arm64-msvc@1.5.8':
     resolution: {integrity: sha512-7i3ZTHFXKfU/9Jm9XhpMkrdkxO7lfeYMNVEGkuU5dyBfRMQj69dRgPL7zJwc2plXiqu9LUOl+TwDNTjap7Q36g==}
@@ -3626,14 +3633,14 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@1.6.8':
-    resolution: {integrity: sha512-23YX7zlOZlub+nPGDBUzktb4D5D6ETUAluKjXEeHIZ9m7fSlEYBnGL66YE+3t1DHXGd0OqsdwlvrNGcyo6EXDQ==}
+  '@rspack/binding-win32-arm64-msvc@1.6.6':
+    resolution: {integrity: sha512-cw5OgxqoDwjoZlk0L3vGEwcjPZsOVFYLwr2ssiC05rsTbhBwxj8coLpAJdvUvbf6C2TTmCB7iPe2sPq1KWD37g==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.5.2':
-    resolution: {integrity: sha512-zPbu3lx/NrNxdjZzTIjwD0mILUOpfhuPdUdXIFiOAO8RiWSeQpYOvyI061s/+bNOmr4A+Z0uM0dEoOClfkhUFg==}
-    cpu: [ia32]
+  '@rspack/binding-win32-arm64-msvc@1.6.8':
+    resolution: {integrity: sha512-23YX7zlOZlub+nPGDBUzktb4D5D6ETUAluKjXEeHIZ9m7fSlEYBnGL66YE+3t1DHXGd0OqsdwlvrNGcyo6EXDQ==}
+    cpu: [arm64]
     os: [win32]
 
   '@rspack/binding-win32-ia32-msvc@1.5.8':
@@ -3651,14 +3658,14 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.6.8':
-    resolution: {integrity: sha512-cFgRE3APxrY4AEdooVk2LtipwNNT/9mrnjdC5lVbsIsz+SxvGbZR231bxDJEqP15+RJOaD07FO1sIjINFqXMEg==}
+  '@rspack/binding-win32-ia32-msvc@1.6.6':
+    resolution: {integrity: sha512-M4ruR+VZ59iy+mPjy6FQPT27cOgeytf3wFBrt7e0suKeNLYGxrNyI9YhgpCTY++SMJsAMgRLGDHoI3ZgWulw1Q==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.5.2':
-    resolution: {integrity: sha512-duLNUTshX38xhC10/W9tpkPca7rOifP2begZjdb1ikw7C4AI0I7VnBnYt8qPSxGISoclmhOBxU/LuAhS8jMMlg==}
-    cpu: [x64]
+  '@rspack/binding-win32-ia32-msvc@1.6.8':
+    resolution: {integrity: sha512-cFgRE3APxrY4AEdooVk2LtipwNNT/9mrnjdC5lVbsIsz+SxvGbZR231bxDJEqP15+RJOaD07FO1sIjINFqXMEg==}
+    cpu: [ia32]
     os: [win32]
 
   '@rspack/binding-win32-x64-msvc@1.5.8':
@@ -3676,13 +3683,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@1.6.6':
+    resolution: {integrity: sha512-q5QTvdhPUh+CA93cQG5zWKRIHMIWPzw+ftFDEwBw52zYdvNAoLniqD8o5Mi8CT0pndhulXgR5aw0Sjd3eMah+A==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@1.6.8':
     resolution: {integrity: sha512-cIuhVsZYd3o3Neo1JSAhJYw6BDvlxaBoqvgwRkG1rs0ExFmEmgYyG7ip9pFKnKNWph/tmW3rDYypmEfjs1is7g==}
     cpu: [x64]
     os: [win32]
-
-  '@rspack/binding@1.5.2':
-    resolution: {integrity: sha512-NKiBcsxmAzFDYRnK2ZHWbTtDFVT5/704eK4OfpgsDXPMkaMnBKijMKNgP5pbe18X4rUlz+8HnGm4+Xllo9EESw==}
 
   '@rspack/binding@1.5.8':
     resolution: {integrity: sha512-/91CzhRl9r5BIQCgGsS7jA6MDbw1I2BQpbfcUUdkdKl2P79K3Zo/Mw/TvKzS86catwLaUQEgkGRmYawOfPg7ow==}
@@ -3693,17 +3702,11 @@ packages:
   '@rspack/binding@1.6.0-beta.1':
     resolution: {integrity: sha512-r3L60ekkDLM5qoRjCMrqsgwU9SQ5e8oA/Omltu/FEEUspIVHawPvAqNZvAXnGB+FoNxM8YgdRRh12PAwXJww0A==}
 
+  '@rspack/binding@1.6.6':
+    resolution: {integrity: sha512-noiV+qhyBTVpvG2M4bnOwKk2Ynl6G47Wf7wpCjPCFr87qr3txNwTTnhkEJEU59yj+VvIhbRD2rf5+9TLoT0Wxg==}
+
   '@rspack/binding@1.6.8':
     resolution: {integrity: sha512-lUeL4mbwGo+nqRKqFDCm9vH2jv9FNMVt1X8jqayWRcOCPlj/2UVMEFgqjR7Pp2vlvnTKq//31KbDBJmDZq31RQ==}
-
-  '@rspack/core@1.5.2':
-    resolution: {integrity: sha512-ifjHqLczC81d1xjXPXCzxTFKNOFsEzuuLN44cMnyzQ/GWi4B48fyX7JHndWE7Lxd54cW1O9Ik7AdBN3Gq891EA==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
 
   '@rspack/core@1.5.8':
     resolution: {integrity: sha512-sUd2LfiDhqYVfvknuoz0+/c+wSpn693xotnG5g1CSWKZArbtwiYzBIVnNlcHGmuoBRsnj/TkSq8dTQ7gwfBroQ==}
@@ -3725,6 +3728,15 @@ packages:
 
   '@rspack/core@1.6.0-beta.1':
     resolution: {integrity: sha512-2ff8XWonPPHyQ6mEWogMspg+Sul3lXZUfNQVrbYSjfNpi8CeDV0/ZtRbHHbAXiy6pz5fvBFL6X+i/ATckjTYBw==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@1.6.6':
+    resolution: {integrity: sha512-2mR+2YBydlgZ7Q0Rpd6bCC3MBnV9TS0x857K0zIhbDj4BQOqaWVy1n7fx/B3MrS8TR0QCuzKfyDAjNz+XTyJVQ==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -4102,11 +4114,11 @@ packages:
       vitest:
         optional: true
 
-  '@vitest/expect@2.1.8':
-    resolution: {integrity: sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==}
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
-  '@vitest/mocker@2.1.8':
-    resolution: {integrity: sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==}
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0
@@ -4116,23 +4128,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@2.1.8':
-    resolution: {integrity: sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==}
-
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
-  '@vitest/runner@2.1.8':
-    resolution: {integrity: sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==}
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
-  '@vitest/snapshot@2.1.8':
-    resolution: {integrity: sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==}
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
 
-  '@vitest/spy@2.1.8':
-    resolution: {integrity: sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==}
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
 
-  '@vitest/utils@2.1.8':
-    resolution: {integrity: sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==}
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -4534,9 +4543,6 @@ packages:
 
   core-js-compat@3.47.0:
     resolution: {integrity: sha512-IGfuznZ/n7Kp9+nypamBhvwdwLsW6KC8IOaURw2doAK5e98AG3acVLdh0woOnEqCfUtS+Vu882JE4k/DAm3ItQ==}
-
-  core-js@3.45.1:
-    resolution: {integrity: sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==}
 
   core-js@3.46.0:
     resolution: {integrity: sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==}
@@ -5372,6 +5378,7 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   global-directory@4.0.1:
@@ -7364,8 +7371,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite-node@2.1.8:
-    resolution: {integrity: sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==}
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
@@ -7400,15 +7407,15 @@ packages:
       terser:
         optional: true
 
-  vitest@2.1.8:
-    resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.8
-      '@vitest/ui': 2.1.8
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -8415,16 +8422,16 @@ snapshots:
     dependencies:
       '@lynx-js/webpack-runtime-globals': 0.0.6
 
-  '@lynx-js/css-extract-webpack-plugin@0.6.4(@lynx-js/template-webpack-plugin@0.9.0)(webpack@5.104.1)':
+  '@lynx-js/css-extract-webpack-plugin@0.6.4(@lynx-js/template-webpack-plugin@0.9.1)(webpack@5.104.1)':
     dependencies:
-      '@lynx-js/template-webpack-plugin': 0.9.0
+      '@lynx-js/template-webpack-plugin': 0.9.1
       mini-css-extract-plugin: 2.9.4(webpack@5.104.1)
     transitivePeerDependencies:
       - webpack
 
-  '@lynx-js/css-extract-webpack-plugin@0.6.4(@lynx-js/template-webpack-plugin@0.9.1)(webpack@5.104.1)':
+  '@lynx-js/css-extract-webpack-plugin@0.7.0(@lynx-js/template-webpack-plugin@0.10.1)(webpack@5.104.1)':
     dependencies:
-      '@lynx-js/template-webpack-plugin': 0.9.1
+      '@lynx-js/template-webpack-plugin': 0.10.1
       mini-css-extract-plugin: 2.9.4(webpack@5.104.1)
     transitivePeerDependencies:
       - webpack
@@ -8433,16 +8440,16 @@ snapshots:
     dependencies:
       css-tree: 3.1.0
 
-  '@lynx-js/gesture-runtime@2.1.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)':
+  '@lynx-js/gesture-runtime@2.1.1(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)':
     dependencies:
-      '@lynx-js/react': 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+      '@lynx-js/react': 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       '@lynx-js/types': 3.6.0
 
   '@lynx-js/lynx-core@0.1.3': {}
 
-  '@lynx-js/motion@0.0.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@lynx-js/motion@0.0.2(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/types@3.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@lynx-js/react': 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+      '@lynx-js/react': 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       framer-motion: 12.23.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       motion-dom: 12.23.12
       motion-utils: 12.23.6
@@ -8466,55 +8473,19 @@ snapshots:
       picocolors: 1.1.1
       qrcode-terminal: 0.12.0
 
-  '@lynx-js/react-alias-rsbuild-plugin@0.11.2':
-    dependencies:
-      unrs-resolver: 1.11.1
-
   '@lynx-js/react-alias-rsbuild-plugin@0.11.4':
     dependencies:
       unrs-resolver: 1.11.1
 
-  '@lynx-js/react-refresh-webpack-plugin@0.3.4(@lynx-js/react-webpack-plugin@0.7.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0))':
-    dependencies:
-      '@lynx-js/react-webpack-plugin': 0.7.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0)
-
-  '@lynx-js/react-refresh-webpack-plugin@0.3.4(@lynx-js/react-webpack-plugin@0.7.1(@lynx-js/react@0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0))':
-    dependencies:
-      '@lynx-js/react-webpack-plugin': 0.7.1(@lynx-js/react@0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0)
+  '@lynx-js/react-alias-rsbuild-plugin@0.12.4': {}
 
   '@lynx-js/react-refresh-webpack-plugin@0.3.4(@lynx-js/react-webpack-plugin@0.7.2(@lynx-js/react@0.114.4(@lynx-js/types@3.4.11)(@types/react@18.3.24))(@lynx-js/template-webpack-plugin@0.9.1))':
     dependencies:
       '@lynx-js/react-webpack-plugin': 0.7.2(@lynx-js/react@0.114.4(@lynx-js/types@3.4.11)(@types/react@18.3.24))(@lynx-js/template-webpack-plugin@0.9.1)
 
-  '@lynx-js/react-rsbuild-plugin@0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)':
+  '@lynx-js/react-refresh-webpack-plugin@0.3.4(@lynx-js/react-webpack-plugin@0.7.3(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.10.1))':
     dependencies:
-      '@lynx-js/css-extract-webpack-plugin': 0.6.4(@lynx-js/template-webpack-plugin@0.9.0)(webpack@5.104.1)
-      '@lynx-js/react-alias-rsbuild-plugin': 0.11.2
-      '@lynx-js/react-refresh-webpack-plugin': 0.3.4(@lynx-js/react-webpack-plugin@0.7.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0))
-      '@lynx-js/react-webpack-plugin': 0.7.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0)
-      '@lynx-js/runtime-wrapper-webpack-plugin': 0.1.3
-      '@lynx-js/template-webpack-plugin': 0.9.0
-      '@lynx-js/use-sync-external-store': 1.5.0(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))
-      background-only: 0.0.1
-    optionalDependencies:
-      '@lynx-js/react': 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
-    transitivePeerDependencies:
-      - webpack
-
-  '@lynx-js/react-rsbuild-plugin@0.11.2(@lynx-js/react@0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)':
-    dependencies:
-      '@lynx-js/css-extract-webpack-plugin': 0.6.4(@lynx-js/template-webpack-plugin@0.9.0)(webpack@5.104.1)
-      '@lynx-js/react-alias-rsbuild-plugin': 0.11.2
-      '@lynx-js/react-refresh-webpack-plugin': 0.3.4(@lynx-js/react-webpack-plugin@0.7.1(@lynx-js/react@0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0))
-      '@lynx-js/react-webpack-plugin': 0.7.1(@lynx-js/react@0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0)
-      '@lynx-js/runtime-wrapper-webpack-plugin': 0.1.3
-      '@lynx-js/template-webpack-plugin': 0.9.0
-      '@lynx-js/use-sync-external-store': 1.5.0(@lynx-js/react@0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27))
-      background-only: 0.0.1
-    optionalDependencies:
-      '@lynx-js/react': 0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27)
-    transitivePeerDependencies:
-      - webpack
+      '@lynx-js/react-webpack-plugin': 0.7.3(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.10.1)
 
   '@lynx-js/react-rsbuild-plugin@0.11.4(@lynx-js/react@0.114.4(@lynx-js/types@3.4.11)(@types/react@18.3.24))(webpack@5.104.1)':
     dependencies:
@@ -8531,29 +8502,28 @@ snapshots:
     transitivePeerDependencies:
       - webpack
 
-  '@lynx-js/react-use@0.0.7(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@lynx-js/react-rsbuild-plugin@0.12.4(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)':
     dependencies:
-      '@lynx-js/react': 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+      '@lynx-js/css-extract-webpack-plugin': 0.7.0(@lynx-js/template-webpack-plugin@0.10.1)(webpack@5.104.1)
+      '@lynx-js/react-alias-rsbuild-plugin': 0.12.4
+      '@lynx-js/react-refresh-webpack-plugin': 0.3.4(@lynx-js/react-webpack-plugin@0.7.3(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.10.1))
+      '@lynx-js/react-webpack-plugin': 0.7.3(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.10.1)
+      '@lynx-js/runtime-wrapper-webpack-plugin': 0.1.3
+      '@lynx-js/template-webpack-plugin': 0.10.1
+      '@lynx-js/use-sync-external-store': 1.5.0(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))
+      background-only: 0.0.1
+    optionalDependencies:
+      '@lynx-js/react': 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+    transitivePeerDependencies:
+      - webpack
+
+  '@lynx-js/react-use@0.0.7(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/react': 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
       react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - react
       - react-dom
-
-  '@lynx-js/react-webpack-plugin@0.7.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0)':
-    dependencies:
-      '@lynx-js/template-webpack-plugin': 0.9.0
-      '@lynx-js/webpack-runtime-globals': 0.0.6
-      tiny-invariant: 1.3.3
-    optionalDependencies:
-      '@lynx-js/react': 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
-
-  '@lynx-js/react-webpack-plugin@0.7.1(@lynx-js/react@0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0)':
-    dependencies:
-      '@lynx-js/template-webpack-plugin': 0.9.0
-      '@lynx-js/webpack-runtime-globals': 0.0.6
-      tiny-invariant: 1.3.3
-    optionalDependencies:
-      '@lynx-js/react': 0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27)
 
   '@lynx-js/react-webpack-plugin@0.7.2(@lynx-js/react@0.114.4(@lynx-js/types@3.4.11)(@types/react@18.3.24))(@lynx-js/template-webpack-plugin@0.9.1)':
     dependencies:
@@ -8563,12 +8533,13 @@ snapshots:
     optionalDependencies:
       '@lynx-js/react': 0.114.4(@lynx-js/types@3.4.11)(@types/react@18.3.24)
 
-  '@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)':
+  '@lynx-js/react-webpack-plugin@0.7.3(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.10.1)':
     dependencies:
-      '@types/react': 18.3.27
-      preact: '@hongzhiyuan/preact@10.24.0-00213bad'
+      '@lynx-js/template-webpack-plugin': 0.10.1
+      '@lynx-js/webpack-runtime-globals': 0.0.6
+      tiny-invariant: 1.3.3
     optionalDependencies:
-      '@lynx-js/types': 3.6.0
+      '@lynx-js/react': 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
 
   '@lynx-js/react@0.114.4(@lynx-js/types@3.4.11)(@types/react@18.3.24)':
     dependencies:
@@ -8584,30 +8555,12 @@ snapshots:
     optionalDependencies:
       '@lynx-js/types': 3.6.0
 
-  '@lynx-js/rspeedy@0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)':
+  '@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)':
     dependencies:
-      '@lynx-js/cache-events-webpack-plugin': 0.0.2
-      '@lynx-js/chunk-loading-webpack-plugin': 0.3.3
-      '@lynx-js/webpack-dev-transport': 0.2.0
-      '@lynx-js/websocket': 0.0.4
-      '@rsbuild/core': 1.5.4
-      '@rsbuild/plugin-css-minimizer': 1.0.3(@rsbuild/core@1.5.4)(webpack@5.104.1)
-      '@rsdoctor/rspack-plugin': 1.2.3(@rsbuild/core@1.5.4)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)
+      '@types/react': 18.3.27
+      preact: '@hongzhiyuan/preact@10.24.0-00213bad'
     optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/css'
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - lightningcss
-      - supports-color
-      - utf-8-validate
-      - webpack
+      '@lynx-js/types': 3.6.0
 
   '@lynx-js/rspeedy@0.11.8(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.2)(webpack@5.104.1)':
     dependencies:
@@ -8635,6 +8588,32 @@ snapshots:
       - utf-8-validate
       - webpack
 
+  '@lynx-js/rspeedy@0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)':
+    dependencies:
+      '@lynx-js/cache-events-webpack-plugin': 0.0.2
+      '@lynx-js/chunk-loading-webpack-plugin': 0.3.3
+      '@lynx-js/web-rsbuild-server-middleware': 0.19.1
+      '@lynx-js/webpack-dev-transport': 0.2.0
+      '@lynx-js/websocket': 0.0.4
+      '@rsbuild/core': 1.6.13
+      '@rsbuild/plugin-css-minimizer': 1.0.3(@rsbuild/core@1.6.13)(webpack@5.104.1)
+      '@rsdoctor/rspack-plugin': 1.2.3(@rsbuild/core@1.6.13)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/css'
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - lightningcss
+      - supports-color
+      - utf-8-validate
+      - webpack
+
   '@lynx-js/runtime-wrapper-webpack-plugin@0.1.3':
     dependencies:
       '@lynx-js/webpack-runtime-globals': 0.0.6
@@ -8645,10 +8624,12 @@ snapshots:
 
   '@lynx-js/tasm@0.0.18': {}
 
-  '@lynx-js/template-webpack-plugin@0.9.0':
+  '@lynx-js/tasm@0.0.20': {}
+
+  '@lynx-js/template-webpack-plugin@0.10.1':
     dependencies:
       '@lynx-js/css-serializer': 0.1.3
-      '@lynx-js/tasm': 0.0.18
+      '@lynx-js/tasm': 0.0.20
       '@lynx-js/webpack-runtime-globals': 0.0.6
       '@rspack/lite-tapable': 1.0.1
       css-tree: 3.1.0
@@ -8671,17 +8652,13 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
-  '@lynx-js/use-sync-external-store@1.5.0(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))':
-    dependencies:
-      '@lynx-js/react': 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
-
   '@lynx-js/use-sync-external-store@1.5.0(@lynx-js/react@0.114.4(@lynx-js/types@3.4.11)(@types/react@18.3.24))':
     dependencies:
       '@lynx-js/react': 0.114.4(@lynx-js/types@3.4.11)(@types/react@18.3.24)
 
-  '@lynx-js/use-sync-external-store@1.5.0(@lynx-js/react@0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27))':
+  '@lynx-js/use-sync-external-store@1.5.0(@lynx-js/react@0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27))':
     dependencies:
-      '@lynx-js/react': 0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+      '@lynx-js/react': 0.115.1(@lynx-js/types@3.6.0)(@types/react@18.3.27)
 
   '@lynx-js/web-constants@0.18.1':
     dependencies:
@@ -8714,6 +8691,8 @@ snapshots:
       hyphenate-style-name: 1.1.0
 
   '@lynx-js/web-rsbuild-server-middleware@0.18.2': {}
+
+  '@lynx-js/web-rsbuild-server-middleware@0.19.1': {}
 
   '@lynx-js/web-style-transformer@0.18.1':
     dependencies:
@@ -9165,14 +9144,6 @@ snapshots:
       core-js: 3.46.0
       jiti: 2.6.1
 
-  '@rsbuild/core@1.5.4':
-    dependencies:
-      '@rspack/core': 1.5.2(@swc/helpers@0.5.18)
-      '@rspack/lite-tapable': 1.0.1
-      '@swc/helpers': 0.5.18
-      core-js: 3.45.1
-      jiti: 2.6.1
-
   '@rsbuild/core@1.6.0-beta.1':
     dependencies:
       '@rspack/core': 1.6.0-beta.1(@swc/helpers@0.5.18)
@@ -9187,6 +9158,14 @@ snapshots:
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.18
       core-js: 3.46.0
+      jiti: 2.6.1
+
+  '@rsbuild/core@1.6.13':
+    dependencies:
+      '@rspack/core': 1.6.6(@swc/helpers@0.5.18)
+      '@rspack/lite-tapable': 1.1.0
+      '@swc/helpers': 0.5.18
+      core-js: 3.47.0
       jiti: 2.6.1
 
   '@rsbuild/core@1.6.15':
@@ -9207,7 +9186,7 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.5.17
 
-  '@rsbuild/plugin-check-syntax@1.3.0(@rsbuild/core@1.5.4)':
+  '@rsbuild/plugin-check-syntax@1.3.0(@rsbuild/core@1.6.13)':
     dependencies:
       acorn: 8.15.0
       browserslist-to-es-version: 1.3.0
@@ -9215,7 +9194,7 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
     optionalDependencies:
-      '@rsbuild/core': 1.5.4
+      '@rsbuild/core': 1.6.13
 
   '@rsbuild/plugin-css-minimizer@1.0.3(@rsbuild/core@1.5.17)(webpack@5.104.1)':
     dependencies:
@@ -9232,12 +9211,12 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-css-minimizer@1.0.3(@rsbuild/core@1.5.4)(webpack@5.104.1)':
+  '@rsbuild/plugin-css-minimizer@1.0.3(@rsbuild/core@1.6.13)(webpack@5.104.1)':
     dependencies:
       css-minimizer-webpack-plugin: 5.0.1(webpack@5.104.1)
       reduce-configs: 1.1.1
     optionalDependencies:
-      '@rsbuild/core': 1.5.4
+      '@rsbuild/core': 1.6.13
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/css'
@@ -9314,9 +9293,9 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/core@1.2.3(@rsbuild/core@1.5.4)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)':
+  '@rsdoctor/core@1.2.3(@rsbuild/core@1.6.13)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)':
     dependencies:
-      '@rsbuild/plugin-check-syntax': 1.3.0(@rsbuild/core@1.5.4)
+      '@rsbuild/plugin-check-syntax': 1.3.0(@rsbuild/core@1.6.13)
       '@rsdoctor/graph': 1.2.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)
       '@rsdoctor/sdk': 1.2.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)
       '@rsdoctor/types': 1.2.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)
@@ -9368,9 +9347,9 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.2.3(@rsbuild/core@1.5.4)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)':
+  '@rsdoctor/rspack-plugin@1.2.3(@rsbuild/core@1.6.13)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)':
     dependencies:
-      '@rsdoctor/core': 1.2.3(@rsbuild/core@1.5.4)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)
+      '@rsdoctor/core': 1.2.3(@rsbuild/core@1.6.13)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)
       '@rsdoctor/graph': 1.2.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)
       '@rsdoctor/sdk': 1.2.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)
       '@rsdoctor/types': 1.2.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)
@@ -9462,9 +9441,6 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript/native-preview'
 
-  '@rspack/binding-darwin-arm64@1.5.2':
-    optional: true
-
   '@rspack/binding-darwin-arm64@1.5.8':
     optional: true
 
@@ -9474,10 +9450,10 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.6.0-beta.1':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.6.8':
+  '@rspack/binding-darwin-arm64@1.6.6':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.5.2':
+  '@rspack/binding-darwin-arm64@1.6.8':
     optional: true
 
   '@rspack/binding-darwin-x64@1.5.8':
@@ -9489,10 +9465,10 @@ snapshots:
   '@rspack/binding-darwin-x64@1.6.0-beta.1':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.6.8':
+  '@rspack/binding-darwin-x64@1.6.6':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.5.2':
+  '@rspack/binding-darwin-x64@1.6.8':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.5.8':
@@ -9504,10 +9480,10 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@1.6.0-beta.1':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.6.8':
+  '@rspack/binding-linux-arm64-gnu@1.6.6':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.5.2':
+  '@rspack/binding-linux-arm64-gnu@1.6.8':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.5.8':
@@ -9519,10 +9495,10 @@ snapshots:
   '@rspack/binding-linux-arm64-musl@1.6.0-beta.1':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.6.8':
+  '@rspack/binding-linux-arm64-musl@1.6.6':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.5.2':
+  '@rspack/binding-linux-arm64-musl@1.6.8':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.5.8':
@@ -9534,10 +9510,10 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@1.6.0-beta.1':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.6.8':
+  '@rspack/binding-linux-x64-gnu@1.6.6':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.5.2':
+  '@rspack/binding-linux-x64-gnu@1.6.8':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.5.8':
@@ -9549,12 +9525,10 @@ snapshots:
   '@rspack/binding-linux-x64-musl@1.6.0-beta.1':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.6.8':
+  '@rspack/binding-linux-x64-musl@1.6.6':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@1.5.2':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+  '@rspack/binding-linux-x64-musl@1.6.8':
     optional: true
 
   '@rspack/binding-wasm32-wasi@1.5.8':
@@ -9572,12 +9546,14 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
-  '@rspack/binding-wasm32-wasi@1.6.8':
+  '@rspack/binding-wasm32-wasi@1.6.6':
     dependencies:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.5.2':
+  '@rspack/binding-wasm32-wasi@1.6.8':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.5.8':
@@ -9589,10 +9565,10 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@1.6.0-beta.1':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.6.8':
+  '@rspack/binding-win32-arm64-msvc@1.6.6':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.5.2':
+  '@rspack/binding-win32-arm64-msvc@1.6.8':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.5.8':
@@ -9604,10 +9580,10 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@1.6.0-beta.1':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.6.8':
+  '@rspack/binding-win32-ia32-msvc@1.6.6':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.5.2':
+  '@rspack/binding-win32-ia32-msvc@1.6.8':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.5.8':
@@ -9619,21 +9595,11 @@ snapshots:
   '@rspack/binding-win32-x64-msvc@1.6.0-beta.1':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.6.8':
+  '@rspack/binding-win32-x64-msvc@1.6.6':
     optional: true
 
-  '@rspack/binding@1.5.2':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.5.2
-      '@rspack/binding-darwin-x64': 1.5.2
-      '@rspack/binding-linux-arm64-gnu': 1.5.2
-      '@rspack/binding-linux-arm64-musl': 1.5.2
-      '@rspack/binding-linux-x64-gnu': 1.5.2
-      '@rspack/binding-linux-x64-musl': 1.5.2
-      '@rspack/binding-wasm32-wasi': 1.5.2
-      '@rspack/binding-win32-arm64-msvc': 1.5.2
-      '@rspack/binding-win32-ia32-msvc': 1.5.2
-      '@rspack/binding-win32-x64-msvc': 1.5.2
+  '@rspack/binding-win32-x64-msvc@1.6.8':
+    optional: true
 
   '@rspack/binding@1.5.8':
     optionalDependencies:
@@ -9674,6 +9640,19 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.6.0-beta.1
       '@rspack/binding-win32-x64-msvc': 1.6.0-beta.1
 
+  '@rspack/binding@1.6.6':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.6.6
+      '@rspack/binding-darwin-x64': 1.6.6
+      '@rspack/binding-linux-arm64-gnu': 1.6.6
+      '@rspack/binding-linux-arm64-musl': 1.6.6
+      '@rspack/binding-linux-x64-gnu': 1.6.6
+      '@rspack/binding-linux-x64-musl': 1.6.6
+      '@rspack/binding-wasm32-wasi': 1.6.6
+      '@rspack/binding-win32-arm64-msvc': 1.6.6
+      '@rspack/binding-win32-ia32-msvc': 1.6.6
+      '@rspack/binding-win32-x64-msvc': 1.6.6
+
   '@rspack/binding@1.6.8':
     optionalDependencies:
       '@rspack/binding-darwin-arm64': 1.6.8
@@ -9686,14 +9665,6 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 1.6.8
       '@rspack/binding-win32-ia32-msvc': 1.6.8
       '@rspack/binding-win32-x64-msvc': 1.6.8
-
-  '@rspack/core@1.5.2(@swc/helpers@0.5.18)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.18.0
-      '@rspack/binding': 1.5.2
-      '@rspack/lite-tapable': 1.0.1
-    optionalDependencies:
-      '@swc/helpers': 0.5.18
 
   '@rspack/core@1.5.8(@swc/helpers@0.5.18)':
     dependencies:
@@ -9716,6 +9687,14 @@ snapshots:
       '@module-federation/runtime-tools': 0.21.1
       '@rspack/binding': 1.6.0-beta.1
       '@rspack/lite-tapable': 1.0.1
+    optionalDependencies:
+      '@swc/helpers': 0.5.18
+
+  '@rspack/core@1.6.6(@swc/helpers@0.5.18)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.21.6
+      '@rspack/binding': 1.6.6
+      '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
       '@swc/helpers': 0.5.18
 
@@ -10061,7 +10040,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.8(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1))':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -10075,62 +10054,58 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.8(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)
+      vitest: 2.1.9(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.6.5(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)(vitest@2.1.8(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1))':
+  '@vitest/eslint-plugin@1.6.5(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)(vitest@2.1.9(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.52.0
       '@typescript-eslint/utils': 8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
-      vitest: 2.1.8(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)
+      vitest: 2.1.9(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@2.1.8':
+  '@vitest/expect@2.1.9':
     dependencies:
-      '@vitest/spy': 2.1.8
-      '@vitest/utils': 2.1.8
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.8(vite@5.4.21(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1))':
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1))':
     dependencies:
-      '@vitest/spy': 2.1.8
+      '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 5.4.21(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)
 
-  '@vitest/pretty-format@2.1.8':
-    dependencies:
-      tinyrainbow: 1.2.0
-
   '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
 
-  '@vitest/runner@2.1.8':
+  '@vitest/runner@2.1.9':
     dependencies:
-      '@vitest/utils': 2.1.8
+      '@vitest/utils': 2.1.9
       pathe: 1.1.2
 
-  '@vitest/snapshot@2.1.8':
+  '@vitest/snapshot@2.1.9':
     dependencies:
-      '@vitest/pretty-format': 2.1.8
+      '@vitest/pretty-format': 2.1.9
       magic-string: 0.30.21
       pathe: 1.1.2
 
-  '@vitest/spy@2.1.8':
+  '@vitest/spy@2.1.9':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/utils@2.1.8':
+  '@vitest/utils@2.1.9':
     dependencies:
-      '@vitest/pretty-format': 2.1.8
+      '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
@@ -10574,8 +10549,6 @@ snapshots:
   core-js-compat@3.47.0:
     dependencies:
       browserslist: 4.28.1
-
-  core-js@3.45.1: {}
 
   core-js@3.46.0: {}
 
@@ -13640,7 +13613,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@2.1.8(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1):
+  vite-node@2.1.9(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
@@ -13670,15 +13643,15 @@ snapshots:
       sass-embedded: 1.97.2
       terser: 5.44.1
 
-  vitest@2.1.8(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1):
+  vitest@2.1.9(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1):
     dependencies:
-      '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.21(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1))
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1))
       '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.8
-      '@vitest/snapshot': 2.1.8
-      '@vitest/spy': 2.1.8
-      '@vitest/utils': 2.1.8
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
@@ -13690,7 +13663,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
       vite: 5.4.21(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)
-      vite-node: 2.1.8(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)
+      vite-node: 2.1.9(@types/node@18.19.130)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 18.19.130

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,9 +11,9 @@ packages:
   - "!**/output/**"
 
 catalog:
-  "@lynx-js/react": 0.113.0
-  "@lynx-js/react-rsbuild-plugin": 0.11.2
-  "@lynx-js/rspeedy": 0.11.2
+  "@lynx-js/rspeedy": 0.12.2
+  "@lynx-js/react": 0.115.1
+  "@lynx-js/react-rsbuild-plugin": 0.12.4
   "@lynx-js/types": 3.6.0
   "@lynx-js/gesture-runtime": 2.1.1
   "@lynx-js/qrcode-rsbuild-plugin": 0.3.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped test/coverage tooling to v2.1.9 (vitest, @vitest/coverage-v8).
  * Upgraded workspace package versions for several @lynx-js packages (minor version bumps).
  * Simplified CI submodule initialization behavior to rely on superproject-referenced commits rather than remote tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->