### PR TITLE
feat(lynx-ui): add Slider primitive package and re-export from lynx-ui

### DIFF
--- a/.changeset/slider-readonly-prop.md
+++ b/.changeset/slider-readonly-prop.md
@@ -1,0 +1,6 @@
+---
+'@lynx-js/lynx-ui': patch
+'@lynx-js/lynx-ui-slider': patch
+---
+
+Rename the slider interaction lock prop to `readonly` and keep `disabled` as a deprecated compatibility alias.

--- a/apps/examples/Slider/Basic/index.css
+++ b/apps/examples/Slider/Basic/index.css
@@ -1,0 +1,137 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.demo-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding-top: 48px;
+  padding-bottom: 24px;
+  padding-left: 48px;
+  padding-right: 48px;
+}
+
+.demo-canvas {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 64px;
+  padding-left: 48px;
+  padding-right: 48px;
+  border-radius: 16px;
+  overflow: hidden;
+  color: var(--content);
+  background-color: var(--canvas);
+}
+
+.luna-gradient-berry {
+  background: linear-gradient(
+    0deg,
+    var(--gradient-b),
+    var(--gradient-c)
+  );
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  row-gap: 16px;
+}
+
+.title {
+  font-size: 16px;
+  color: var(--content-2);
+}
+
+.desc {
+  font-size: 14px;
+  color: var(--content-subtle);
+}
+
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.slider-label {
+  font-size: 16px;
+  color: var(--content-2);
+}
+
+.slider-label.disabled {
+  opacity: 0.5;
+}
+
+.slider-root {
+  position: relative;
+  width: 100%;
+  height: 36px;
+  display: flex;
+  align-items: center;
+}
+
+.slider-root.ui-disabled {
+  opacity: 0.4;
+}
+
+.slider-track {
+  width: 100%;
+  height: 4px;
+  border-radius: 9999px;
+  background-color: var(--neutral-faint);
+}
+
+.slider-range {
+  width: 100%;
+  height: 4px;
+  border-radius: 9999px;
+  margin-top: 16px;
+  background: var(--primary);
+}
+
+.slider-thumb-wrapper {
+  position: absolute;
+  top: 0;
+  right: -18px;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.slider-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18), 0 3px 8px rgba(0, 0, 0, 0.12);
+}
+
+.slider-thumb-pill {
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+  background-color: white;
+  border: 3px solid var(--primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18), 0 3px 8px rgba(0, 0, 0, 0.12);
+}
+
+.rtl-card {
+  direction: rtl;
+}
+
+.slider-thumb-wrapper-rtl {
+  position: absolute;
+  top: 0;
+  left: -18px;
+  right: auto;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/apps/examples/Slider/Basic/index.tsx
+++ b/apps/examples/Slider/Basic/index.tsx
@@ -1,0 +1,105 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from '@lynx-js/react'
+
+import {
+  SliderRange,
+  SliderRoot,
+  SliderThumb,
+  SliderTrack,
+} from '@lynx-js/lynx-ui'
+
+import './index.css'
+
+function formatValue(value: number) {
+  return `${Math.round(value * 100)}%`
+}
+
+function App() {
+  const [variantValue, setVariantValue] = useState(0.68)
+  const [rtlValue, setRtlValue] = useState(0.4)
+
+  return (
+    <view className='demo-container lunaris-dark luna-gradient-berry'>
+      <view className='demo-canvas'>
+        <view className='section'>
+          <text className='title'>Variant</text>
+          <text className='desc'>
+            A slider with a bordered thumb and a filled thumb side by side.
+          </text>
+
+          <view className='row'>
+            <text className='slider-label'>
+              {formatValue(variantValue)}
+            </text>
+            <SliderRoot
+              className='slider-root'
+              defaultValue={0.68}
+              onValueChange={(value: number) => {
+                setVariantValue(value)
+              }}
+            >
+              <SliderTrack className='slider-track' />
+              <SliderRange className='slider-range'>
+                <SliderThumb className='slider-thumb-wrapper'>
+                  <view className='slider-thumb-pill' />
+                </SliderThumb>
+              </SliderRange>
+            </SliderRoot>
+          </view>
+
+          <view className='row'>
+            <text className='slider-label disabled'>Readonly</text>
+            <SliderRoot
+              className='slider-root ui-disabled'
+              defaultValue={0.45}
+              readonly
+            >
+              <SliderTrack className='slider-track' />
+              <SliderRange className='slider-range'>
+                <SliderThumb className='slider-thumb-wrapper'>
+                  <view className='slider-thumb' />
+                </SliderThumb>
+              </SliderRange>
+            </SliderRoot>
+          </view>
+        </view>
+
+        <view className='section'>
+          <text className='title'>RTL</text>
+          <text className='desc'>
+            A slider with `enableRTL` and CSS `direction: rtl`. The range grows
+            from right to left.
+          </text>
+
+          <view className='row rtl-card'>
+            <text className='slider-label'>
+              {formatValue(rtlValue)}
+            </text>
+            <SliderRoot
+              className='slider-root'
+              enableRTL
+              defaultValue={0.4}
+              onValueChange={(value: number) => {
+                setRtlValue(value)
+              }}
+            >
+              <SliderTrack className='slider-track' />
+              <SliderRange className='slider-range'>
+                <SliderThumb className='slider-thumb-wrapper slider-thumb-wrapper-rtl'>
+                  <view className='slider-thumb' />
+                </SliderThumb>
+              </SliderRange>
+            </SliderRoot>
+          </view>
+        </view>
+      </view>
+    </view>
+  )
+}
+
+root.render(<App />)
+
+export default App

--- a/apps/examples/Slider/Controlled/index.css
+++ b/apps/examples/Slider/Controlled/index.css
@@ -1,0 +1,128 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.demo-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding-top: 48px;
+  padding-bottom: 24px;
+  padding-left: 48px;
+  padding-right: 48px;
+}
+
+.demo-canvas {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 64px;
+  padding-left: 48px;
+  padding-right: 48px;
+  border-radius: 16px;
+  overflow: hidden;
+  color: var(--content);
+  background-color: var(--canvas);
+}
+
+.luna-gradient-berry {
+  background: linear-gradient(
+    0deg,
+    var(--gradient-b),
+    var(--gradient-c)
+  );
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  row-gap: 16px;
+}
+
+.title {
+  font-size: 16px;
+  color: var(--content-2);
+}
+
+.desc {
+  font-size: 14px;
+  color: var(--content-subtle);
+}
+
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.slider-label {
+  font-size: 16px;
+  color: var(--content-2);
+}
+
+.slider-root {
+  position: relative;
+  width: 100%;
+  height: 36px;
+  display: flex;
+  align-items: center;
+}
+
+.slider-track {
+  width: 100%;
+  height: 4px;
+  border-radius: 9999px;
+  background-color: var(--neutral-faint);
+}
+
+.slider-range {
+  width: 100%;
+  height: 4px;
+  border-radius: 9999px;
+  margin-top: 16px;
+  background: var(--primary);
+}
+
+.slider-thumb-wrapper {
+  position: absolute;
+  top: 0;
+  right: -18px;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.slider-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18), 0 3px 8px rgba(0, 0, 0, 0.12);
+}
+
+.preset-row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.preset-chip {
+  min-width: 52px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-left: 10px;
+  padding-right: 10px;
+  border-radius: 9999px;
+  background-color: var(--neutral-faint);
+}
+
+.preset-label {
+  font-size: 14px;
+  color: var(--content-2);
+}

--- a/apps/examples/Slider/Controlled/index.tsx
+++ b/apps/examples/Slider/Controlled/index.tsx
@@ -1,0 +1,116 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from '@lynx-js/react'
+
+import {
+  SliderRange,
+  SliderRoot,
+  SliderThumb,
+  SliderTrack,
+} from '@lynx-js/lynx-ui'
+
+import './index.css'
+
+const PRESET_VALUES = [0, 0.25, 0.5, 0.75, 1]
+
+function formatValue(value: number) {
+  return `${Math.round(value * 100)}%`
+}
+
+function App() {
+  const [value, setValue] = useState(0.32)
+  const [primitiveDragging, setPrimitiveDragging] = useState(false)
+  const [steppedValue, setSteppedValue] = useState(0.5)
+
+  return (
+    <view className='demo-container lunaris-dark luna-gradient-berry'>
+      <view className='demo-canvas'>
+        <view className='section'>
+          <text className='title'>Controlled</text>
+          <text className='desc'>
+            Pass `value` and `onValueChange` to fully control the slider from
+            the outside. Use preset chips to jump to specific values.
+          </text>
+
+          <view className='row'>
+            <text className='slider-label'>
+              {primitiveDragging
+                ? 'Dragging...'
+                : formatValue(value)}
+            </text>
+            <SliderRoot
+              className='slider-root'
+              value={value}
+              onDragging={() => {
+                setPrimitiveDragging(true)
+              }}
+              onValueChange={(v: number) => {
+                setValue(v)
+              }}
+              onValueCommit={() => {
+                setPrimitiveDragging(false)
+              }}
+            >
+              <SliderTrack className='slider-track' />
+              <SliderRange className='slider-range'>
+                <SliderThumb className='slider-thumb-wrapper'>
+                  <view className='slider-thumb' />
+                </SliderThumb>
+              </SliderRange>
+            </SliderRoot>
+
+            <view className='preset-row'>
+              {PRESET_VALUES.map((v) => (
+                <view
+                  key={`preset-${v}`}
+                  className='preset-chip'
+                  bindtap={() => {
+                    setValue(v)
+                  }}
+                >
+                  <text className='preset-label'>
+                    {formatValue(v)}
+                  </text>
+                </view>
+              ))}
+            </view>
+          </view>
+        </view>
+
+        <view className='section'>
+          <text className='title'>Stepped</text>
+          <text className='desc'>
+            A slider with `step={0.1}` that snaps to 10% increments.
+          </text>
+
+          <view className='row'>
+            <text className='slider-label'>
+              {formatValue(steppedValue)} — Step: 10%
+            </text>
+            <SliderRoot
+              className='slider-root'
+              value={steppedValue}
+              step={0.1}
+              onValueChange={(value: number) => {
+                setSteppedValue(value)
+              }}
+            >
+              <SliderTrack className='slider-track' />
+              <SliderRange className='slider-range'>
+                <SliderThumb className='slider-thumb-wrapper'>
+                  <view className='slider-thumb' />
+                </SliderThumb>
+              </SliderRange>
+            </SliderRoot>
+          </view>
+        </view>
+      </view>
+    </view>
+  )
+}
+
+root.render(<App />)
+
+export default App

