### PR TITLE
fix(popover): prevent backdrop tap bubbling in uncontrolled mode

### DIFF
--- a/.changeset/short-clowns-travel.md
+++ b/.changeset/short-clowns-travel.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/lynx-ui-popover": patch
+"@lynx-js/lynx-ui-button": patch
+---
+
+Fix Popover Backdrop click to close in uncontrolled mode by preventing tap bubbling; allow Button to use `catchtap` via `buttonProps`.

--- a/packages/lynx-ui-button/src/Button.tsx
+++ b/packages/lynx-ui-button/src/Button.tsx
@@ -30,6 +30,12 @@ export const Button = (prop: ButtonProps) => {
   } = prop
   const [active, setActive] = useState(false)
 
+  const rawButtonProps = buttonProps ?? {}
+  const { catchtap, ...restButtonProps } = rawButtonProps as unknown as {
+    catchtap?: unknown
+  } & Record<string, unknown>
+  const hasCatchTap = typeof catchtap === 'function'
+
   // Only when the button is active and not disabled, the active style will be applied
   const isEffectiveActive = active && !disabled
 
@@ -47,8 +53,14 @@ export const Button = (prop: ButtonProps) => {
     if (disabled) return
   })
 
-  const handleTap = useMemoizedFn(() => {
+  const handleTap = useMemoizedFn((_e?: unknown) => {
     if (disabled) return
+    onClick?.()
+  })
+
+  const handleCatchTap = useMemoizedFn((_e?: unknown) => {
+    if (disabled) return
+    ;(catchtap as undefined | ((_e?: unknown) => void))?.(_e)
     onClick?.()
   })
 
@@ -60,7 +72,9 @@ export const Button = (prop: ButtonProps) => {
   return (
     <ButtonContext.Provider value={contextValue}>
       <view
-        bindtap={handleTap}
+        {...(hasCatchTap
+          ? { catchtap: handleCatchTap }
+          : { bindtap: handleTap })}
         bindtouchstart={handleTouchStart}
         bindtouchend={handleTouchEnd}
         bindtouchcancel={handleTouchEnd}
@@ -70,7 +84,7 @@ export const Button = (prop: ButtonProps) => {
           'ui-active': isEffectiveActive,
           'ui-disabled': disabled,
         })}
-        {...buttonProps}
+        {...restButtonProps}
       >
         {renderedChildren}
       </view>

--- a/packages/lynx-ui-popover/src/Popover.tsx
+++ b/packages/lynx-ui-popover/src/Popover.tsx
@@ -327,7 +327,7 @@ export const PopoverTrigger = (props: PopoverTriggerProps) => {
 }
 
 export const PopoverBackdrop = (props: PopoverBackdropProps) => {
-  const { className, style, onClick, transition, ...restProps } = props
+  const { className, style, onClick, transition } = props
   const { state, setUncontrolledShow, isControlled, onVisibleChange } =
     useContext(PopoverContext)
 
@@ -344,6 +344,8 @@ export const PopoverBackdrop = (props: PopoverBackdropProps) => {
   const busy = resolveBusyState(state)
 
   const handleTap = () => {
+    if (busy) return
+
     if (isControlled) {
       onVisibleChange?.(false)
     } else {
@@ -363,9 +365,8 @@ export const PopoverBackdrop = (props: PopoverBackdropProps) => {
     <Button
       className={`popover-backdrop ${presenceClassName}`}
       style={style}
-      onClick={handleTap}
       disabled={busy}
-      {...restProps}
+      buttonProps={{ catchtap: handleTap }}
     />
   )
 }


### PR DESCRIPTION
When `PopoverBackdrop` is rendered inside `PopoverTrigger`, taps can bubble to the
trigger and toggle twice in uncontrolled mode, so the popover doesn't close
cleanly on iOS/Android.

Fixes #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Button component now supports `catchtap` event handling via `buttonProps`.

* **Bug Fixes**
  * Fixed Popover backdrop click behavior to properly close the Popover in uncontrolled mode and prevent event bubbling.
  * Improved Popover backdrop handler to prevent execution during state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->