### PR TITLE
fix: exclude Slider from public exports pending API review

### DIFF
--- a/.changeset/slider-readonly-prop.md
+++ b/.changeset/slider-readonly-prop.md
@@ -1,6 +1,0 @@
----
-'@lynx-js/lynx-ui': patch
-'@lynx-js/lynx-ui-slider': patch
----
-
-Rename the slider interaction lock prop to `readonly` and keep `disabled` as a deprecated compatibility alias.

--- a/apps/examples/Slider/Basic/index.tsx
+++ b/apps/examples/Slider/Basic/index.tsx
@@ -9,7 +9,7 @@ import {
   SliderRoot,
   SliderThumb,
   SliderTrack,
-} from '@lynx-js/lynx-ui'
+} from '@lynx-js/lynx-ui-slider'
 
 import './index.css'
 

--- a/apps/examples/Slider/Controlled/index.tsx
+++ b/apps/examples/Slider/Controlled/index.tsx
@@ -9,7 +9,7 @@ import {
   SliderRoot,
   SliderThumb,
   SliderTrack,
-} from '@lynx-js/lynx-ui'
+} from '@lynx-js/lynx-ui-slider'
 
 import './index.css'
 

--- a/apps/examples/Slider/DynamicWidth/index.tsx
+++ b/apps/examples/Slider/DynamicWidth/index.tsx
@@ -9,7 +9,7 @@ import {
   SliderRoot,
   SliderThumb,
   SliderTrack,
-} from '@lynx-js/lynx-ui'
+} from '@lynx-js/lynx-ui-slider'
 
 import './index.css'
 

--- a/apps/examples/Slider/Facade/index.tsx
+++ b/apps/examples/Slider/Facade/index.tsx
@@ -10,8 +10,8 @@ import {
   SliderRoot,
   SliderThumb,
   SliderTrack,
-} from '@lynx-js/lynx-ui'
-import type { SliderRef, SliderRootProps } from '@lynx-js/lynx-ui'
+} from '@lynx-js/lynx-ui-slider'
+import type { SliderRef, SliderRootProps } from '@lynx-js/lynx-ui-slider'
 
 import './index.css'
 

--- a/apps/examples/Slider/Progress/index.tsx
+++ b/apps/examples/Slider/Progress/index.tsx
@@ -4,7 +4,7 @@
 
 import { root, useEffect, useRef, useState } from '@lynx-js/react'
 
-import { SliderRange, SliderRoot, SliderTrack } from '@lynx-js/lynx-ui'
+import { SliderRange, SliderRoot, SliderTrack } from '@lynx-js/lynx-ui-slider'
 
 import './index.css'
 

--- a/apps/examples/Slider/Shapes/index.tsx
+++ b/apps/examples/Slider/Shapes/index.tsx
@@ -9,7 +9,7 @@ import {
   SliderRoot,
   SliderThumb,
   SliderTrack,
-} from '@lynx-js/lynx-ui'
+} from '@lynx-js/lynx-ui-slider'
 
 import './index.css'
 

--- a/apps/examples/Slider/WithScrollView/index.tsx
+++ b/apps/examples/Slider/WithScrollView/index.tsx
@@ -9,7 +9,7 @@ import {
   SliderRoot,
   SliderThumb,
   SliderTrack,
-} from '@lynx-js/lynx-ui'
+} from '@lynx-js/lynx-ui-slider'
 
 import './index.css'
 