--- a/apps/examples/Slider/DynamicWidth/index.css
+++ b/apps/examples/Slider/DynamicWidth/index.css
@@ -1,0 +1,136 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.demo-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding-top: 48px;
+  padding-bottom: 24px;
+  padding-left: 48px;
+  padding-right: 48px;
+}
+
+.demo-canvas {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 64px;
+  padding-left: 48px;
+  padding-right: 48px;
+  border-radius: 16px;
+  overflow: hidden;
+  color: var(--content);
+  background-color: var(--canvas);
+}
+
+.luna-gradient-berry {
+  background: linear-gradient(
+    0deg,
+    var(--gradient-b),
+    var(--gradient-c)
+  );
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  row-gap: 16px;
+}
+
+.title {
+  font-size: 16px;
+  color: var(--content-2);
+}
+
+.desc {
+  font-size: 14px;
+  color: var(--content-subtle);
+}
+
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.slider-label {
+  font-size: 16px;
+  color: var(--content-2);
+}
+
+.slider-root {
+  position: relative;
+  width: 100%;
+  height: 36px;
+  display: flex;
+  align-items: center;
+}
+
+.slider-track {
+  width: 100%;
+  height: 4px;
+  border-radius: 9999px;
+  background-color: var(--neutral-faint);
+}
+
+.slider-range {
+  width: 100%;
+  height: 4px;
+  border-radius: 9999px;
+  margin-top: 16px;
+  background: var(--primary);
+}
+
+.slider-thumb-wrapper {
+  position: absolute;
+  top: 0;
+  right: -18px;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.slider-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18), 0 3px 8px rgba(0, 0, 0, 0.12);
+}
+
+.width-row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.width-chip {
+  min-width: 52px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-left: 10px;
+  padding-right: 10px;
+  border-radius: 9999px;
+  background-color: var(--neutral-faint);
+}
+
+.width-chip-active {
+  background-color: var(--primary);
+}
+
+.width-label {
+  font-size: 14px;
+  color: var(--content-2);
+}
+
+.width-label-active {
+  color: var(--primary-content);
+}

--- a/apps/examples/Slider/DynamicWidth/index.tsx
+++ b/apps/examples/Slider/DynamicWidth/index.tsx
@@ -1,0 +1,86 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from '@lynx-js/react'
+
+import {
+  SliderRange,
+  SliderRoot,
+  SliderThumb,
+  SliderTrack,
+} from '@lynx-js/lynx-ui'
+
+import './index.css'
+
+const WIDTHS = [200, 300, 420, 280, 360]
+
+function formatValue(value: number) {
+  return `${Math.round(value * 100)}%`
+}
+
+function App() {
+  const [widthIndex, setWidthIndex] = useState(2)
+  const [value, setValue] = useState(0.5)
+  const currentWidth = WIDTHS[widthIndex]
+
+  return (
+    <view className='demo-container lunaris-dark luna-gradient-berry'>
+      <view className='demo-canvas' style={{ maxWidth: `${currentWidth}px` }}>
+        <view className='section'>
+          <text className='title'>Dynamic Width</text>
+          <text className='desc'>
+            Tap the buttons below to change the slider container width. This
+            tests the `onLayoutChange` handler re-measuring correctly.
+          </text>
+
+          <view className='row'>
+            <text className='slider-label'>
+              {formatValue(value)} — {currentWidth}px
+            </text>
+            <SliderRoot
+              className='slider-root'
+              defaultValue={0.5}
+              onValueChange={(v: number) => {
+                setValue(v)
+              }}
+            >
+              <SliderTrack className='slider-track' />
+              <SliderRange className='slider-range'>
+                <SliderThumb className='slider-thumb-wrapper'>
+                  <view className='slider-thumb' />
+                </SliderThumb>
+              </SliderRange>
+            </SliderRoot>
+
+            <view className='width-row'>
+              {WIDTHS.map((w, i) => (
+                <view
+                  key={`w-${w}`}
+                  className={`width-chip${
+                    i === widthIndex ? ' width-chip-active' : ''
+                  }`}
+                  bindtap={() => {
+                    setWidthIndex(i)
+                  }}
+                >
+                  <text
+                    className={`width-label${
+                      i === widthIndex ? ' width-label-active' : ''
+                    }`}
+                  >
+                    {w}px
+                  </text>
+                </view>
+              ))}
+            </view>
+          </view>
+        </view>
+      </view>
+    </view>
+  )
+}
+
+root.render(<App />)
+
+export default App

--- a/apps/examples/Slider/Facade/index.css
+++ b/apps/examples/Slider/Facade/index.css
@@ -1,0 +1,121 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.demo-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding-top: 48px;
+  padding-bottom: 24px;
+  padding-left: 48px;
+  padding-right: 48px;
+}
+
+.demo-canvas {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 64px;
+  padding-left: 48px;
+  padding-right: 48px;
+  border-radius: 16px;
+  overflow: hidden;
+  color: var(--content);
+  background-color: var(--canvas);
+}
+
+.luna-gradient-berry {
+  background: linear-gradient(
+    0deg,
+    var(--gradient-b),
+    var(--gradient-c)
+  );
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  row-gap: 16px;
+}
+
+.title {
+  font-size: 16px;
+  color: var(--content-2);
+}
+
+.desc {
+  font-size: 14px;
+  color: var(--content-subtle);
+}
+
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.slider-label {
+  font-size: 16px;
+  color: var(--content-2);
+}
+
+.slider-label.disabled {
+  opacity: 0.5;
+}
+
+.slider-root {
+  position: relative;
+  width: 100%;
+  height: 36px;
+  display: flex;
+  align-items: center;
+}
+
+.slider-root.ui-disabled {
+  opacity: 0.4;
+}
+
+.slider-track {
+  width: 100%;
+  height: 4px;
+  border-radius: 9999px;
+  background-color: var(--neutral-faint);
+}
+
+.slider-range {
+  width: 100%;
+  height: 4px;
+  border-radius: 9999px;
+  margin-top: 16px;
+  background: var(--primary);
+}
+
+.slider-thumb-wrapper {
+  position: absolute;
+  top: 0;
+  right: -18px;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.slider-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18), 0 3px 8px rgba(0, 0, 0, 0.12);
+}
+
+.slider-thumb-pill {
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+  background-color: white;
+  border: 3px solid var(--primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18), 0 3px 8px rgba(0, 0, 0, 0.12);
+}

--- a/apps/examples/Slider/Facade/index.tsx
+++ b/apps/examples/Slider/Facade/index.tsx
@@ -1,0 +1,123 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { forwardRef, memo, root, useState } from '@lynx-js/react'
+import type { ForwardedRef, ReactNode } from '@lynx-js/react'
+
+import {
+  SliderRange,
+  SliderRoot,
+  SliderThumb,
+  SliderTrack,
+} from '@lynx-js/lynx-ui'
+import type { SliderRef, SliderRootProps } from '@lynx-js/lynx-ui'
+
+import './index.css'
+
+interface SliderProps extends Omit<SliderRootProps, 'children'> {
+  thumb?: ReactNode
+  trackClassName?: string
+  rangeClassName?: string
+  thumbWrapperClassName?: string
+}
+
+const Slider = memo(
+  forwardRef(function Slider(
+    props: SliderProps,
+    ref: ForwardedRef<SliderRef>,
+  ) {
+    const {
+      thumb,
+      trackClassName,
+      rangeClassName,
+      thumbWrapperClassName,
+      ...rootProps
+    } = props
+
+    return (
+      <SliderRoot ref={ref} {...rootProps}>
+        <SliderTrack className={trackClassName} />
+        <SliderRange className={rangeClassName}>
+          <SliderThumb className={thumbWrapperClassName}>
+            {thumb}
+          </SliderThumb>
+        </SliderRange>
+      </SliderRoot>
+    )
+  }),
+)
+
+function formatValue(value: number) {
+  return `${Math.round(value * 100)}%`
+}
+
+function App() {
+  const [defaultValue, setDefaultValue] = useState(0.4)
+  const [pillValue, setPillValue] = useState(0.72)
+
+  return (
+    <view className='demo-container lunaris-dark luna-gradient-berry'>
+      <view className='demo-canvas'>
+        <view className='section'>
+          <text className='title'>Facade</text>
+          <text className='desc'>
+            A single-component wrapper built from Slider primitives. This
+            example shows how to compose your own facade for simple use cases.
+          </text>
+
+          <view className='row'>
+            <text className='slider-label'>
+              {formatValue(defaultValue)}
+            </text>
+            <Slider
+              className='slider-root'
+              defaultValue={0.4}
+              trackClassName='slider-track'
+              rangeClassName='slider-range'
+              thumbWrapperClassName='slider-thumb-wrapper'
+              thumb={<view className='slider-thumb' />}
+              onValueChange={(value: number) => {
+                setDefaultValue(value)
+              }}
+            />
+          </view>
+
+          <view className='row'>
+            <text className='slider-label'>
+              {formatValue(pillValue)}
+            </text>
+            <Slider
+              className='slider-root'
+              defaultValue={0.72}
+              trackClassName='slider-track'
+              rangeClassName='slider-range'
+              thumbWrapperClassName='slider-thumb-wrapper'
+              thumb={<view className='slider-thumb-pill' />}
+              onValueChange={(value: number) => {
+                setPillValue(value)
+              }}
+            />
+          </view>
+
+          <view className='row'>
+            <text className='slider-label disabled'>Readonly</text>
+            <Slider
+              className='slider-root'
+              defaultValue={0.45}
+              readonly
+              trackClassName='slider-track'
+              rangeClassName='slider-range'
+              thumbWrapperClassName='slider-thumb-wrapper'
+              thumb={<view className='slider-thumb' />}
+            />
+          </view>
+        </view>
+      </view>
+    </view>
+  )
+}
+
+root.render(<App />)
+
+export default App

