### PR TITLE
fix(sheet): increase placeholder height on Android

### DIFF
--- a/.changeset/sheet-placeholder-200vh.md
+++ b/.changeset/sheet-placeholder-200vh.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/lynx-ui-sheet': patch
+---
+
+Increase the `SheetContent` placeholder height to `200vh` so Android snap positions do not undershoot the bottom edge.

--- a/packages/lynx-ui-sheet/src/SheetContent/index.tsx
+++ b/packages/lynx-ui-sheet/src/SheetContent/index.tsx
@@ -191,7 +191,7 @@ export function SheetContent(props: SheetContentProps) {
       className={className}
       style={{
         top: '100%',
-        height: '100vh',
+        height: '200vh',
         overflow: 'hidden',
         ...style,
       }}


### PR DESCRIPTION
## Summary
- increase the `SheetContent` placeholder height from `100vh` to `200vh`
- keep the placeholder tall enough to avoid the Android bottom-edge gap described in #64
- add a patch changeset for `@lynx-js/lynx-ui-sheet`

Fixes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Sheet component snap positioning behavior on Android devices to prevent undershooting when snapping to the bottom edge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->