### PR TITLE
docs: include documentation in each package's published files

### DIFF
--- a/packages/lynx-ui-button/package.json
+++ b/packages/lynx-ui-button/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-checkbox/package.json
+++ b/packages/lynx-ui-checkbox/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-common/package.json
+++ b/packages/lynx-ui-common/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-dialog/package.json
+++ b/packages/lynx-ui-dialog/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-draggable/package.json
+++ b/packages/lynx-ui-draggable/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-feed-list/package.json
+++ b/packages/lynx-ui-feed-list/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-form/package.json
+++ b/packages/lynx-ui-form/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-input/package.json
+++ b/packages/lynx-ui-input/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-lazy-component/package.json
+++ b/packages/lynx-ui-lazy-component/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-list/package.json
+++ b/packages/lynx-ui-list/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-overlay/package.json
+++ b/packages/lynx-ui-overlay/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "CHANGELOG.md",
     "LICENSE",
     "tsconfig.docs.json",

--- a/packages/lynx-ui-popover/package.json
+++ b/packages/lynx-ui-popover/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-presence/package.json
+++ b/packages/lynx-ui-presence/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "CHANGELOG.md",
     "LICENSE",
     "tsconfig.docs.json",

--- a/packages/lynx-ui-radio-group/package.json
+++ b/packages/lynx-ui-radio-group/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-scroll-view/package.json
+++ b/packages/lynx-ui-scroll-view/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-sheet/package.json
+++ b/packages/lynx-ui-sheet/package.json
@@ -18,6 +18,7 @@
   "files": [
     "LICENSE",
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "tsconfig.docs.json",

--- a/packages/lynx-ui-sortable/package.json
+++ b/packages/lynx-ui-sortable/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-swipe-action/package.json
+++ b/packages/lynx-ui-swipe-action/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-swiper/package.json
+++ b/packages/lynx-ui-swiper/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/lynx-ui-switch/package.json
+++ b/packages/lynx-ui-switch/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src/**",
+    "docs/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",


### PR DESCRIPTION
## Summary

Add `docs/**` to the `files` field in each component package's `package.json`, so docs ship with `npm publish`.

This is the missing piece: docs content has already been added to main via #114 and #121, but without `docs/**` in `files`, they won't be included in published npm packages.

## Changes

20 `package.json` files updated, one line each:

```diff
 "files": [
   "src/**",
+  "docs/**",
   "README.md",
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing configuration across the UI component library to include documentation files with all component packages, making documentation more readily available upon installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->