--- a/apps/examples/Slider/Progress/index.css
+++ b/apps/examples/Slider/Progress/index.css
@@ -1,0 +1,120 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.demo-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding-top: 48px;
+  padding-bottom: 24px;
+  padding-left: 48px;
+  padding-right: 48px;
+}
+
+.demo-canvas {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 64px;
+  padding-left: 48px;
+  padding-right: 48px;
+  border-radius: 16px;
+  overflow: hidden;
+  color: var(--content);
+  background-color: var(--canvas);
+}
+
+.luna-gradient-berry {
+  background: linear-gradient(
+    0deg,
+    var(--gradient-b),
+    var(--gradient-c)
+  );
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  row-gap: 16px;
+}
+
+.title {
+  font-size: 16px;
+  color: var(--content-2);
+}
+
+.desc {
+  font-size: 14px;
+  color: var(--content-subtle);
+}
+
+.progress-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.progress-meta {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.progress-label {
+  font-size: 16px;
+  color: var(--content-2);
+}
+
+.progress-value {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--content-2);
+}
+
+.progress-root {
+  position: relative;
+  width: 100%;
+  height: 6px;
+  display: flex;
+  align-items: center;
+}
+
+.progress-track {
+  width: 100%;
+  height: 6px;
+  border-radius: 9999px;
+  background-color: var(--neutral-faint);
+}
+
+.progress-range {
+  width: 100%;
+  height: 6px;
+  border-radius: 9999px;
+  background: var(--primary);
+}
+
+.progress-range-secondary {
+  background: var(--secondary);
+}
+
+.static-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+}
+
+.static-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--content-subtle);
+  width: 40px;
+  text-align: right;
+}
+
+.static-bar-wrapper {
+  flex: 1;
+}

--- a/apps/examples/Slider/Progress/index.tsx
+++ b/apps/examples/Slider/Progress/index.tsx
@@ -1,0 +1,118 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useEffect, useRef, useState } from '@lynx-js/react'
+
+import { SliderRange, SliderRoot, SliderTrack } from '@lynx-js/lynx-ui'
+
+import './index.css'
+
+function formatValue(value: number) {
+  return `${Math.round(value * 100)}%`
+}
+
+function App() {
+  const [downloadProgress, setDownloadProgress] = useState(0)
+  const [uploadProgress, setUploadProgress] = useState(0)
+  const downloadTimer = useRef<ReturnType<typeof setInterval> | null>(null)
+  const uploadTimer = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => {
+    downloadTimer.current = setInterval(() => {
+      setDownloadProgress((prev) => {
+        if (prev >= 1) return 0
+        return Math.min(prev + 0.02, 1)
+      })
+    }, 80)
+
+    uploadTimer.current = setInterval(() => {
+      setUploadProgress((prev) => {
+        if (prev >= 1) return 0
+        return Math.min(prev + 0.01, 1)
+      })
+    }, 100)
+
+    return () => {
+      if (downloadTimer.current) clearInterval(downloadTimer.current)
+      if (uploadTimer.current) clearInterval(uploadTimer.current)
+    }
+  }, [])
+
+  return (
+    <view className='demo-container lunaris-dark luna-gradient-berry'>
+      <view className='demo-canvas'>
+        <view className='section'>
+          <text className='title'>Progress (No Thumb)</text>
+          <text className='desc'>
+            SliderRoot + SliderRange without SliderThumb, used as a read-only
+            progress indicator.
+          </text>
+
+          <view className='progress-row'>
+            <view className='progress-meta'>
+              <text className='progress-label'>Downloading...</text>
+              <text className='progress-value'>
+                {formatValue(downloadProgress)}
+              </text>
+            </view>
+            <SliderRoot
+              className='progress-root'
+              value={downloadProgress}
+              readonly
+            >
+              <SliderTrack className='progress-track' />
+              <SliderRange className='progress-range' />
+            </SliderRoot>
+          </view>
+
+          <view className='progress-row'>
+            <view className='progress-meta'>
+              <text className='progress-label'>Uploading...</text>
+              <text className='progress-value'>
+                {formatValue(uploadProgress)}
+              </text>
+            </view>
+            <SliderRoot
+              className='progress-root'
+              value={uploadProgress}
+              readonly
+            >
+              <SliderTrack className='progress-track' />
+              <SliderRange className='progress-range progress-range-secondary' />
+            </SliderRoot>
+          </view>
+        </view>
+
+        <view className='section'>
+          <text className='title'>Static Progress</text>
+          <text className='desc'>
+            Fixed progress values showing various completion states.
+          </text>
+
+          <view className='progress-row'>
+            {[0.25, 0.5, 0.75, 1].map((v) => (
+              <view key={`static-${v}`} className='static-row'>
+                <text className='static-label'>{formatValue(v)}</text>
+                <view className='static-bar-wrapper'>
+                  <SliderRoot
+                    className='progress-root'
+                    value={v}
+                    readonly
+                  >
+                    <SliderTrack className='progress-track' />
+                    <SliderRange className='progress-range' />
+                  </SliderRoot>
+                </view>
+              </view>
+            ))}
+          </view>
+        </view>
+      </view>
+    </view>
+  )
+}
+
+root.render(<App />)
+
+export default App