--- a/apps/examples/Slider/package.json
+++ b/apps/examples/Slider/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@lynx-js/luna-styles": "workspace:*",
-    "@lynx-js/lynx-ui": "workspace:*",
+    "@lynx-js/lynx-ui-slider": "workspace:*",
     "@lynx-js/react": "catalog:"
   },
   "devDependencies": {

--- a/packages/lynx-ui-slider/package.json
+++ b/packages/lynx-ui-slider/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lynx-js/lynx-ui-slider",
   "version": "0.0.1",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-ui.git",

--- a/packages/lynx-ui/package.json
+++ b/packages/lynx-ui/package.json
@@ -45,7 +45,6 @@
     "@lynx-js/lynx-ui-radio-group": "workspace:*",
     "@lynx-js/lynx-ui-scroll-view": "workspace:*",
     "@lynx-js/lynx-ui-sheet": "workspace:*",
-    "@lynx-js/lynx-ui-slider": "workspace:*",
     "@lynx-js/lynx-ui-sortable": "workspace:*",
     "@lynx-js/lynx-ui-swipe-action": "workspace:*",
     "@lynx-js/lynx-ui-swiper": "workspace:*",

--- a/packages/lynx-ui/src/index.tsx
+++ b/packages/lynx-ui/src/index.tsx
@@ -240,23 +240,6 @@ export type {
   SwitchRenderProps,
 } from '@lynx-js/lynx-ui-switch'
 
-// slider
-export {
-  SliderRoot,
-  SliderTrack,
-  SliderRange,
-  SliderThumb,
-} from '@lynx-js/lynx-ui-slider'
-export type {
-  SliderRangeProps,
-  SliderRef,
-  SliderRootProps,
-  SliderThumbProps,
-  SliderTrackProps,
-  SliderUpdateValueOptions,
-  SliderValueChangeSource,
-} from '@lynx-js/lynx-ui-slider'
-
 export {
   SheetRoot,
   SheetContent,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         version: 0.11.2(@lynx-js/react@0.114.4(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 1.4.2(@rsbuild/core@1.6.0-beta.1)
+        version: 1.4.2(@rsbuild/core@1.6.15)
       '@rslib/core':
         specifier: 'catalog:'
         version: 0.16.1(typescript@5.9.3)
@@ -562,9 +562,9 @@ importers:
       '@lynx-js/luna-styles':
         specifier: workspace:*
         version: link:../../../luna/packages/luna-styles
-      '@lynx-js/lynx-ui':
+      '@lynx-js/lynx-ui-slider':
         specifier: workspace:*
-        version: link:../../../packages/lynx-ui
+        version: link:../../../packages/lynx-ui-slider
       '@lynx-js/react':
         specifier: 'catalog:'
         version: 0.113.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
@@ -809,9 +809,6 @@ importers:
       '@lynx-js/lynx-ui-sheet':
         specifier: workspace:*
         version: link:../lynx-ui-sheet
-      '@lynx-js/lynx-ui-slider':
-        specifier: workspace:*
-        version: link:../lynx-ui-slider
       '@lynx-js/lynx-ui-sortable':
         specifier: workspace:*
         version: link:../lynx-ui-sortable
@@ -7778,8 +7775,7 @@ snapshots:
 
   '@module-federation/error-codes@0.21.1': {}
 
-  '@module-federation/error-codes@0.21.6':
-    optional: true
+  '@module-federation/error-codes@0.21.6': {}
 
   '@module-federation/runtime-core@0.18.0':
     dependencies:
@@ -7795,7 +7791,6 @@ snapshots:
     dependencies:
       '@module-federation/error-codes': 0.21.6
       '@module-federation/sdk': 0.21.6
-    optional: true
 
   '@module-federation/runtime-tools@0.18.0':
     dependencies:
@@ -7811,7 +7806,6 @@ snapshots:
     dependencies:
       '@module-federation/runtime': 0.21.6
       '@module-federation/webpack-bundler-runtime': 0.21.6
-    optional: true
 
   '@module-federation/runtime@0.18.0':
     dependencies:
@@ -7830,14 +7824,12 @@ snapshots:
       '@module-federation/error-codes': 0.21.6
       '@module-federation/runtime-core': 0.21.6
       '@module-federation/sdk': 0.21.6
-    optional: true
 
   '@module-federation/sdk@0.18.0': {}
 
   '@module-federation/sdk@0.21.1': {}
 
-  '@module-federation/sdk@0.21.6':
-    optional: true
+  '@module-federation/sdk@0.21.6': {}
 
   '@module-federation/webpack-bundler-runtime@0.18.0':
     dependencies:
@@ -7853,7 +7845,6 @@ snapshots:
     dependencies:
       '@module-federation/runtime': 0.21.6
       '@module-federation/sdk': 0.21.6
-    optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -8118,7 +8109,6 @@ snapshots:
       '@swc/helpers': 0.5.18
       core-js: 3.47.0
       jiti: 2.6.1
-    optional: true
 
   '@rsbuild/plugin-check-syntax@1.3.0(@rsbuild/core@1.5.4)':
     dependencies:
@@ -8145,9 +8135,9 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-react@1.4.2(@rsbuild/core@1.6.0-beta.1)':
+  '@rsbuild/plugin-react@1.4.2(@rsbuild/core@1.6.15)':
     dependencies:
-      '@rsbuild/core': 1.6.0-beta.1
+      '@rsbuild/core': 1.6.15
       '@rspack/plugin-react-refresh': 1.5.3(react-refresh@0.18.0)
       react-refresh: 0.18.0
     transitivePeerDependencies:
@@ -8410,7 +8400,6 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 1.6.8
       '@rspack/binding-win32-ia32-msvc': 1.6.8
       '@rspack/binding-win32-x64-msvc': 1.6.8
-    optional: true
 
   '@rspack/core@1.5.2(@swc/helpers@0.5.18)':
     dependencies:
@@ -8435,12 +8424,10 @@ snapshots:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
       '@swc/helpers': 0.5.18
-    optional: true
 
   '@rspack/lite-tapable@1.0.1': {}
 
-  '@rspack/lite-tapable@1.1.0':
-    optional: true
+  '@rspack/lite-tapable@1.1.0': {}
 
   '@rspack/plugin-react-refresh@1.5.3(react-refresh@0.18.0)':
     dependencies:
@@ -9238,8 +9225,7 @@ snapshots:
 
   core-js@3.46.0: {}
 
-  core-js@3.47.0:
-    optional: true
+  core-js@3.47.0: {}
 
   core-util-is@1.0.3: {}
 

--- a/tools/scripts/check-aggregate-exports.mjs
+++ b/tools/scripts/check-aggregate-exports.mjs
@@ -26,6 +26,12 @@ function getPackageDirs() {
       name.startsWith('lynx-ui-') && name !== aggregatePackageName
     )
     .filter(name => fs.statSync(path.join(packagesDir, name)).isDirectory())
+    .filter(name => {
+      const pkgPath = path.join(packagesDir, name, 'package.json')
+      if (!fs.existsSync(pkgPath)) return true
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+      return pkg.private !== true
+    })
     .sort()
 }
 


### PR DESCRIPTION
## Summary

Slider was merged but has not passed API review. This PR excludes it from
the public release surface until all issues are resolved.

- Tracking issue: #124
- Original PR: #109 

## Changes

- `@lynx-js/lynx-ui-slider`: mark as `private: true`
- `@lynx-js/lynx-ui`: remove Slider from public exports
- `@lynx-example/lynx-ui-slider`: temporarily depend on `@lynx-js/lynx-ui-slider`
  directly, as Slider has been removed from `@lynx-js/lynx-ui` exports
- Remove premature changeset

## Notes

Slider will remain excluded until Issue #124 is fully resolved and re-reviewed.

The `pnpm-lock.yaml` changes reflect lockfile regeneration during branch sync
with `origin/main` and are unrelated to this PR's intent. No dependencies were
intentionally added or upgraded.