### PR TITLE
refactor(slider): align primitive props with ComponentBasicProps

### DIFF
--- a/.changeset/slider-component-basic-props.md
+++ b/.changeset/slider-component-basic-props.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-slider": patch
+---
+
+Align slider primitive props with `ComponentBasicProps`.

--- a/packages/lynx-ui-slider/README.md
+++ b/packages/lynx-ui-slider/README.md
@@ -4,8 +4,6 @@ A primitives-first slider component package for lynx-ui.
 
 ## Installation
 
-We strongly recommend consuming this through the aggregate package:
-
 ```bash
 # pnpm (recommended)
 pnpm add @lynx-js/lynx-ui
@@ -17,15 +15,11 @@ npm install @lynx-js/lynx-ui
 yarn add @lynx-js/lynx-ui
 ```
 
-If needed, you can install the standalone package directly:
-
-```bash
-pnpm add @lynx-js/lynx-ui-slider
-```
+_(If necessary, you can still install the standalone package via `pnpm add @lynx-js/lynx-ui-slider`)_
 
 ## Usage
 
-### Primitive Composition (Recommended)
+### Primitive Composition
 
 ```tsx
 import {
@@ -38,10 +32,11 @@ import {
 export function SliderPrimitiveDemo() {
   return (
     <SliderRoot
-      defaultProgress={0.35}
-      onSeek={(value) => console.log(value)}
+      defaultValue={0.35}
+      onValueChange={(value, source) => console.log(value, source)}
+      onValueCommit={(value) => console.log('commit', value)}
     >
-      <SliderTrack />
+      <SliderTrack className='slider-track' />
       <SliderRange className='slider-range'>
         <SliderThumb className='slider-thumb-wrapper'>
           <view className='slider-thumb-dot' />
@@ -49,16 +44,6 @@ export function SliderPrimitiveDemo() {
       </SliderRange>
     </SliderRoot>
   )
-}
-```
-
-### Compatibility Facade
-
-```tsx
-import { Slider } from '@lynx-js/lynx-ui'
-
-export function SliderFacadeDemo() {
-  return <Slider defaultProgress={0.5} />
 }
 ```
 
