### PR TITLE
fix(sheet): fix `clickToClose` on backdrop tap

### DIFF
--- a/.changeset/ripe-pigs-poke.md
+++ b/.changeset/ripe-pigs-poke.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-sheet": patch
+---
+
+Fix SheetBackdrop `clickToClose` by disabling event-through.

--- a/packages/lynx-ui-sheet/src/SheetBackdrop/index.tsx
+++ b/packages/lynx-ui-sheet/src/SheetBackdrop/index.tsx
@@ -56,7 +56,7 @@ export function SheetBackdrop(props: SheetBackdropProps) {
       main-thread:ref={overlayMTRef}
       className={clsx('lynx-ui-sheet-backdrop', className)}
       main-thread:bindtap={handleClickMT}
-      event-through={true}
+      event-through={false}
       style={{
         width: '100%',
         height: '100%',


### PR DESCRIPTION
Disable `event-through` on `SheetBackdrop` so tap events are captured.
This restores `clickToClose` behavior for backdrop taps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Sheet backdrop click handling to prevent events from passing through when the close-on-click feature is active, ensuring the backdrop close behavior works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->