--- a/apps/examples/Slider/Shapes/index.css
+++ b/apps/examples/Slider/Shapes/index.css
@@ -1,0 +1,221 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.demo-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding-top: 48px;
+  padding-bottom: 24px;
+  padding-left: 48px;
+  padding-right: 48px;
+}
+
+.demo-canvas {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 64px;
+  padding-left: 48px;
+  padding-right: 48px;
+  border-radius: 16px;
+  overflow: hidden;
+  color: var(--content);
+  background-color: var(--canvas);
+}
+
+.luna-gradient-berry {
+  background: linear-gradient(
+    0deg,
+    var(--gradient-b),
+    var(--gradient-c)
+  );
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  row-gap: 16px;
+}
+
+.title {
+  font-size: 16px;
+  color: var(--content-2);
+}
+
+.desc {
+  font-size: 14px;
+  color: var(--content-subtle);
+}
+
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.slider-label {
+  font-size: 16px;
+  color: var(--content-2);
+}
+
+.slider-root {
+  --slider-thumb-width: 36px;
+  --slider-thumb-half-width: 18px;
+  --slider-thumb-half-width-negative: -18px;
+  position: relative;
+  width: auto;
+  height: 36px;
+  margin-left: var(--slider-thumb-half-width);
+  margin-right: var(--slider-thumb-half-width);
+  display: flex;
+  align-items: center;
+}
+
+.slider-track {
+  position: absolute;
+  top: 0;
+  left: var(--slider-thumb-half-width-negative);
+  right: var(--slider-thumb-half-width-negative);
+  height: 36px;
+  border-radius: 18px;
+  background-color: var(--neutral-faint);
+}
+
+.slider-range {
+  position: absolute;
+  top: 0;
+  left: var(--slider-thumb-half-width-negative);
+  right: var(--slider-thumb-half-width-negative);
+  height: 36px;
+  border-radius: 18px;
+  background: var(--primary);
+}
+
+.slider-thumb-wrapper {
+  position: absolute;
+  top: 0;
+  right: var(--slider-thumb-half-width-negative);
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--primary);
+  border-radius: 18px;
+}
+
+.slider-thumb-dot {
+  width: 32px;
+  height: 32px;
+  margin: 2px;
+  border-radius: 16px;
+  background-color: var(--primary-content);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.slider-thumb-dot-ring {
+  width: 24px;
+  height: 24px;
+  border-radius: 12px;
+  background-color: var(--primary);
+}
+
+.slider-track-gradient {
+  background: linear-gradient(90deg, var(--primary), var(--primary-2));
+}
+
+.slider-range-gradient {
+  background: transparent;
+}
+
+.slider-thumb-wrapper-gradient {
+  background-color: transparent;
+}
+
+.slider-track-secondary {
+  background-color: var(--neutral-faint);
+}
+
+.slider-range-secondary {
+  background: var(--primary);
+}
+
+.slider-thumb-ring {
+  width: 36px;
+  height: 36px;
+  border-radius: 18px;
+  border: 4px solid var(--primary-content);
+  background: var(--primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18), 0 3px 8px rgba(0, 0, 0, 0.12);
+}
+
+.slider-track-inverted {
+  height: 24px;
+  margin-top: 6px;
+  border-radius: 12px;
+}
+
+.slider-thumb-ring-inverted {
+  width: 36px;
+  height: 36px;
+  border-radius: 18px;
+  background: var(--primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.slider-thumb-dot-ring-inverted {
+  width: 28px;
+  height: 28px;
+  border-radius: 14px;
+  background-color: var(--primary-content);
+}
+
+.slider-root-pill {
+  position: relative;
+  width: 100%;
+  height: 36px;
+  display: flex;
+  align-items: center;
+}
+
+.slider-track-pill {
+  width: 100%;
+  height: 24px;
+  border-radius: 3px;
+  background-color: var(--neutral-faint);
+}
+
+.slider-range-pill {
+  width: 100%;
+  height: 24px;
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+  margin-top: 6px;
+  background: var(--primary);
+}
+
+.slider-thumb-pill-wrapper {
+  position: absolute;
+  top: 0;
+  right: -18px;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.slider-thumb-bar {
+  width: 6px;
+  height: 24px;
+  border-radius: 3px;
+  background-color: var(--primary-content);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18), 0 3px 8px rgba(0, 0, 0, 0.12);
+}

--- a/apps/examples/Slider/Shapes/index.tsx
+++ b/apps/examples/Slider/Shapes/index.tsx
@@ -1,0 +1,148 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from '@lynx-js/react'
+
+import {
+  SliderRange,
+  SliderRoot,
+  SliderThumb,
+  SliderTrack,
+} from '@lynx-js/lynx-ui'
+
+import './index.css'
+
+function formatValue(value: number) {
+  return `${Math.round(value * 100)}%`
+}
+
+function App() {
+  const [fullValue, setFullValue] = useState(0.4)
+  const [gradientValue, setGradientValue] = useState(0.55)
+  const [secondaryValue, setSecondaryValue] = useState(0.65)
+  const [invertedRingValue, setInvertedRingValue] = useState(0.35)
+  const [pillValue, setPillValue] = useState(0.5)
+
+  return (
+    <view className='demo-container lunaris-dark luna-gradient-berry'>
+      <view className='demo-canvas'>
+        <view className='section'>
+          <text className='title'>Shapes</text>
+          <text className='desc'>
+            Different visual shapes for thick sliders: full dot, ring, inverted
+            ring, and pill.
+          </text>
+
+          <view className='row'>
+            <text className='slider-label'>
+              {formatValue(fullValue)} — Full
+            </text>
+            <SliderRoot
+              className='slider-root'
+              defaultValue={0.4}
+              onValueChange={(value: number) => {
+                setFullValue(value)
+              }}
+            >
+              <SliderTrack className='slider-track' />
+              <SliderRange className='slider-range'>
+                <SliderThumb className='slider-thumb-wrapper'>
+                  <view className='slider-thumb-dot' />
+                </SliderThumb>
+              </SliderRange>
+            </SliderRoot>
+          </view>
+
+          <view className='row'>
+            <text className='slider-label'>
+              {formatValue(gradientValue)} — Gradient
+            </text>
+            <SliderRoot
+              className='slider-root'
+              defaultValue={0.55}
+              onValueChange={(value: number) => {
+                setGradientValue(value)
+              }}
+            >
+              <SliderTrack className='slider-track slider-track-gradient' />
+              <SliderRange className='slider-range slider-range-gradient'>
+                <SliderThumb className='slider-thumb-wrapper slider-thumb-wrapper-gradient'>
+                  <view className='slider-thumb-dot'>
+                    <view className='slider-thumb-dot-ring' />
+                  </view>
+                </SliderThumb>
+              </SliderRange>
+            </SliderRoot>
+          </view>
+
+          <view className='row'>
+            <text className='slider-label'>
+              {formatValue(secondaryValue)} — Ring
+            </text>
+            <SliderRoot
+              className='slider-root'
+              defaultValue={0.65}
+              onValueChange={(value: number) => {
+                setSecondaryValue(value)
+              }}
+            >
+              <SliderTrack className='slider-track slider-track-secondary' />
+              <SliderRange className='slider-range slider-range-secondary'>
+                <SliderThumb className='slider-thumb-wrapper'>
+                  <view className='slider-thumb-ring' />
+                </SliderThumb>
+              </SliderRange>
+            </SliderRoot>
+          </view>
+
+          <view className='row'>
+            <text className='slider-label'>
+              {formatValue(invertedRingValue)} — Inverted Ring
+            </text>
+            <SliderRoot
+              className='slider-root'
+              defaultValue={0.35}
+              onValueChange={(value: number) => {
+                setInvertedRingValue(value)
+              }}
+            >
+              <SliderTrack className='slider-track slider-track-inverted' />
+              <SliderRange className='slider-range'>
+                <SliderThumb className='slider-thumb-wrapper'>
+                  <view className='slider-thumb-ring-inverted'>
+                    <view className='slider-thumb-dot-ring-inverted' />
+                  </view>
+                </SliderThumb>
+              </SliderRange>
+            </SliderRoot>
+          </view>
+
+          <view className='row'>
+            <text className='slider-label'>
+              {formatValue(pillValue)} — Pill
+            </text>
+            <SliderRoot
+              className='slider-root-pill'
+              defaultValue={0.5}
+              onValueChange={(value: number) => {
+                setPillValue(value)
+              }}
+            >
+              <SliderTrack className='slider-track-pill' />
+              <SliderRange className='slider-range-pill'>
+                <SliderThumb className='slider-thumb-pill-wrapper'>
+                  <view className='slider-thumb-bar' />
+                </SliderThumb>
+              </SliderRange>
+            </SliderRoot>
+          </view>
+        </view>
+      </view>
+    </view>
+  )
+}
+
+root.render(<App />)
+
+export default App

--- a/apps/examples/Slider/WithScrollView/index.css
+++ b/apps/examples/Slider/WithScrollView/index.css
@@ -1,0 +1,117 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.demo-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding-top: 48px;
+  padding-bottom: 24px;
+  padding-left: 24px;
+  padding-right: 24px;
+  background-color: var(--canvas);
+  color: var(--content);
+}
+
+.header {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--content);
+  margin-bottom: 16px;
+}
+
+.vertical-scroll {
+  width: 100%;
+  flex: 1;
+}
+
+.horizontal-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.section-title {
+  font-size: 14px;
+  color: var(--content-subtle);
+}
+
+.horizontal-scroll {
+  width: 100%;
+  height: 140px;
+}
+
+.horizontal-content {
+  width: max-content;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+}
+
+.card {
+  width: 260px;
+  height: 128px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+  border-radius: 12px;
+  background-color: var(--neutral-faint);
+}
+
+.card-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--content);
+}
+
+.card-value {
+  font-size: 12px;
+  color: var(--content-subtle);
+}
+
+.slider-root {
+  position: relative;
+  width: 100%;
+  height: 36px;
+  display: flex;
+  align-items: center;
+}
+
+.slider-track {
+  width: 100%;
+  height: 4px;
+  border-radius: 9999px;
+  background-color: var(--neutral-faint);
+}
+
+.slider-range {
+  width: 100%;
+  height: 4px;
+  border-radius: 9999px;
+  margin-top: 16px;
+  background: var(--primary);
+}
+
+.slider-thumb-wrapper {
+  position: absolute;
+  top: 0;
+  right: -18px;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.slider-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18), 0 3px 8px rgba(0, 0, 0, 0.12);
+}

--- a/apps/examples/Slider/WithScrollView/index.tsx
+++ b/apps/examples/Slider/WithScrollView/index.tsx
@@ -1,0 +1,77 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from '@lynx-js/react'
+
+import {
+  SliderRange,
+  SliderRoot,
+  SliderThumb,
+  SliderTrack,
+} from '@lynx-js/lynx-ui'
+
+import './index.css'
+
+function formatValue(value: number) {
+  return `${Math.round(value * 100)}%`
+}
+
+const VERTICAL_ITEMS = Array.from({ length: 8 }, (_, i) => i)
+
+function SliderCard({ index }: { index: number }) {
+  const [value, setValue] = useState(0.5)
+
+  return (
+    <view className='card'>
+      <text className='card-title'>Slider {index + 1}</text>
+      <text className='card-value'>{formatValue(value)}</text>
+      <SliderRoot
+        className='slider-root'
+        defaultValue={0.5}
+        onValueChange={(v: number) => {
+          setValue(v)
+        }}
+      >
+        <SliderTrack className='slider-track' />
+        <SliderRange className='slider-range'>
+          <SliderThumb className='slider-thumb-wrapper'>
+            <view className='slider-thumb' />
+          </SliderThumb>
+        </SliderRange>
+      </SliderRoot>
+    </view>
+  )
+}
+
+function App() {
+  return (
+    <view className='demo-container lunaris-dark'>
+      <text className='header'>Slider in Nested ScrollView</text>
+      <scroll-view
+        scroll-orientation='vertical'
+        className='vertical-scroll'
+      >
+        {VERTICAL_ITEMS.map((i) => (
+          <view className='horizontal-section' key={`section-${i}`}>
+            <text className='section-title'>Section {i + 1}</text>
+            <scroll-view
+              scroll-orientation='horizontal'
+              className='horizontal-scroll'
+            >
+              <view className='horizontal-content'>
+                <SliderCard index={i * 3} />
+                <SliderCard index={i * 3 + 1} />
+                <SliderCard index={i * 3 + 2} />
+              </view>
+            </scroll-view>
+          </view>
+        ))}
+      </scroll-view>
+    </view>
+  )
+}
+
+root.render(<App />)
+
+export default App

--- a/apps/examples/Slider/lynx.config.mjs
+++ b/apps/examples/Slider/lynx.config.mjs
@@ -1,0 +1,17 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { exampleConfig } from '../../../tools/configs/exampleConfig.mjs'
+
+const defaultConfig = exampleConfig({
+  SliderBasic: './Basic/index.tsx',
+  SliderControlled: './Controlled/index.tsx',
+  SliderShapes: './Shapes/index.tsx',
+  SliderFacade: './Facade/index.tsx',
+  SliderDynamicWidth: './DynamicWidth/index.tsx',
+  SliderProgress: './Progress/index.tsx',
+  SliderWithScrollView: './WithScrollView/index.tsx',
+}, { enableWebBundle: true })
+
+export default defaultConfig

--- a/apps/examples/Slider/package.json
+++ b/apps/examples/Slider/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@lynx-example/lynx-ui-slider",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Example app demonstrating Slider usage in lynx-ui",
+  "homepage": "https://github.com/lynx-family/lynx-ui/tree/main/apps/examples/Slider#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-ui.git",
+    "directory": "apps/examples/Slider"
+  },
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Lynx Authors"
+  },
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "build:dev": "rspeedy build --mode=development",
+    "dev": "rspeedy dev",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@lynx-js/luna-styles": "workspace:*",
+    "@lynx-js/lynx-ui": "workspace:*",
+    "@lynx-js/react": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
+    "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rspeedy": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@types/react": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/apps/examples/Slider/tsconfig.json
+++ b/apps/examples/Slider/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["."],
+  "exclude": ["dist", "node_modules"],
+}

--- a/packages/lynx-ui-slider/CHANGELOG.md
+++ b/packages/lynx-ui-slider/CHANGELOG.md
@@ -1,0 +1,13 @@
+# @lynx-js/lynx-ui-slider
+
+## 3.130.1
+
+- Introduced primitives-first slider components:
+  - `SliderRoot`
+  - `SliderTrack`
+  - `SliderRange`
+  - `SliderThumb`
+- Added compatibility facade component `Slider`.
+- Added imperative API via `SliderRef` (`updateProgress`, `getProgress`).
+- Added export integration in aggregate package `@lynx-js/lynx-ui`.
+- Track/thumb visual customization is designed to be done via CSS classes or inline style instead of dedicated size/color props.