@@ -75,13 +60,12 @@ export function SliderFacadeDemo() {
 </SliderRoot>
 ```
 
-- **`SliderRoot`**: owns interaction logic and imperative methods.
+- **`SliderRoot`**: owns interaction logic and exposes `SliderRef` imperative methods in uncontrolled mode.
 - **`SliderTrack`**: renders background track.
 - **`SliderRange`**: renders the active progress range and owns its width.
 - **`SliderThumb`**: renders thumb content passed through `children`.
-- **`Slider`**: compatibility facade built from primitives.
 
-Styling for track/thumb size and colors is expected to be done through CSS (`className`/`class`) or inline `style`, instead of dedicated style props.
+Styling for track/thumb size and colors is expected to be done through `className` or inline `style`, instead of dedicated style props.
 
 ### About Track/Thumb Centering
 

--- a/packages/lynx-ui-slider/SKILL.md
+++ b/packages/lynx-ui-slider/SKILL.md
@@ -5,12 +5,13 @@
 ## 1. Core Capabilities
 
 - **Primitives Composition**: Build slider UI with `SliderRoot` + `SliderTrack` + `SliderRange` + `SliderThumb`.
+- **Shared Base Props**: All primitives inherit `className` and `style` from `ComponentBasicProps`.
 - **Controlled & Uncontrolled Modes**: Use `value` + `onValueChange` for controlled mode, or `defaultValue` for uncontrolled mode.
 - **Imperative API** (uncontrolled only): Access `updateValue` and `getValue` through `SliderRef`. Throws in controlled mode.
 - **RTL Support**: Set `enableRTL` to reverse range direction (right-to-left).
 - **Stepping**: Set `step` to snap values to discrete increments.
 - **Readonly Mode**: Set `readonly` to prevent dragging while still displaying the current value.
-- **Interaction Callbacks**: `onDragging(value)`, `onValueChange(value, source)`, `onValueCommit(value)`.
+- **Interaction Callbacks**: `onDragging(value)` when dragging starts, `onValueChange(value, source)` for slider-driven updates, `onValueCommit(value)` at drag end.
 - **Headless Styling**: Supports styling via `className` and `style` props on every primitive.
 
 ## 2. AI Coding Guide
@@ -99,16 +100,18 @@ function ControlledSlider() {
 
 ### SliderRootProps
 
-| Prop            | Type                              | Default | Description                                                      |
-| --------------- | --------------------------------- | ------- | ---------------------------------------------------------------- |
-| `value`         | `number`                          | —       | Controlled value `[0, 1]`. Do not use with `defaultValue`.       |
-| `defaultValue`  | `number`                          | `0`     | Initial value for uncontrolled mode.                             |
-| `step`          | `number`                          | —       | Snap interval in `[0, 1]`.                                       |
-| `readonly`      | `boolean`                         | `false` | Prevent interaction while keeping the slider value visible.      |
-| `enableRTL`     | `boolean`                         | `false` | Reverse range direction (right-to-left).                         |
-| `onDragging`    | `(value: number) => void`         | —       | Fires during drag with current value.                            |
-| `onValueChange` | `(value: number, source) => void` | —       | Fires on every value change. Source is `'drag'` or `'external'`. |
-| `onValueCommit` | `(value: number) => void`         | —       | Fires at drag end with final value.                              |
+`SliderRootProps`, `SliderTrackProps`, `SliderRangeProps`, and `SliderThumbProps` all inherit `className` and `style` from `ComponentBasicProps`.
+
+| Prop            | Type                              | Default | Description                                                                         |
+| --------------- | --------------------------------- | ------- | ----------------------------------------------------------------------------------- |
+| `value`         | `number`                          | —       | Controlled value `[0, 1]`. Do not use with `defaultValue`.                          |
+| `defaultValue`  | `number`                          | `0`     | Initial value for uncontrolled mode.                                                |
+| `step`          | `number`                          | —       | Snap interval in `[0, 1]`.                                                          |
+| `readonly`      | `boolean`                         | `false` | Prevent interaction while keeping the slider value visible.                         |
+| `enableRTL`     | `boolean`                         | `false` | Reverse range direction (right-to-left).                                            |
+| `onDragging`    | `(value: number) => void`         | —       | Fires once when the interaction enters dragging state.                              |
+| `onValueChange` | `(value: number, source) => void` | —       | Fires for drag updates and `updateValue` calls. Source is `'drag'` or `'external'`. |
+| `onValueCommit` | `(value: number) => void`         | —       | Fires at drag end with final value.                                                 |
 
 ### SliderRef (uncontrolled only)
 
@@ -123,9 +126,9 @@ function ControlledSlider() {
 
 A: Use controlled (`value` + `onValueChange`) when you need to sync slider state with external state. Use uncontrolled (`defaultValue`) for simpler cases where internal state suffices.
 
-**Q: What is the difference between `onValueChange` and `onValueCommit`?**
+**Q: What is the difference between `onDragging`, `onValueChange`, and `onValueCommit`?**
 
-A: `onValueChange` fires on every value change (including during drag). `onValueCommit` fires once at drag end — useful for persisting the final value.
+A: `onDragging` fires once when dragging starts. `onValueChange` fires for slider-driven value updates during drag and imperative `updateValue` calls. `onValueCommit` fires once at drag end — useful for persisting the final value.
 
 **Q: Is `disabled` still supported?**
 

--- a/packages/lynx-ui-slider/src/types/index.docs.ts
+++ b/packages/lynx-ui-slider/src/types/index.docs.ts
@@ -4,6 +4,8 @@
 
 import type { ReactNode } from '@lynx-js/react'
 
+import type { ComponentBasicProps } from '@lynx-js/lynx-ui-common'
+
 /**
  * Source of a value change.
  *
@@ -66,7 +68,7 @@ export interface SliderRef {
  *
  * `SliderRoot` 负责交互逻辑（拖拽、值跟踪）并为子原语组件提供上下文。
  */
-export interface SliderRootProps {
+export interface SliderRootProps extends ComponentBasicProps {
   /**
    * Controlled value in range `[0, 1]`. When provided, the slider is in controlled mode. Do not use together with `defaultValue`.
    * @zh 受控模式下的值，范围 `[0, 1]`。传入此属性时滑块为受控模式，请勿与 `defaultValue` 同时使用。
@@ -100,23 +102,13 @@ export interface SliderRootProps {
    */
   enableRTL?: boolean
   /**
-   * Class name for the root container.
-   * @zh 根容器的类名。
-   */
-  className?: string
-  /**
-   * Inline style for the root container.
-   * @zh 根容器的内联样式。
-   */
-  style?: Record<string, unknown>
-  /**
-   * Triggered during dragging with the current progress value.
-   * @zh 拖拽过程中触发，传入当前进度值。
+   * Triggered once when an interaction enters dragging state, with the current progress value.
+   * @zh 交互进入拖拽态时触发一次，传入当前进度值。
    */
   onDragging?: (value: number) => void
   /**
-   * Triggered on every value change.  In controlled mode, the slider does **not** update its internal value automatically; use this callback to update the controlled `value` prop.
-   * @zh 每次值变更时触发。在受控模式下，滑块不会自动更新内部值，需要通过此回调更新外部的 `value` 属性。
+   * Triggered for slider-driven value updates, including dragging and `SliderRef.updateValue`. In controlled mode, the slider does **not** update its internal value automatically; use this callback to update the controlled `value` prop.
+   * @zh 由滑块自身驱动的值更新时触发，包括拖拽和 `SliderRef.updateValue`。在受控模式下，滑块不会自动更新内部值，需要通过此回调更新外部的 `value` 属性。
    */
   onValueChange?: (value: number, source: SliderValueChangeSource) => void
   /**
@@ -135,18 +127,7 @@ export interface SliderRootProps {
  * Track primitive props.
  * @zh 轨道原语组件属性。
  */
-export interface SliderTrackProps {
-  /**
-   * Class name for the background track.
-   * @zh 背景轨道的类名。
-   */
-  className?: string
-  /**
-   * Inline style for background track.
-   * @zh 背景轨道的内联样式。
-   */
-  style?: Record<string, unknown>
-}
+export interface SliderTrackProps extends ComponentBasicProps {}
 
 /**
  * Range primitive props.
@@ -157,17 +138,7 @@ export interface SliderTrackProps {
  *
  * `SliderRange` 的宽度和前景条由根组件的值控制。
  */
-export interface SliderRangeProps {
-  /**
-   * Class name for the foreground range bar.
-   * @zh 前景范围条的类名。
-   */
-  className?: string
-  /**
-   * Inline style for the foreground range bar.
-   * @zh 前景范围条的内联样式。
-   */
-  style?: Record<string, unknown>
+export interface SliderRangeProps extends ComponentBasicProps {
   /**
    * Usually includes `SliderThumb` and optional custom range content.
    * @zh 通常包含 `SliderThumb` 及可选的自定义范围内容。
@@ -179,17 +150,7 @@ export interface SliderRangeProps {
  * Thumb primitive props.
  * @zh 滑块拇指原语组件属性。
  */
-export interface SliderThumbProps {
-  /**
-   * Class name for the thumb wrapper.
-   * @zh 拇指包裹元素的类名。
-   */
-  className?: string
-  /**
-   * Inline style for the thumb wrapper.
-   * @zh 拇指包裹元素的内联样式。
-   */
-  style?: Record<string, unknown>
+export interface SliderThumbProps extends ComponentBasicProps {
   /**
    * Custom thumb content.
    * @zh 自定义拇指内容。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Slider is now a standalone package — update imports to the slider package.
  * Props changed: `defaultProgress`/`onSeek` replaced by `defaultValue`, `onValueChange`, and `onValueCommit`.
  * Built-in Slider compatibility wrapper removed — compose custom wrappers as needed.

* **New Features**
  * All slider primitives inherit shared base props (className/style) for consistent styling.

* **Documentation**
  * Installation, examples, and callback timing (onDragging/onValueChange) clarified and updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->