### PR TITLE
feat: default sheet snap points to fit

### DIFF
--- a/.changeset/short-sheets-fit.md
+++ b/.changeset/short-sheets-fit.md
@@ -1,0 +1,6 @@
+---
+'@lynx-js/lynx-ui-sheet': minor
+'@lynx-js/lynx-ui': minor
+---
+
+Default `Sheet` snap points to `['fit']` so sheets fit measured content when `snapPoints` is omitted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,11 @@ Documentation should be treated as code. While AI can draft updates, humans must
 3. **Scope of `AGENTS.md`**:
    - Keep `AGENTS.md` focused on repository workflow, build, verification, and contribution guidance.
    - Do not add component-specific usage, prop documentation, examples, or design guidance to `AGENTS.md`; put that information in the component README, typedoc comments, examples, or component `SKILL.md`.
-4. **Code Review**:
+4. **Package README Scope**:
+   - Keep package `README.md` files high-level. They should describe purpose, installation, component structure, and point readers to examples or API docs.
+   - Do not turn package READMEs into step-by-step usage manuals by appending narrow usage rules or behavioral footnotes for every change.
+   - Put detailed behavior guidance, caveats, and prompt-oriented instructions in typed API docs, examples, component `SKILL.md`, or `AGENTS.md` when that context is the better fit.
+5. **Code Review**:
    - Documentation changes must be included in the same Pull Request as the code changes.
    - Reviewers should verify that `AGENTS.md` and `SKILL.md` accurately reflect the code changes.
 

--- a/packages/lynx-ui-sheet/src/SheetContent/index.tsx
+++ b/packages/lynx-ui-sheet/src/SheetContent/index.tsx
@@ -10,7 +10,7 @@ import { useSnap, useSnapTouches } from '../hooks'
 import type { SheetContentProps, SheetTransition } from '../types'
 import { getDefaultRubberBand } from '../utils'
 
-const DEFAULT_SNAP_POINTS: Array<number | string> = []
+const DEFAULT_SNAP_POINTS: Array<number | string> = ['fit']
 const DEFAULT_TRANSITION: SheetTransition = {
   type: 'spring',
   stiffness: 200,

--- a/packages/lynx-ui-sheet/src/types/index.docs.ts
+++ b/packages/lynx-ui-sheet/src/types/index.docs.ts
@@ -161,6 +161,7 @@ export interface SheetRootProps extends ComponentBasicProps {
    *   and relative to screen width for `left` / `right` / `start` / `end`
    * - 'fit' dynamically resolves to the measured content height for `top` / `bottom`,
    *   and the measured content width for `left` / `right` / `start` / `end`
+   * @defaultValue ['fit']
    * The index order follows the order of this array.
    * @example snapPoints={['fit', '80%']} // First snap fits content, second is 80% of screen
    * @zh Sheet 的吸附点。可以是像素数值、百分比或 'fit'。


### PR DESCRIPTION
## Summary

- default `Sheet` `snapPoints` to `['fit']` when the prop is omitted
- document the new default in the typed API docs
- add a changeset for `@lynx-js/lynx-ui-sheet` and `@lynx-js/lynx-ui`
- add an `AGENTS.md` rule that package READMEs should stay high-level rather than become usage manuals

## Scope

This PR intentionally contains only the default snap-point behavior change. The directional `Sheet` work is tracked separately and is not included here.

## Validation

- `pnpm exec dprint check AGENTS.md .changeset/short-sheets-fit.md`
- `pnpm check:exports`

## Notes

In a fresh `main`-based worktree, package builds are currently blocked by existing declaration-generation issues in upstream dependencies (`@lynx-js/lynx-ui-presence` / `@lynx-js/lynx-ui-overlay`) that are independent of this patch.