--- a/packages/lynx-ui-slider/LICENSE
+++ b/packages/lynx-ui-slider/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/lynx-ui-slider/README.md
+++ b/packages/lynx-ui-slider/README.md
@@ -1,0 +1,102 @@
+# @lynx-js/lynx-ui-slider
+
+A primitives-first slider component package for lynx-ui.
+
+## Installation
+
+We strongly recommend consuming this through the aggregate package:
+
+```bash
+# pnpm (recommended)
+pnpm add @lynx-js/lynx-ui
+
+# npm
+npm install @lynx-js/lynx-ui
+
+# yarn
+yarn add @lynx-js/lynx-ui
+```
+
+If needed, you can install the standalone package directly:
+
+```bash
+pnpm add @lynx-js/lynx-ui-slider
+```
+
+## Usage
+
+### Primitive Composition (Recommended)
+
+```tsx
+import {
+  SliderRoot,
+  SliderTrack,
+  SliderRange,
+  SliderThumb,
+} from '@lynx-js/lynx-ui'
+
+export function SliderPrimitiveDemo() {
+  return (
+    <SliderRoot
+      defaultProgress={0.35}
+      onSeek={(value) => console.log(value)}
+    >
+      <SliderTrack />
+      <SliderRange className='slider-range'>
+        <SliderThumb className='slider-thumb-wrapper'>
+          <view className='slider-thumb-dot' />
+        </SliderThumb>
+      </SliderRange>
+    </SliderRoot>
+  )
+}
+```
+
+### Compatibility Facade
+
+```tsx
+import { Slider } from '@lynx-js/lynx-ui'
+
+export function SliderFacadeDemo() {
+  return <Slider defaultProgress={0.5} />
+}
+```
+
+## Component Structure
+
+```tsx
+<SliderRoot>
+  <SliderTrack />
+  <SliderRange>
+    <SliderThumb>
+      <view />
+    </SliderThumb>
+  </SliderRange>
+</SliderRoot>
+```
+
+- **`SliderRoot`**: owns interaction logic and imperative methods.
+- **`SliderTrack`**: renders background track.
+- **`SliderRange`**: renders the active progress range and owns its width.
+- **`SliderThumb`**: renders thumb content passed through `children`.
+- **`Slider`**: compatibility facade built from primitives.
+
+Styling for track/thumb size and colors is expected to be done through CSS (`className`/`class`) or inline `style`, instead of dedicated style props.
+
+### About Track/Thumb Centering
+
+The slider internally aligns thumb and track with an implicit size relationship:
+
+- `thumb` vertical center aligns to the track center.
+- `thumb` horizontal anchor is the range end center point.
+
+If you override track/thumb sizes with custom CSS, keep this relationship to avoid visual offset:
+
+- progress bar top offset should follow: `(thumbHeight - trackHeight) / 2`
+- thumb wrapper right offset should follow: `-thumbWidth / 2`
+
+When these offsets are not updated together with your custom sizes, the thumb may look vertically or horizontally misaligned.
+
+## License
+
+[**lynx-ui**](https://github.com/lynx-family/lynx-ui) is [**Apache License 2.0**](./LICENSE) licensed.

--- a/packages/lynx-ui-slider/SKILL.md
+++ b/packages/lynx-ui-slider/SKILL.md
@@ -1,0 +1,158 @@
+# lynx-ui-slider SKILL
+
+`lynx-ui-slider` is a primitives-first slider package for ReactLynx. It provides composable building blocks (`SliderRoot`, `SliderTrack`, `SliderRange`, `SliderThumb`).
+
+## 1. Core Capabilities
+
+- **Primitives Composition**: Build slider UI with `SliderRoot` + `SliderTrack` + `SliderRange` + `SliderThumb`.
+- **Controlled & Uncontrolled Modes**: Use `value` + `onValueChange` for controlled mode, or `defaultValue` for uncontrolled mode.
+- **Imperative API** (uncontrolled only): Access `updateValue` and `getValue` through `SliderRef`. Throws in controlled mode.
+- **RTL Support**: Set `enableRTL` to reverse range direction (right-to-left).
+- **Stepping**: Set `step` to snap values to discrete increments.
+- **Readonly Mode**: Set `readonly` to prevent dragging while still displaying the current value.
+- **Interaction Callbacks**: `onDragging(value)`, `onValueChange(value, source)`, `onValueCommit(value)`.
+- **Headless Styling**: Supports styling via `className` and `style` props on every primitive.
+
+## 2. AI Coding Guide
+
+### Minimal Usable Example (Uncontrolled)
+
+```tsx
+import {
+  SliderRoot,
+  SliderTrack,
+  SliderRange,
+  SliderThumb,
+} from '@lynx-js/lynx-ui'
+
+function BasicSlider() {
+  return (
+    <SliderRoot
+      defaultValue={0.3}
+      onValueCommit={(value) => console.log(value)}
+    >
+      <SliderTrack className='track' />
+      <SliderRange className='range'>
+        <SliderThumb className='thumb'>
+          <view />
+        </SliderThumb>
+      </SliderRange>
+    </SliderRoot>
+  )
+}
+```
+
+### Controlled Mode Example
+
+```tsx
+import { useState } from '@lynx-js/react'
+import {
+  SliderRoot,
+  SliderTrack,
+  SliderRange,
+  SliderThumb,
+} from '@lynx-js/lynx-ui'
+
+function ControlledSlider() {
+  const [value, setValue] = useState(0.5)
+
+  return (
+    <SliderRoot
+      value={value}
+      onValueChange={(v) => setValue(v)}
+    >
+      <SliderTrack className='track' />
+      <SliderRange className='range'>
+        <SliderThumb className='thumb'>
+          <view />
+        </SliderThumb>
+      </SliderRange>
+    </SliderRoot>
+  )
+}
+```
+
+### RTL Example
+
+```tsx
+<SliderRoot enableRTL defaultValue={0.4}>
+  <SliderTrack className='track' />
+  <SliderRange className='range'>
+    <SliderThumb className='thumb'>
+      <view />
+    </SliderThumb>
+  </SliderRange>
+</SliderRoot>
+```
+
+### Recommended Prompt Formula
+
+> **State mode** + **Visual structure** + **Interaction callbacks** + **Styling hooks**
+
+**Example Prompts:**
+
+- "Create a controlled slider with custom thumb UI and `onValueCommit` callback."
+- "Build a headless slider with `step={0.1}` and custom class names for each primitive."
+- "Add an RTL slider with `enableRTL` and `direction: rtl` CSS."
+
+## 3. Props Reference
+
+### SliderRootProps
+
+| Prop            | Type                              | Default | Description                                                      |
+| --------------- | --------------------------------- | ------- | ---------------------------------------------------------------- |
+| `value`         | `number`                          | —       | Controlled value `[0, 1]`. Do not use with `defaultValue`.       |
+| `defaultValue`  | `number`                          | `0`     | Initial value for uncontrolled mode.                             |
+| `step`          | `number`                          | —       | Snap interval in `[0, 1]`.                                       |
+| `readonly`      | `boolean`                         | `false` | Prevent interaction while keeping the slider value visible.      |
+| `enableRTL`     | `boolean`                         | `false` | Reverse range direction (right-to-left).                         |
+| `onDragging`    | `(value: number) => void`         | —       | Fires during drag with current value.                            |
+| `onValueChange` | `(value: number, source) => void` | —       | Fires on every value change. Source is `'drag'` or `'external'`. |
+| `onValueCommit` | `(value: number) => void`         | —       | Fires at drag end with final value.                              |
+
+### SliderRef (uncontrolled only)
+
+| Method        | Signature                           | Description                                        |
+| ------------- | ----------------------------------- | -------------------------------------------------- |
+| `updateValue` | `(value: number, options?) => void` | Set value imperatively. Throws in controlled mode. |
+| `getValue`    | `() => number`                      | Read current value. Throws in controlled mode.     |
+
+## 4. FAQ
+
+**Q: Should I use controlled or uncontrolled mode?**
+
+A: Use controlled (`value` + `onValueChange`) when you need to sync slider state with external state. Use uncontrolled (`defaultValue`) for simpler cases where internal state suffices.
+
+**Q: What is the difference between `onValueChange` and `onValueCommit`?**
+
+A: `onValueChange` fires on every value change (including during drag). `onValueCommit` fires once at drag end — useful for persisting the final value.
+
+**Q: Is `disabled` still supported?**
+
+A: Use `readonly` going forward. `disabled` is kept only as a deprecated compatibility alias.
+
+**Q: What happens if I call `updateValue` / `getValue` in controlled mode?**
+
+A: They will throw an error. In controlled mode, update the `value` prop directly instead.
+
+**Q: Can I set value outside `[0, 1]`?**
+
+A: Input values are clamped to `[0, 1]` internally.
+
+**Q: How do I enable RTL?**
+
+A: Pass `enableRTL` to `SliderRoot` and add `direction: rtl` to the container CSS.
+
+**Q: I changed thumb/track size in CSS and now thumb is not centered. Why?**
+
+A: Thumb and track have an implicit centering relationship. If you change one size, also update the matching offsets in CSS:
+
+- vertical alignment offset: `(thumbHeight - trackHeight) / 2`
+- horizontal anchor offset: `-thumbWidth / 2`
+
+## 5. Sub Components
+
+- **`SliderRoot`**: Owns measurement, drag behavior, value management, and context provider.
+- **`SliderTrack`**: Background track bar.
+- **`SliderRange`**: Foreground range container with width bound to value. Supports RTL via `right: 0` positioning.
+- **`SliderThumb`**: Draggable thumb visual node, positioned at the end of the range.

--- a/packages/lynx-ui-slider/package.json
+++ b/packages/lynx-ui-slider/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@lynx-js/lynx-ui-slider",
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-ui.git",
+    "directory": "packages/lynx-ui-slider"
+  },
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Lynx Authors"
+  },
+  "sideEffects": false,
+  "type": "module",
+  "main": "./dist/index.jsx",
+  "module": "./dist/index.jsx",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "src/**",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE",
+    "tsconfig.docs.json",
+    "tsconfig.json",
+    "dist/**"
+  ],
+  "scripts": {
+    "build": "rslib build",
+    "build:watch": "rslib build --watch",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@lynx-js/lynx-ui-common": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/react": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@rslib/core": "catalog:",
+    "@types/react": "catalog:",
+    "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "@lynx-js/react": ">=0.100.0",
+    "@lynx-js/types": "*",
+    "@types/react": "^18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "jsnext:source": "./src/index.tsx"
+}

