### PR TITLE
docs: remove redundant @defaultValue undefined tags

### DIFF
--- a/packages/lynx-ui-common/src/types/interfaces/BaseScrollEvents.ts
+++ b/packages/lynx-ui-common/src/types/interfaces/BaseScrollEvents.ts
@@ -11,7 +11,6 @@ export interface BaseScrollEvents {
   /**
    * Being triggered when scrolling occurs.
    * @zh 滚动时触发。
-   * @defaultValue undefined
    * @eventProperty
    * @Android
    * @iOS

--- a/packages/lynx-ui-common/src/types/interfaces/LazyInterface.tsx
+++ b/packages/lynx-ui-common/src/types/interfaces/LazyInterface.tsx
@@ -16,7 +16,6 @@ export interface EnableLazyMode {
   /**
    * Be used to mark the exposure timing of lazy loading. Please ensure that it is unique throughout the page.
    * @zh 用于标记懒加载的曝光时机。请确保在整个页面中是唯一的。
-   * @defaultValue undefined
    * @Android
    * @iOS
    */

--- a/packages/lynx-ui-input/src/types/index.docs.ts
+++ b/packages/lynx-ui-input/src/types/index.docs.ts
@@ -175,7 +175,6 @@ export interface InputProps extends ComponentBasicProps {
   /**
    * Filter the input content and process it in the form of regular expressions
    * @zh 输入框内容过滤正则表达式
-   * @defaultValue undefined
    * @Android
    * @iOS
    * @Harmony

--- a/packages/lynx-ui-lazy-component/src/types/index.docs.ts
+++ b/packages/lynx-ui-lazy-component/src/types/index.docs.ts
@@ -15,7 +15,6 @@ export interface LazyComponentProps {
   /**
    * Be used to mark the exposure timing of lazy loading. Please ensure that it is unique throughout the page.
    * @zh 用于标记懒加载的曝光时机。请确保该标识在整个页面中是唯一的。
-   * @defaultValue undefined
    * @Android
    * @iOS
    */
@@ -23,7 +22,6 @@ export interface LazyComponentProps {
   /**
    * Be used to mark the exposure timing of lazy loading. Please ensure that it is unique throughout the page.
    * @zh 用于标记懒加载的曝光时机。请确保该标识在整个页面中是唯一的。
-   * @defaultValue undefined
    * @Android
    * @iOS
    */
@@ -31,7 +29,6 @@ export interface LazyComponentProps {
   /**
    * Estimated height and width need to be set
    * @zh 需要设置预估的高度和宽度
-   * @defaultValue undefined
    * @Android
    * @iOS
    */
@@ -88,7 +85,6 @@ export interface LazyComponentProps {
   /**
    * Children
    * @zh 子节点
-   * @defaultValue undefined
    * @Android
    * @iOS
    */


### PR DESCRIPTION
Clean up documentation by removing unnecessary @defaultValue undefined tags from interface.