### PR TITLE
fix(sheet): rename imperative method from `show()` to `open()` for consistency with `close()`

### DIFF
--- a/apps/examples/Sheet/AutoHeight/index.tsx
+++ b/apps/examples/Sheet/AutoHeight/index.tsx
@@ -30,7 +30,7 @@ function App() {
       <text className='title-text'>Sheet Auto Height</text>
 
       <TriggerButton
-        onClick={() => sheetRef.current?.show()}
+        onClick={() => sheetRef.current?.open()}
         text='Open Sheet (via ref)'
       />
 

--- a/apps/examples/Sheet/Basic/index.tsx
+++ b/apps/examples/Sheet/Basic/index.tsx
@@ -24,7 +24,7 @@ function App() {
     <view className='container lunaris-dark'>
       <text className='title-text'>Basic Sheet</text>
       <TriggerButton
-        onClick={() => sheetRef.current?.show()}
+        onClick={() => sheetRef.current?.open()}
         text='Open Sheet'
       />
       <SheetRoot

--- a/apps/examples/Sheet/DefaultOpen/index.tsx
+++ b/apps/examples/Sheet/DefaultOpen/index.tsx
@@ -32,7 +32,7 @@ function App() {
 
       <TriggerButton
         disabled={show}
-        onClick={() => sheetRef.current?.show()}
+        onClick={() => sheetRef.current?.open()}
         text={show ? 'Opened' : 'Open (via ref)'}
       />
 

--- a/apps/examples/Sheet/Imperative/index.tsx
+++ b/apps/examples/Sheet/Imperative/index.tsx
@@ -27,7 +27,7 @@ function App() {
 
       <TriggerButton
         text='Open Sheet (via ref)'
-        onClick={() => sheetRef.current?.show()}
+        onClick={() => sheetRef.current?.open()}
       />
 
       <SheetRoot

--- a/apps/examples/Sheet/InternalTest/index.tsx
+++ b/apps/examples/Sheet/InternalTest/index.tsx
@@ -44,18 +44,18 @@ function App() {
   // Test: Rapid open/close
   const testRapidOpenClose = () => {
     log('TEST: Rapid open/close')
-    sheetRef.current?.show()
+    sheetRef.current?.open()
     setTimeout(() => sheetRef.current?.close(), 100)
-    setTimeout(() => sheetRef.current?.show(), 200)
+    setTimeout(() => sheetRef.current?.open(), 200)
     setTimeout(() => sheetRef.current?.close(), 300)
-    setTimeout(() => sheetRef.current?.show(), 400)
+    setTimeout(() => sheetRef.current?.open(), 400)
   }
 
   // Test: Double open
   const testDoubleOpen = () => {
     log('TEST: Double open (should ignore second)')
-    sheetRef.current?.show()
-    setTimeout(() => sheetRef.current?.show(), 50)
+    sheetRef.current?.open()
+    setTimeout(() => sheetRef.current?.open(), 50)
   }
 
   // Test: Double close
@@ -68,14 +68,14 @@ function App() {
   // Test: Snap during entry
   const testSnapDuringEntry = () => {
     log('TEST: snapTo during entry animation')
-    sheetRef.current?.show()
+    sheetRef.current?.open()
     setTimeout(() => sheetRef.current?.snapTo(2), 100)
   }
 
   // Test: Close during entry
   const testCloseDuringEntry = () => {
     log('TEST: close during entry animation')
-    sheetRef.current?.show()
+    sheetRef.current?.open()
     setTimeout(() => sheetRef.current?.close(), 150)
   }
 
@@ -102,7 +102,7 @@ function App() {
             if (controlled) {
               setShow(true)
             } else {
-              sheetRef.current?.show()
+              sheetRef.current?.open()
             }
           }}
         >

--- a/apps/examples/Sheet/Tablet/index.tsx
+++ b/apps/examples/Sheet/Tablet/index.tsx
@@ -30,7 +30,7 @@ function App() {
     <view className='container lunaris-dark'>
       <text className='title-text'>Sheet Tablet</text>
       <TriggerButton
-        onClick={() => sheetRef.current?.show()}
+        onClick={() => sheetRef.current?.open()}
         text='Open Sheet (via ref)'
       />
 

--- a/packages/lynx-ui-sheet/src/SheetRoot/index.tsx
+++ b/packages/lynx-ui-sheet/src/SheetRoot/index.tsx
@@ -18,26 +18,7 @@ import { useMotionValueRef } from '@lynx-js/motion/mini'
 
 import { SheetContext } from '../context'
 import type { SheetMethods } from '../context'
-import type { SheetRootProps, SheetTransition } from '../types'
-
-export interface SheetRootRef {
-  snapTo: (
-    index: number,
-    opts?: { animate?: boolean, snapAnimation?: SheetTransition },
-  ) => void
-  expand: (
-    opts?: { animate?: boolean, snapAnimation?: SheetTransition },
-  ) => void
-  collapse: (
-    opts?: { animate?: boolean, snapAnimation?: SheetTransition },
-  ) => void
-  close: (
-    opts?: { animate?: boolean, snapAnimation?: SheetTransition },
-  ) => void
-  show: (
-    opts?: { animate?: boolean, snapAnimation?: SheetTransition },
-  ) => void
-}
+import type { SheetRootProps, SheetRootRef } from '../types'
 
 export const SheetRoot = forwardRef<SheetRootRef, SheetRootProps>(
   (props, ref) => {
@@ -107,7 +88,6 @@ export const SheetRoot = forwardRef<SheetRootRef, SheetRootProps>(
     }, [])
 
     // Imperative handle methods
-    // Imperative handle methods
     useImperativeHandle(ref, () => {
       const queueAction = (action: () => void) => {
         if (mounted && sheetMethodsRef.current) {
@@ -137,7 +117,7 @@ export const SheetRoot = forwardRef<SheetRootRef, SheetRootProps>(
             queueAction(() => sheetMethodsRef.current?.close(opts))
           }
         },
-        show: (opts) => {
+        open: (opts) => {
           handleShowChange(true)
           queueAction(() => sheetMethodsRef.current?.show?.(opts))
         },

--- a/packages/lynx-ui-sheet/src/index.tsx
+++ b/packages/lynx-ui-sheet/src/index.tsx
@@ -3,7 +3,6 @@
 // LICENSE file in the root directory of this source tree.
 
 export { SheetRoot } from './SheetRoot'
-export type { SheetRootRef } from './SheetRoot'
 export { SheetBackdrop } from './SheetBackdrop'
 export { SheetContent } from './SheetContent'
 export { SheetHandle } from './SheetHandle'
@@ -17,4 +16,5 @@ export type {
   SheetViewProps,
   SheetHandleProps,
   SheetTransition,
+  SheetRootRef,
 } from './types'

--- a/packages/lynx-ui-sheet/src/types/index.docs.ts
+++ b/packages/lynx-ui-sheet/src/types/index.docs.ts
@@ -7,6 +7,25 @@ import type { ReactNode } from '@lynx-js/react'
 import type { ComponentBasicProps } from '@lynx-js/lynx-ui-common'
 import type { OverlayViewProps } from '@lynx-js/lynx-ui-overlay'
 
+export interface SheetRootRef {
+  snapTo: (
+    index: number,
+    opts?: { animate?: boolean, snapAnimation?: SheetTransition },
+  ) => void
+  expand: (
+    opts?: { animate?: boolean, snapAnimation?: SheetTransition },
+  ) => void
+  collapse: (
+    opts?: { animate?: boolean, snapAnimation?: SheetTransition },
+  ) => void
+  close: (
+    opts?: { animate?: boolean, snapAnimation?: SheetTransition },
+  ) => void
+  open: (
+    opts?: { animate?: boolean, snapAnimation?: SheetTransition },
+  ) => void
+}
+
 /**
  * The backdrop mask of the Sheet.
  * @zh Sheet 的背景遮罩。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated the Sheet component's imperative API: renamed the method to open sheets via refs from `show()` to `open()`. If using refs to control sheets imperatively, update calls from `sheetRef.current?.show()` to `sheetRef.current?.open()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->