--- a/packages/lynx-ui-slider/rslib.config.ts
+++ b/packages/lynx-ui-slider/rslib.config.ts
@@ -1,0 +1,8 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from '@rslib/core'
+import { baseConfig } from '../../tools/configs/rslib.base.js'
+
+export default defineConfig(baseConfig)

--- a/packages/lynx-ui-slider/src/SliderRange/index.tsx
+++ b/packages/lynx-ui-slider/src/SliderRange/index.tsx
@@ -1,0 +1,30 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { memo } from '@lynx-js/react'
+
+import { useSliderContext } from '../context'
+import type { SliderRangeProps } from '../types'
+
+export const SliderRange = memo(function SliderRange(props: SliderRangeProps) {
+  const { valueRef, currentValue, enableRTL } = useSliderContext()
+  const { children, className, style } = props
+
+  return (
+    <view
+      ref={valueRef}
+      style={{
+        position: 'absolute',
+        top: '0px',
+        ...(enableRTL ? { right: '0px' } : { left: '0px' }),
+        height: '100%',
+        overflow: 'visible',
+        width: `${currentValue.current * 100}%`,
+      }}
+    >
+      <view className={className} style={style} />
+      {children}
+    </view>
+  )
+})

--- a/packages/lynx-ui-slider/src/SliderRoot/index.tsx
+++ b/packages/lynx-ui-slider/src/SliderRoot/index.tsx
@@ -1,0 +1,333 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// cspell:ignore catchmousemove catchmousedown catchmouseup
+
+import {
+  forwardRef,
+  memo,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from '@lynx-js/react'
+import type { ForwardedRef } from '@lynx-js/react'
+
+import type { NodesRef } from '@lynx-js/types'
+
+import { SliderContext } from '../context'
+import type {
+  SliderRef,
+  SliderRootProps,
+  SliderUpdateValueOptions,
+  SliderValueChangeSource,
+} from '../types'
+import { clamp01, getTouchX, snapToStep } from '../utils'
+
+export const SliderRoot = memo(forwardRef(SliderRootImpl))
+
+function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
+  const {
+    value: controlledValue,
+    defaultValue = 0,
+    step,
+    readonly = false,
+    disabled = false,
+    enableRTL = false,
+    className,
+    style,
+    onDragging,
+    onValueChange,
+    onValueCommit,
+    children,
+  } = props
+
+  // @ts-expect-error Known issue for types
+  const isWebPlatform = useRef<boolean>(SystemInfo.platform === 'web')
+
+  const isWebMouseDown = useRef<boolean>(false)
+  const isReadonly = readonly || disabled
+
+  const isControlled = controlledValue !== undefined
+
+  const containerRef = useRef<NodesRef>(null)
+  const valueRef = useRef<NodesRef>(null)
+
+  const bgWidth = useRef<number>(0)
+  const bgLeft = useRef<number>(0)
+  const leftMeasured = useRef<boolean>(false)
+  const isMeasuringBounds = useRef<boolean>(false)
+  const pendingMoveX = useRef<number | null>(null)
+
+  const isDragging = useRef<boolean>(false)
+  const currentValue = useRef<number>(
+    snapToStep(clamp01(isControlled ? controlledValue : defaultValue), step),
+  )
+
+  const applyNativeWidth = (next: number): void => {
+    valueRef.current
+      ?.setNativeProps?.({
+        width: `${next * 100}%`,
+      })
+      ?.exec?.()
+  }
+
+  const syncCurrentValue = (next: number): boolean => {
+    if (currentValue.current === next) return false
+    currentValue.current = next
+    applyNativeWidth(next)
+    return true
+  }
+
+  const updateValue = (
+    value: number,
+    options: SliderUpdateValueOptions = {},
+  ): void => {
+    const next = snapToStep(clamp01(value), step)
+    const source: SliderValueChangeSource = options.source ?? 'external'
+
+    if (isDragging.current && !options.force && source === 'external') {
+      return
+    }
+
+    if (!syncCurrentValue(next)) return
+
+    onValueChange?.(next, source)
+  }
+
+  useEffect(() => {
+    if (!isControlled) return
+    const next = snapToStep(clamp01(controlledValue), step)
+    syncCurrentValue(next)
+  }, [controlledValue, isControlled, step])
+
+  const getValue = (): number => currentValue.current
+
+  const applyMeasuredMoveX = (x: number): void => {
+    const value = valueFromX(x)
+    if (value === null) return
+
+    setDragging(true, value)
+    updateValue(value, { source: 'drag', force: true })
+  }
+
+  const updateBounds = (res: unknown): boolean => {
+    const left = Number(
+      (res as { left?: unknown } | null | undefined)?.left,
+    )
+    const width = Number(
+      (res as { width?: unknown } | null | undefined)?.width,
+    )
+
+    if (Number.isFinite(left)) {
+      bgLeft.current = left
+    }
+
+    if (Number.isFinite(width) && width > 0) {
+      bgWidth.current = width
+    }
+
+    const ready = Number.isFinite(bgLeft.current) && bgWidth.current > 0
+    leftMeasured.current = ready
+    return ready
+  }
+
+  const flushPendingMoveX = (): void => {
+    if (pendingMoveX.current === null || !leftMeasured.current) return
+    const x = pendingMoveX.current
+    pendingMoveX.current = null
+    applyMeasuredMoveX(x)
+  }
+
+  const measureBounds = (): void => {
+    if (isMeasuringBounds.current) return
+    isMeasuringBounds.current = true
+
+    containerRef.current
+      ?.invoke?.({
+        method: 'boundingClientRect',
+        params: { relativeTo: 'screen' },
+        success: (res: unknown) => {
+          isMeasuringBounds.current = false
+          updateBounds(res)
+          flushPendingMoveX()
+        },
+        fail: () => {
+          isMeasuringBounds.current = false
+        },
+      })
+      ?.exec?.()
+  }
+
+  const setDragging = (nextDragging: boolean, value: number): void => {
+    if (isDragging.current === nextDragging) return
+    isDragging.current = nextDragging
+    onDragging?.(value)
+  }
+
+  const valueFromX = (x: number): number | null => {
+    const width = bgWidth.current
+    if (!Number.isFinite(x) || width <= 0) return null
+    const ratio = (x - bgLeft.current) / width
+    return clamp01(enableRTL ? 1 - ratio : ratio)
+  }
+
+  const handleMoveX = (x: number): void => {
+    if (isReadonly) return
+    if (!Number.isFinite(x)) return
+
+    if (!leftMeasured.current || bgWidth.current <= 0) {
+      pendingMoveX.current = x
+      measureBounds()
+      return
+    }
+
+    applyMeasuredMoveX(x)
+  }
+
+  const handleInteractionStart = (x: number): void => {
+    if (isReadonly) return
+    if (!Number.isFinite(x)) return
+
+    pendingMoveX.current = x
+    leftMeasured.current = false
+    measureBounds()
+  }
+
+  const handleEnd = (): void => {
+    if (!isDragging.current) return
+
+    const value = currentValue.current
+    setDragging(false, value)
+    onValueCommit?.(value)
+  }
+
+  const onLayoutChange = (event: {
+    params: { width: number, height: number }
+    detail?: { width: number, height: number }
+  }): void => {
+    const width = Number(event?.detail?.width ?? event?.params?.width)
+    if (Number.isFinite(width) && width > 0) {
+      bgWidth.current = width
+      leftMeasured.current = false
+      measureBounds()
+      return
+    }
+
+    bgWidth.current = 0
+    leftMeasured.current = false
+  }
+
+  const getMouseX = (event: unknown): number => {
+    const xInTouches = (
+      event as
+        | { touches?: Array<{ clientX?: unknown }> }
+        | null
+        | undefined
+    )?.touches?.[0]?.clientX
+
+    const x = Number(
+      (event as { clientX?: unknown } | null | undefined)?.clientX,
+    )
+
+    return xInTouches ? Number(xInTouches) : x
+  }
+
+  const handleMouseX = (event: unknown): void => {
+    handleMoveX(getMouseX(event))
+  }
+
+  const handleMouseStart = (event: unknown): void => {
+    handleInteractionStart(getMouseX(event))
+  }
+
+  const handleTouchStart = (event: unknown): void => {
+    if (isWebPlatform.current) {
+      handleMouseStart(event)
+      return
+    }
+
+    handleInteractionStart(getTouchX(event))
+  }
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      updateValue: (value: number, options?: SliderUpdateValueOptions) => {
+        if (isControlled) {
+          throw new Error(
+            'SliderRoot: updateValue() must not be called in controlled mode. Update the `value` prop instead.',
+          )
+        }
+        updateValue(value, options)
+      },
+      getValue: () => {
+        if (isControlled) {
+          throw new Error(
+            'SliderRoot: getValue() must not be called in controlled mode. Read the `value` prop instead.',
+          )
+        }
+        return getValue()
+      },
+    }),
+    [updateValue, getValue, isControlled],
+  )
+
+  const contextValue = {
+    valueRef,
+    currentValue,
+    enableRTL,
+  }
+
+  return (
+    <SliderContext.Provider value={contextValue}>
+      <view
+        ref={containerRef}
+        className={className}
+        flatten={false}
+        style={style}
+        block-native-event={true}
+        native-interaction-enabled={true}
+        consume-slide-event={[[-180, 180]]}
+        catchmousemove={(event: unknown) => {
+          if (isWebPlatform.current && !isWebMouseDown.current) return
+          handleMouseX(event)
+        }}
+        catchmousedown={(event: unknown) => {
+          isWebMouseDown.current = true
+          handleMouseStart(event)
+        }}
+        catchmouseup={() => {
+          isWebMouseDown.current = false
+          handleEnd()
+        }}
+        global-bindmouseup={() => {
+          isWebMouseDown.current = false
+          handleEnd()
+        }}
+        catchtouchmove={(event: unknown) => {
+          if (isWebPlatform.current) {
+            handleMouseX(event)
+          } else {
+            handleMoveX(getTouchX(event))
+          }
+        }}
+        catchtouchstart={(event: unknown) => {
+          isWebMouseDown.current = true
+          handleTouchStart(event)
+        }}
+        catchtouchend={() => {
+          isWebMouseDown.current = false
+          handleEnd()
+        }}
+        catchtouchcancel={() => {
+          isWebMouseDown.current = false
+          handleEnd()
+        }}
+        bindlayoutchange={onLayoutChange}
+      >
+        {children}
+      </view>
+    </SliderContext.Provider>
+  )
+}

