### PR TITLE
docs(checkbox): fix checkboxProps description typo

### DIFF
--- a/.changeset/cool-feet-occur.md
+++ b/.changeset/cool-feet-occur.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-checkbox": patch
+---
+
+Fix checkbox docs typo in the `checkboxProps` description.

--- a/packages/lynx-ui-checkbox/docs/APIReference.mdx
+++ b/packages/lynx-ui-checkbox/docs/APIReference.mdx
@@ -10,7 +10,7 @@ import { UIApiTable } from "@lynx-ui/index";
     "summary": [
       {
         "kind": "text",
-        "text": "Radio supports original view props to be directly spread in this prop."
+        "text": "Checkbox supports original view props to be directly spread in this prop."
       }
     ],
     "summary_zh": "Checkbox 支持将原始视图属性直接展开到这个属性中。",
@@ -241,5 +241,3 @@ import { UIApiTable } from "@lynx-ui/index";
     "docTypeFallback": null
   }
 ]}/>
-      
-  

--- a/packages/lynx-ui-checkbox/docs/APIReference.zh.mdx
+++ b/packages/lynx-ui-checkbox/docs/APIReference.zh.mdx
@@ -10,7 +10,7 @@ import { UIApiTable } from "@lynx-ui/index";
     "summary": [
       {
         "kind": "text",
-        "text": "Radio supports original view props to be directly spread in this prop."
+        "text": "Checkbox supports original view props to be directly spread in this prop."
       }
     ],
     "summary_zh": "Checkbox 支持将原始视图属性直接展开到这个属性中。",
@@ -241,5 +241,3 @@ import { UIApiTable } from "@lynx-ui/index";
     "docTypeFallback": null
   }
 ]}/>
-      
-  

--- a/packages/lynx-ui-checkbox/src/types/index.docs.ts
+++ b/packages/lynx-ui-checkbox/src/types/index.docs.ts
@@ -47,7 +47,7 @@ export interface CheckboxProps extends ComponentBasicProps {
    */
   onChange?: (checked: boolean) => void
   /**
-   * Radio supports original view props to be directly spread in this prop.
+   * Checkbox supports original view props to be directly spread in this prop.
    * @Android
    * @iOS
    * @zh Checkbox 支持将原始视图属性直接展开到这个属性中。


### PR DESCRIPTION
- Fix `@lynx-js/lynx-ui-checkbox` docs typo: `checkboxProps` description mistakenly said “Radio”, now “Checkbox”.
- Add changeset for patch release.
- Verified: `pnpm run build`, `pnpm run check`.