### PR TITLE
fix(sheet): rename SheetContent inner props and remove default styles

### DIFF
--- a/.changeset/whole-cars-grow.md
+++ b/.changeset/whole-cars-grow.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-sheet": patch
+---
+
+Rename `SheetContent` inner layer props and remove non-headless default styles.

--- a/packages/lynx-ui-sheet/src/SheetContent/index.tsx
+++ b/packages/lynx-ui-sheet/src/SheetContent/index.tsx
@@ -24,8 +24,8 @@ export function SheetContent(props: SheetContentProps) {
     exitAnimation,
     className,
     style,
-    contentClassName,
-    contentStyle,
+    innerClassName,
+    innerStyle,
     ...rest
   } = props
 
@@ -193,11 +193,6 @@ export function SheetContent(props: SheetContentProps) {
         top: '100%',
         height: '100vh',
         overflow: 'hidden',
-        alignSelf: 'center',
-        padding: 0,
-        margin: 0,
-        border: 'none',
-        boxShadow: 'none',
         ...style,
       }}
       main-thread:ref={setSheetMTRef}
@@ -209,10 +204,10 @@ export function SheetContent(props: SheetContentProps) {
     >
       <view
         {...rest}
-        className={contentClassName}
+        className={innerClassName}
         style={{
           width: '100%',
-          ...contentStyle,
+          ...innerStyle,
         }}
         main-thread:bindlayoutchange={handleSheetLayoutChangeMT}
       >

--- a/packages/lynx-ui-sheet/src/types/index.docs.ts
+++ b/packages/lynx-ui-sheet/src/types/index.docs.ts
@@ -75,26 +75,26 @@ export interface SheetContentProps extends ComponentBasicProps {
    */
   exitAnimation?: SheetTransition
   /**
-   * CSS class name for the inner content layer.
-   * Use this for layout or sizing styles specific to the content area.
-   * @zh 内层内容的 CSS 类名。用于设置内容区域特定的布局或尺寸样式。
+   * CSS class name for the inner layer.
+   * Use this for layout or sizing styles specific to the inner area.
+   * @zh 内层容器的 CSS 类名。用于设置内层区域特定的布局或尺寸样式。
    * @Android
    * @iOS
    * @Harmony
    */
-  contentClassName?: string
+  innerClassName?: string
   /**
-   * Inline styles for the inner content layer.
-   * Use this for layout or sizing styles specific to the content area.
+   * Inline styles for the inner layer.
+   * Use this for layout or sizing styles specific to the inner area.
    * Note: Visual styles (background, borderRadius, etc.) should be set via
    * the main `style` prop which applies to the surface layer.
-   * @zh 内层内容的内联样式。用于设置内容区域特定的布局或尺寸样式。
+   * @zh 内层容器的内联样式。用于设置内层区域特定的布局或尺寸样式。
    * 注意：视觉样式（背景、圆角等）应通过主 `style` 属性设置，它会应用到 surface 层。
    * @Android
    * @iOS
    * @Harmony
    */
-  contentStyle?: ComponentBasicProps['style']
+  innerStyle?: ComponentBasicProps['style']
   /**
    * children
    * @zh 子元素


### PR DESCRIPTION
- `contentClassName`/`contentStyle` -> `innerClassName`/`innerStyle`
- remove non-headless default styles from SheetContent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SheetContent Component Updates**
  * Renamed props `contentClassName` and `contentStyle` to `innerClassName` and `innerStyle` to better indicate which layer they apply to
  * Removed default styling from the outer container, giving developers complete control over the sheet's appearance and customization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->