--- a/packages/lynx-ui-slider/src/SliderThumb/index.tsx
+++ b/packages/lynx-ui-slider/src/SliderThumb/index.tsx
@@ -1,0 +1,25 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { memo } from '@lynx-js/react'
+
+import type { SliderThumbProps } from '../types'
+
+export const SliderThumb = memo(function SliderThumb(props: SliderThumbProps) {
+  const {
+    children,
+    className,
+    style,
+  } = props
+
+  return (
+    children
+      ? (
+        <view className={className} style={style}>
+          {children}
+        </view>
+      )
+      : null
+  )
+})

--- a/packages/lynx-ui-slider/src/SliderTrack/index.tsx
+++ b/packages/lynx-ui-slider/src/SliderTrack/index.tsx
@@ -1,0 +1,13 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { memo } from '@lynx-js/react'
+
+import type { SliderTrackProps } from '../types'
+
+export const SliderTrack = memo(function SliderTrack(props: SliderTrackProps) {
+  const { className, style } = props
+
+  return <view className={className} style={style} />
+})

--- a/packages/lynx-ui-slider/src/context/index.tsx
+++ b/packages/lynx-ui-slider/src/context/index.tsx
@@ -1,0 +1,23 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { createContext, useContext } from '@lynx-js/react'
+
+import type { NodesRef } from '@lynx-js/types'
+
+export interface SliderContextValue {
+  valueRef: { current: NodesRef | null }
+  currentValue: { current: number }
+  enableRTL: boolean
+}
+
+export const SliderContext = createContext<SliderContextValue | null>(null)
+
+export function useSliderContext(): SliderContextValue {
+  const context = useContext(SliderContext)
+  if (!context) {
+    throw new Error('Slider components must be used inside <SliderRoot>.')
+  }
+  return context
+}

--- a/packages/lynx-ui-slider/src/index.tsx
+++ b/packages/lynx-ui-slider/src/index.tsx
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export { SliderRoot } from './SliderRoot'
+export { SliderTrack } from './SliderTrack'
+export { SliderRange } from './SliderRange'
+export { SliderThumb } from './SliderThumb'
+
+export type {
+  SliderRangeProps,
+  SliderRef,
+  SliderRootProps,
+  SliderThumbProps,
+  SliderTrackProps,
+  SliderUpdateValueOptions,
+  SliderValueChangeSource,
+} from './types'

--- a/packages/lynx-ui-slider/src/types/index.docs.ts
+++ b/packages/lynx-ui-slider/src/types/index.docs.ts
@@ -1,0 +1,198 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { ReactNode } from '@lynx-js/react'
+
+/**
+ * Source of a value change.
+ *
+ * - `external`: value updated by imperative API calls.
+ * - `drag`: value updated by pointer/touch dragging.
+ *
+ * @zh 值变更的来源。
+ *
+ * - `external`：通过命令式 API 调用更新。
+ * - `drag`：通过指针/触摸拖拽更新。
+ */
+export type SliderValueChangeSource = 'external' | 'drag'
+
+/**
+ * Options used by `SliderRef.updateValue`.
+ * @zh `SliderRef.updateValue` 使用的选项。
+ */
+export interface SliderUpdateValueOptions {
+  /**
+   * Mark the update source for analytics/logic branching.
+   * @defaultValue 'external'
+   * @zh 标记更新来源，用于分析或逻辑分支。
+   */
+  source?: SliderValueChangeSource
+  /**
+   * Bypass drag-time guard and force update even while dragging.
+   * @defaultValue false
+   * @zh 跳过拖拽保护，在拖拽过程中也强制更新。
+   */
+  force?: boolean
+}
+
+/**
+ * Imperative methods exposed by `SliderRoot`.
+ * @zh `SliderRoot` 暴露的命令式方法。
+ */
+export interface SliderRef {
+  /**
+   * Imperatively set slider value in range `[0, 1]`.
+   * @zh 命令式地设置滑块值，取值范围 `[0, 1]`。
+   */
+  updateValue: (
+    value: number,
+    options?: SliderUpdateValueOptions,
+  ) => void
+  /**
+   * Read current slider value in range `[0, 1]`.
+   * @zh 读取当前滑块值，取值范围 `[0, 1]`。
+   */
+  getValue: () => number
+}
+
+/**
+ * Root primitive props.
+ *
+ * `SliderRoot` owns interaction logic (dragging and value tracking)
+ * and provides context for child primitives.
+ *
+ * @zh 根原语组件属性。
+ *
+ * `SliderRoot` 负责交互逻辑（拖拽、值跟踪）并为子原语组件提供上下文。
+ */
+export interface SliderRootProps {
+  /**
+   * Controlled value in range `[0, 1]`. When provided, the slider is in controlled mode. Do not use together with `defaultValue`.
+   * @zh 受控模式下的值，范围 `[0, 1]`。传入此属性时滑块为受控模式，请勿与 `defaultValue` 同时使用。
+   */
+  value?: number
+  /**
+   * Initial value for uncontrolled usage.
+   * @defaultValue 0
+   * @zh 非受控模式下的初始值。
+   */
+  defaultValue?: number
+  /**
+   * Stepping interval in range `[0, 1]`. When set, the value snaps to the nearest multiple of `step`.
+   * @zh 步进间隔，范围 `[0, 1]`。设置后值会吸附到最近的 `step` 倍数。
+   */
+  step?: number
+  /**
+   * Make the slider read-only and prevent pointer/touch interaction.
+   * @defaultValue false
+   * @zh 将滑块设为只读，阻止指针/触摸交互。
+   */
+  readonly?: boolean
+  /**
+   * @deprecated Please use `readonly` instead.
+   */
+  disabled?: boolean
+  /**
+   * Enable right-to-left layout. When `true`, the slider range grows from right to left.
+   * @defaultValue false
+   * @zh 启用从右到左的布局。为 `true` 时，滑块范围从右向左增长。
+   */
+  enableRTL?: boolean
+  /**
+   * Class name for the root container.
+   * @zh 根容器的类名。
+   */
+  className?: string
+  /**
+   * Inline style for the root container.
+   * @zh 根容器的内联样式。
+   */
+  style?: Record<string, unknown>
+  /**
+   * Triggered during dragging with the current progress value.
+   * @zh 拖拽过程中触发，传入当前进度值。
+   */
+  onDragging?: (value: number) => void
+  /**
+   * Triggered on every value change.  In controlled mode, the slider does **not** update its internal value automatically; use this callback to update the controlled `value` prop.
+   * @zh 每次值变更时触发。在受控模式下，滑块不会自动更新内部值，需要通过此回调更新外部的 `value` 属性。
+   */
+  onValueChange?: (value: number, source: SliderValueChangeSource) => void
+  /**
+   * Triggered at the end of a drag interaction with the final value.
+   * @zh 拖拽交互结束时以最终值触发。适用于只需要最终提交值的场景，例如持久化到后端。
+   */
+  onValueCommit?: (value: number) => void
+  /**
+   * Primitive children composition, usually: SliderTrack` + `SliderRange` + `SliderThumb`.
+   * @zh 子原语组件组合，通常为：`SliderTrack` + `SliderRange` + `SliderThumb`。
+   */
+  children?: ReactNode
+}
+
+/**
+ * Track primitive props.
+ * @zh 轨道原语组件属性。
+ */
+export interface SliderTrackProps {
+  /**
+   * Class name for the background track.
+   * @zh 背景轨道的类名。
+   */
+  className?: string
+  /**
+   * Inline style for background track.
+   * @zh 背景轨道的内联样式。
+   */
+  style?: Record<string, unknown>
+}
+
+/**
+ * Range primitive props.
+ *
+ * `SliderRange` width and foreground bar are controlled by root value.
+ *
+ * @zh 范围条原语组件属性。
+ *
+ * `SliderRange` 的宽度和前景条由根组件的值控制。
+ */
+export interface SliderRangeProps {
+  /**
+   * Class name for the foreground range bar.
+   * @zh 前景范围条的类名。
+   */
+  className?: string
+  /**
+   * Inline style for the foreground range bar.
+   * @zh 前景范围条的内联样式。
+   */
+  style?: Record<string, unknown>
+  /**
+   * Usually includes `SliderThumb` and optional custom range content.
+   * @zh 通常包含 `SliderThumb` 及可选的自定义范围内容。
+   */
+  children?: ReactNode
+}
+
+/**
+ * Thumb primitive props.
+ * @zh 滑块拇指原语组件属性。
+ */
+export interface SliderThumbProps {
+  /**
+   * Class name for the thumb wrapper.
+   * @zh 拇指包裹元素的类名。
+   */
+  className?: string
+  /**
+   * Inline style for the thumb wrapper.
+   * @zh 拇指包裹元素的内联样式。
+   */
+  style?: Record<string, unknown>
+  /**
+   * Custom thumb content.
+   * @zh 自定义拇指内容。
+   */
+  children?: ReactNode
+}

--- a/packages/lynx-ui-slider/src/types/index.ts
+++ b/packages/lynx-ui-slider/src/types/index.ts
@@ -1,0 +1,5 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export type * from './index.docs'

--- a/packages/lynx-ui-slider/src/utils/index.ts
+++ b/packages/lynx-ui-slider/src/utils/index.ts
@@ -1,0 +1,26 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export const clamp01 = (value: number): number => {
+  if (!Number.isFinite(value)) return 0
+  return Math.min(Math.max(value, 0), 1)
+}
+
+export const snapToStep = (value: number, step: number | undefined): number => {
+  if (step === undefined || step <= 0) return value
+  const snapped = Math.round(value / step) * step
+  const decimalCount = (step.toString().split('.')[1] || '').length
+  return clamp01(Number.parseFloat(snapped.toFixed(decimalCount)))
+}
+
+export const getTouchX = (event: unknown): number => {
+  const detail =
+    typeof event === 'object' && event !== null && 'detail' in event
+      ? event.detail
+      : undefined
+  const x = typeof detail === 'object' && detail !== null && 'x' in detail
+    ? detail.x
+    : undefined
+  return Number(x)
+}

