### PR TITLE
ci: remove submodule `--remote`, add workflow names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+name: Build
+
 on:
   workflow_call:
 env:
@@ -89,7 +91,7 @@ jobs:
           key: turbo-v4-${{ runner.os }}-${{ github.sha }}
       - name: Install
         run: |
-          git submodule update --init --recursive --remote
+          git submodule update --init --recursive
           npm install -g corepack@latest
           corepack enable
           pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           package-manager-cache: false
       - name: Install
         run: |
-          git submodule update --init --recursive --remote
+          git submodule update --init --recursive
           npm install -g corepack@latest
           corepack enable
           pnpm install --frozen-lockfile

--- a/.github/workflows/common-test.yml
+++ b/.github/workflows/common-test.yml
@@ -1,3 +1,5 @@
+name: Common Test
+
 on:
   workflow_call:
     inputs:
@@ -46,7 +48,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Install
         run: |
-          git submodule update --init --recursive --remote
+          git submodule update --init --recursive
           npm install -g corepack@latest
           corepack enable
           pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
       - name: Install
         run: |
-          git submodule update --init --recursive --remote
+          git submodule update --init --recursive
           npm install -g corepack@latest
           corepack enable && corepack prepare
           corepack pnpm install --frozen-lockfile
@@ -77,7 +77,7 @@ jobs:
           package-manager-cache: false
       - name: Install
         run: |
-          git submodule update --init --recursive --remote
+          git submodule update --init --recursive
           npm install -g corepack@latest
           corepack enable && corepack prepare
           corepack pnpm install --frozen-lockfile


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added explicit names to CI workflow configurations for clearer pipeline display.
  * Adjusted git submodule initialization behavior across CI/CD pipelines for more consistent and predictable dependency handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->