--- a/packages/lynx-ui-slider/tsconfig.docs.json
+++ b/packages/lynx-ui-slider/tsconfig.docs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tools/configs/tsconfig.docs.json",
+  "include": [
+    "src",
+    "dist/types/index.docs.d.ts"
+  ]
+}

--- a/packages/lynx-ui-slider/tsconfig.json
+++ b/packages/lynx-ui-slider/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tools/configs/tsconfig.lib.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+  },
+  "include": [
+    "src",
+  ],
+}

--- a/packages/lynx-ui/package.json
+++ b/packages/lynx-ui/package.json
@@ -45,6 +45,7 @@
     "@lynx-js/lynx-ui-radio-group": "workspace:*",
     "@lynx-js/lynx-ui-scroll-view": "workspace:*",
     "@lynx-js/lynx-ui-sheet": "workspace:*",
+    "@lynx-js/lynx-ui-slider": "workspace:*",
     "@lynx-js/lynx-ui-sortable": "workspace:*",
     "@lynx-js/lynx-ui-swipe-action": "workspace:*",
     "@lynx-js/lynx-ui-swiper": "workspace:*",

--- a/packages/lynx-ui/src/index.tsx
+++ b/packages/lynx-ui/src/index.tsx
@@ -241,6 +241,23 @@ export type {
   SwitchRenderProps,
 } from '@lynx-js/lynx-ui-switch'
 
+// slider
+export {
+  SliderRoot,
+  SliderTrack,
+  SliderRange,
+  SliderThumb,
+} from '@lynx-js/lynx-ui-slider'
+export type {
+  SliderRangeProps,
+  SliderRef,
+  SliderRootProps,
+  SliderThumbProps,
+  SliderTrackProps,
+  SliderUpdateValueOptions,
+  SliderValueChangeSource,
+} from '@lynx-js/lynx-ui-slider'
+
 export {
   SheetRoot,
   SheetContent,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         version: 0.11.2(@lynx-js/react@0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 1.4.2(@rsbuild/core@1.6.15)
+        version: 1.4.2(@rsbuild/core@1.6.0-beta.1)
       '@rslib/core':
         specifier: 'catalog:'
         version: 0.16.1(typescript@5.9.3)
@@ -557,6 +557,34 @@ importers:
         specifier: 'catalog:'
         version: 18.3.27
 
+  apps/examples/Slider:
+    dependencies:
+      '@lynx-js/luna-styles':
+        specifier: workspace:*
+        version: link:../../../luna/packages/luna-styles
+      '@lynx-js/lynx-ui':
+        specifier: workspace:*
+        version: link:../../../packages/lynx-ui
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.3.3
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.11.2(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.11.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+      '@lynx-js/types':
+        specifier: 'catalog:'
+        version: 3.6.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.27
+
   apps/examples/Sortable:
     dependencies:
       '@lynx-js/luna-styles':
@@ -781,6 +809,9 @@ importers:
       '@lynx-js/lynx-ui-sheet':
         specifier: workspace:*
         version: link:../lynx-ui-sheet
+      '@lynx-js/lynx-ui-slider':
+        specifier: workspace:*
+        version: link:../lynx-ui-slider
       '@lynx-js/lynx-ui-sortable':
         specifier: workspace:*
         version: link:../lynx-ui-sortable
@@ -1241,6 +1272,28 @@ importers:
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
+    devDependencies:
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+      '@lynx-js/types':
+        specifier: 'catalog:'
+        version: 3.6.0
+      '@rslib/core':
+        specifier: 'catalog:'
+        version: 0.16.1(typescript@5.9.3)
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.27
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
+  packages/lynx-ui-slider:
+    dependencies:
+      '@lynx-js/lynx-ui-common':
+        specifier: workspace:*
+        version: link:../lynx-ui-common
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
@@ -7550,6 +7603,10 @@ snapshots:
     dependencies:
       unrs-resolver: 1.11.1
 
+  '@lynx-js/react-refresh-webpack-plugin@0.3.4(@lynx-js/react-webpack-plugin@0.7.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0))':
+    dependencies:
+      '@lynx-js/react-webpack-plugin': 0.7.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0)
+
   '@lynx-js/react-refresh-webpack-plugin@0.3.4(@lynx-js/react-webpack-plugin@0.7.1(@lynx-js/react@0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0))':
     dependencies:
       '@lynx-js/react-webpack-plugin': 0.7.1(@lynx-js/react@0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0)
@@ -7558,7 +7615,7 @@ snapshots:
     dependencies:
       '@lynx-js/css-extract-webpack-plugin': 0.6.4(@lynx-js/template-webpack-plugin@0.9.0)(webpack@5.104.1)
       '@lynx-js/react-alias-rsbuild-plugin': 0.11.2
-      '@lynx-js/react-refresh-webpack-plugin': 0.3.4(@lynx-js/react-webpack-plugin@0.7.1(@lynx-js/react@0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0))
+      '@lynx-js/react-refresh-webpack-plugin': 0.3.4(@lynx-js/react-webpack-plugin@0.7.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0))
       '@lynx-js/react-webpack-plugin': 0.7.1(@lynx-js/react@0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(@lynx-js/template-webpack-plugin@0.9.0)
       '@lynx-js/runtime-wrapper-webpack-plugin': 0.1.3
       '@lynx-js/template-webpack-plugin': 0.9.0
@@ -7721,7 +7778,8 @@ snapshots:
 
   '@module-federation/error-codes@0.21.1': {}
 
-  '@module-federation/error-codes@0.21.6': {}
+  '@module-federation/error-codes@0.21.6':
+    optional: true
 
   '@module-federation/runtime-core@0.18.0':
     dependencies:
@@ -7737,6 +7795,7 @@ snapshots:
     dependencies:
       '@module-federation/error-codes': 0.21.6
       '@module-federation/sdk': 0.21.6
+    optional: true
 
   '@module-federation/runtime-tools@0.18.0':
     dependencies:
@@ -7752,6 +7811,7 @@ snapshots:
     dependencies:
       '@module-federation/runtime': 0.21.6
       '@module-federation/webpack-bundler-runtime': 0.21.6
+    optional: true
 
   '@module-federation/runtime@0.18.0':
     dependencies:
@@ -7770,12 +7830,14 @@ snapshots:
       '@module-federation/error-codes': 0.21.6
       '@module-federation/runtime-core': 0.21.6
       '@module-federation/sdk': 0.21.6
+    optional: true
 
   '@module-federation/sdk@0.18.0': {}
 
   '@module-federation/sdk@0.21.1': {}
 
-  '@module-federation/sdk@0.21.6': {}
+  '@module-federation/sdk@0.21.6':
+    optional: true
 
   '@module-federation/webpack-bundler-runtime@0.18.0':
     dependencies:
@@ -7791,6 +7853,7 @@ snapshots:
     dependencies:
       '@module-federation/runtime': 0.21.6
       '@module-federation/sdk': 0.21.6
+    optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -8055,6 +8118,7 @@ snapshots:
       '@swc/helpers': 0.5.18
       core-js: 3.47.0
       jiti: 2.6.1
+    optional: true
 
   '@rsbuild/plugin-check-syntax@1.3.0(@rsbuild/core@1.5.4)':
     dependencies:
@@ -8081,9 +8145,9 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-react@1.4.2(@rsbuild/core@1.6.15)':
+  '@rsbuild/plugin-react@1.4.2(@rsbuild/core@1.6.0-beta.1)':
     dependencies:
-      '@rsbuild/core': 1.6.15
+      '@rsbuild/core': 1.6.0-beta.1
       '@rspack/plugin-react-refresh': 1.5.3(react-refresh@0.18.0)
       react-refresh: 0.18.0
     transitivePeerDependencies:
@@ -8346,6 +8410,7 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 1.6.8
       '@rspack/binding-win32-ia32-msvc': 1.6.8
       '@rspack/binding-win32-x64-msvc': 1.6.8
+    optional: true
 
   '@rspack/core@1.5.2(@swc/helpers@0.5.18)':
     dependencies:
@@ -8370,10 +8435,12 @@ snapshots:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
       '@swc/helpers': 0.5.18
+    optional: true
 
   '@rspack/lite-tapable@1.0.1': {}
 
-  '@rspack/lite-tapable@1.1.0': {}
+  '@rspack/lite-tapable@1.1.0':
+    optional: true
 
   '@rspack/plugin-react-refresh@1.5.3(react-refresh@0.18.0)':
     dependencies:
@@ -9171,7 +9238,8 @@ snapshots:
 
   core-js@3.46.0: {}
 
-  core-js@3.47.0: {}
+  core-js@3.47.0:
+    optional: true
 
   core-util-is@1.0.3: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,12 +45,15 @@
       "path": "./packages/lynx-ui-presence"
     },
     {
+      "path": "./packages/lynx-ui-slider"
+    },
+    {
       "path": "./packages/lynx-ui-radio-group"
     },
     {
       "path": "./packages/lynx-ui-scroll-view"
     },
-        {
+    {
       "path": "./packages/lynx-ui-sheet"
     },
     {


### PR DESCRIPTION
### Motivation

- Introduce a new primitives-first slider component to the UI library for reusable progress/seek interactions.
- Provide the slider as its own package `@lynx-js/lynx-ui-slider` and make it available through the main `@lynx-js/lynx-ui` aggregate package.

### Description

- Add a new package `packages/lynx-ui-slider` containing implementation (`src/index.tsx`), types (`src/types/*`), build config (`rslib.config.ts`), and package metadata (`package.json`).
- Implement the `Slider` primitive along with `Slider.Root`, `Slider.Track`, `Slider.Range`, and `Slider.Thumb` components and related types and docs/READMEs. 
- Wire the package into the monorepo by updating `packages/lynx-ui/package.json` exports and adding the package to the workspace `tsconfig.json` paths. 
- Add changelog and a changeset (`.changeset/clever-sloths-smell.md`) to release the new package and bump `@lynx-js/lynx-ui` to export the slider.

### Testing

- No automated tests were added for the new slider package and no test runs were performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d3cce8648331b1153b3307d97357)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New slider package: primitives-based slider components, a compatibility facade, interaction callbacks, and an imperative API; re-exported from the main UI package.

* **Documentation**
  * Added README, changelog, developer guide, examples, and FAQ for the slider.

* **Chores**
  * Package manifest, build configs, license, example app, and versioning changes recorded via a changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->