### PR TITLE
refactor(slider): restructure Slider component anatomy

### DIFF
--- a/apps/examples/Slider/Basic/index.css
+++ b/apps/examples/Slider/Basic/index.css
@@ -84,7 +84,7 @@
   background-color: var(--neutral-faint);
 }
 
-.slider-range {
+.slider-indicator {
   width: 100%;
   height: 4px;
   border-radius: 9999px;
@@ -93,9 +93,6 @@
 }
 
 .slider-thumb-wrapper {
-  position: absolute;
-  top: 0;
-  right: -18px;
   width: 36px;
   height: 36px;
   display: flex;
@@ -122,16 +119,4 @@
 
 .rtl-card {
   direction: rtl;
-}
-
-.slider-thumb-wrapper-rtl {
-  position: absolute;
-  top: 0;
-  left: -18px;
-  right: auto;
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }

--- a/apps/examples/Slider/Basic/index.tsx
+++ b/apps/examples/Slider/Basic/index.tsx
@@ -5,7 +5,7 @@
 import { root, useState } from '@lynx-js/react'
 
 import {
-  SliderRange,
+  SliderIndicator,
   SliderRoot,
   SliderThumb,
   SliderTrack,
@@ -41,12 +41,12 @@ function App() {
                 setVariantValue(value)
               }}
             >
-              <SliderTrack className='slider-track' />
-              <SliderRange className='slider-range'>
+              <SliderTrack className='slider-track'>
+                <SliderIndicator className='slider-indicator' />
                 <SliderThumb className='slider-thumb-wrapper'>
                   <view className='slider-thumb-pill' />
                 </SliderThumb>
-              </SliderRange>
+              </SliderTrack>
             </SliderRoot>
           </view>
 
@@ -55,14 +55,14 @@ function App() {
             <SliderRoot
               className='slider-root ui-disabled'
               defaultValue={0.45}
-              readonly
+              disabled
             >
-              <SliderTrack className='slider-track' />
-              <SliderRange className='slider-range'>
+              <SliderTrack className='slider-track'>
+                <SliderIndicator className='slider-indicator' />
                 <SliderThumb className='slider-thumb-wrapper'>
                   <view className='slider-thumb' />
                 </SliderThumb>
-              </SliderRange>
+              </SliderTrack>
             </SliderRoot>
           </view>
         </view>
@@ -70,8 +70,8 @@ function App() {
         <view className='section'>
           <text className='title'>RTL</text>
           <text className='desc'>
-            A slider with `enableRTL` and CSS `direction: rtl`. The range grows
-            from right to left.
+            A slider with `enableRTL` and CSS `direction: rtl`. The indicator
+            grows from right to left.
           </text>
 
           <view className='row rtl-card'>
@@ -86,12 +86,12 @@ function App() {
                 setRtlValue(value)
               }}
             >
-              <SliderTrack className='slider-track' />
-              <SliderRange className='slider-range'>
-                <SliderThumb className='slider-thumb-wrapper slider-thumb-wrapper-rtl'>
+              <SliderTrack className='slider-track'>
+                <SliderIndicator className='slider-indicator' />
+                <SliderThumb className='slider-thumb-wrapper'>
                   <view className='slider-thumb' />
                 </SliderThumb>
-              </SliderRange>
+              </SliderTrack>
             </SliderRoot>
           </view>
         </view>

--- a/apps/examples/Slider/Controlled/index.css
+++ b/apps/examples/Slider/Controlled/index.css
@@ -76,7 +76,7 @@
   background-color: var(--neutral-faint);
 }
 
-.slider-range {
+.slider-indicator {
   width: 100%;
   height: 4px;
   border-radius: 9999px;
@@ -85,9 +85,6 @@
 }
 
 .slider-thumb-wrapper {
-  position: absolute;
-  top: 0;
-  right: -18px;
   width: 36px;
   height: 36px;
   display: flex;

--- a/apps/examples/Slider/Controlled/index.tsx
+++ b/apps/examples/Slider/Controlled/index.tsx
@@ -5,7 +5,7 @@
 import { root, useState } from '@lynx-js/react'
 
 import {
-  SliderRange,
+  SliderIndicator,
   SliderRoot,
   SliderThumb,
   SliderTrack,
@@ -53,12 +53,12 @@ function App() {
                 setPrimitiveDragging(false)
               }}
             >
-              <SliderTrack className='slider-track' />
-              <SliderRange className='slider-range'>
+              <SliderTrack className='slider-track'>
+                <SliderIndicator className='slider-indicator' />
                 <SliderThumb className='slider-thumb-wrapper'>
                   <view className='slider-thumb' />
                 </SliderThumb>
-              </SliderRange>
+              </SliderTrack>
             </SliderRoot>
 
             <view className='preset-row'>
@@ -97,12 +97,12 @@ function App() {
                 setSteppedValue(value)
               }}
             >
-              <SliderTrack className='slider-track' />
-              <SliderRange className='slider-range'>
+              <SliderTrack className='slider-track'>
+                <SliderIndicator className='slider-indicator' />
                 <SliderThumb className='slider-thumb-wrapper'>
                   <view className='slider-thumb' />
                 </SliderThumb>
-              </SliderRange>
+              </SliderTrack>
             </SliderRoot>
           </view>
         </view>

--- a/apps/examples/Slider/DynamicWidth/index.css
+++ b/apps/examples/Slider/DynamicWidth/index.css
@@ -76,7 +76,7 @@
   background-color: var(--neutral-faint);
 }
 
-.slider-range {
+.slider-indicator {
   width: 100%;
   height: 4px;
   border-radius: 9999px;
@@ -85,9 +85,6 @@
 }
 
 .slider-thumb-wrapper {
-  position: absolute;
-  top: 0;
-  right: -18px;
   width: 36px;
   height: 36px;
   display: flex;

--- a/apps/examples/Slider/DynamicWidth/index.tsx
+++ b/apps/examples/Slider/DynamicWidth/index.tsx
@@ -5,7 +5,7 @@
 import { root, useState } from '@lynx-js/react'
 
 import {
-  SliderRange,
+  SliderIndicator,
   SliderRoot,
   SliderThumb,
   SliderTrack,
@@ -31,7 +31,7 @@ function App() {
           <text className='title'>Dynamic Width</text>
           <text className='desc'>
             Tap the buttons below to change the slider container width. This
-            tests the `onLayoutChange` handler re-measuring correctly.
+            tests the track layout measurement updating correctly.
           </text>
 
           <view className='row'>
@@ -45,12 +45,12 @@ function App() {
                 setValue(v)
               }}
             >
-              <SliderTrack className='slider-track' />
-              <SliderRange className='slider-range'>
+              <SliderTrack className='slider-track'>
+                <SliderIndicator className='slider-indicator' />
                 <SliderThumb className='slider-thumb-wrapper'>
                   <view className='slider-thumb' />
                 </SliderThumb>
-              </SliderRange>
+              </SliderTrack>
             </SliderRoot>
 
             <view className='width-row'>

--- a/apps/examples/Slider/Facade/index.css
+++ b/apps/examples/Slider/Facade/index.css
@@ -84,7 +84,7 @@
   background-color: var(--neutral-faint);
 }
 
-.slider-range {
+.slider-indicator {
   width: 100%;
   height: 4px;
   border-radius: 9999px;
@@ -93,9 +93,6 @@
 }
 
 .slider-thumb-wrapper {
-  position: absolute;
-  top: 0;
-  right: -18px;
   width: 36px;
   height: 36px;
   display: flex;

--- a/apps/examples/Slider/Facade/index.tsx
+++ b/apps/examples/Slider/Facade/index.tsx
@@ -6,7 +6,7 @@ import { forwardRef, memo, root, useState } from '@lynx-js/react'
 import type { ForwardedRef, ReactNode } from '@lynx-js/react'
 
 import {
-  SliderRange,
+  SliderIndicator,
   SliderRoot,
   SliderThumb,
   SliderTrack,
@@ -18,7 +18,7 @@ import './index.css'
 interface SliderProps extends Omit<SliderRootProps, 'children'> {
   thumb?: ReactNode
   trackClassName?: string
-  rangeClassName?: string
+  indicatorClassName?: string
   thumbWrapperClassName?: string
 }
 
@@ -30,19 +30,19 @@ const Slider = memo(
     const {
       thumb,
       trackClassName,
-      rangeClassName,
+      indicatorClassName,
       thumbWrapperClassName,
       ...rootProps
     } = props
 
     return (
       <SliderRoot ref={ref} {...rootProps}>
-        <SliderTrack className={trackClassName} />
-        <SliderRange className={rangeClassName}>
+        <SliderTrack className={trackClassName}>
+          <SliderIndicator className={indicatorClassName} />
           <SliderThumb className={thumbWrapperClassName}>
             {thumb}
           </SliderThumb>
-        </SliderRange>
+        </SliderTrack>
       </SliderRoot>
     )
   }),
@@ -74,7 +74,7 @@ function App() {
               className='slider-root'
               defaultValue={0.4}
               trackClassName='slider-track'
-              rangeClassName='slider-range'
+              indicatorClassName='slider-indicator'
               thumbWrapperClassName='slider-thumb-wrapper'
               thumb={<view className='slider-thumb' />}
               onValueChange={(value: number) => {
@@ -91,7 +91,7 @@ function App() {
               className='slider-root'
               defaultValue={0.72}
               trackClassName='slider-track'
-              rangeClassName='slider-range'
+              indicatorClassName='slider-indicator'
               thumbWrapperClassName='slider-thumb-wrapper'
               thumb={<view className='slider-thumb-pill' />}
               onValueChange={(value: number) => {
@@ -105,9 +105,9 @@ function App() {
             <Slider
               className='slider-root'
               defaultValue={0.45}
-              readonly
+              disabled
               trackClassName='slider-track'
-              rangeClassName='slider-range'
+              indicatorClassName='slider-indicator'
               thumbWrapperClassName='slider-thumb-wrapper'
               thumb={<view className='slider-thumb' />}
             />

--- a/apps/examples/Slider/Progress/index.css
+++ b/apps/examples/Slider/Progress/index.css
@@ -83,20 +83,20 @@
 }
 
 .progress-track {
+  position: relative;
   width: 100%;
   height: 6px;
   border-radius: 9999px;
   background-color: var(--neutral-faint);
 }
 
-.progress-range {
-  width: 100%;
-  height: 6px;
+.progress-indicator {
+  height: 100%;
   border-radius: 9999px;
   background: var(--primary);
 }
 
-.progress-range-secondary {
+.progress-indicator-secondary {
   background: var(--secondary);
 }
 

--- a/apps/examples/Slider/Progress/index.tsx
+++ b/apps/examples/Slider/Progress/index.tsx
@@ -4,7 +4,11 @@
 
 import { root, useEffect, useRef, useState } from '@lynx-js/react'
 
-import { SliderRange, SliderRoot, SliderTrack } from '@lynx-js/lynx-ui-slider'
+import {
+  SliderIndicator,
+  SliderRoot,
+  SliderTrack,
+} from '@lynx-js/lynx-ui-slider'
 
 import './index.css'
 
@@ -45,8 +49,8 @@ function App() {
         <view className='section'>
           <text className='title'>Progress (No Thumb)</text>
           <text className='desc'>
-            SliderRoot + SliderRange without SliderThumb, used as a read-only
-            progress indicator.
+            SliderRoot + SliderIndicator without SliderThumb, used as a
+            read-only progress indicator.
           </text>
 
           <view className='progress-row'>
@@ -59,10 +63,11 @@ function App() {
             <SliderRoot
               className='progress-root'
               value={downloadProgress}
-              readonly
+              disabled
             >
-              <SliderTrack className='progress-track' />
-              <SliderRange className='progress-range' />
+              <SliderTrack className='progress-track'>
+                <SliderIndicator className='progress-indicator' />
+              </SliderTrack>
             </SliderRoot>
           </view>
 
@@ -76,10 +81,11 @@ function App() {
             <SliderRoot
               className='progress-root'
               value={uploadProgress}
-              readonly
+              disabled
             >
-              <SliderTrack className='progress-track' />
-              <SliderRange className='progress-range progress-range-secondary' />
+              <SliderTrack className='progress-track'>
+                <SliderIndicator className='progress-indicator progress-indicator-secondary' />
+              </SliderTrack>
             </SliderRoot>
           </view>
         </view>
@@ -98,10 +104,11 @@ function App() {
                   <SliderRoot
                     className='progress-root'
                     value={v}
-                    readonly
+                    disabled
                   >
-                    <SliderTrack className='progress-track' />
-                    <SliderRange className='progress-range' />
+                    <SliderTrack className='progress-track'>
+                      <SliderIndicator className='progress-indicator' />
+                    </SliderTrack>
                   </SliderRoot>
                 </view>
               </view>

--- a/apps/examples/Slider/Shapes/index.css
+++ b/apps/examples/Slider/Shapes/index.css
@@ -62,14 +62,11 @@
 }
 
 .slider-root {
-  --slider-thumb-width: 36px;
-  --slider-thumb-half-width: 18px;
-  --slider-thumb-half-width-negative: -18px;
   position: relative;
   width: auto;
   height: 36px;
-  margin-left: var(--slider-thumb-half-width);
-  margin-right: var(--slider-thumb-half-width);
+  margin-left: 18px;
+  margin-right: 18px;
   display: flex;
   align-items: center;
 }
@@ -77,27 +74,24 @@
 .slider-track {
   position: absolute;
   top: 0;
-  left: var(--slider-thumb-half-width-negative);
-  right: var(--slider-thumb-half-width-negative);
+  left: -18px;
+  right: -18px;
   height: 36px;
   border-radius: 18px;
   background-color: var(--neutral-faint);
 }
 
-.slider-range {
+.slider-indicator {
   position: absolute;
   top: 0;
-  left: var(--slider-thumb-half-width-negative);
-  right: var(--slider-thumb-half-width-negative);
+  left: -18px;
+  right: -18px;
   height: 36px;
   border-radius: 18px;
   background: var(--primary);
 }
 
 .slider-thumb-wrapper {
-  position: absolute;
-  top: 0;
-  right: var(--slider-thumb-half-width-negative);
   width: 36px;
   height: 36px;
   display: flex;
@@ -129,7 +123,7 @@
   background: linear-gradient(90deg, var(--primary), var(--primary-2));
 }
 
-.slider-range-gradient {
+.slider-indicator-gradient {
   background: transparent;
 }
 
@@ -141,7 +135,7 @@
   background-color: var(--neutral-faint);
 }
 
-.slider-range-secondary {
+.slider-indicator-secondary {
   background: var(--primary);
 }
 
@@ -192,7 +186,7 @@
   background-color: var(--neutral-faint);
 }
 
-.slider-range-pill {
+.slider-indicator-pill {
   width: 100%;
   height: 24px;
   border-top-left-radius: 3px;
@@ -202,9 +196,6 @@
 }
 
 .slider-thumb-pill-wrapper {
-  position: absolute;
-  top: 0;
-  right: -18px;
   width: 36px;
   height: 36px;
   display: flex;

--- a/apps/examples/Slider/Shapes/index.tsx
+++ b/apps/examples/Slider/Shapes/index.tsx
@@ -5,7 +5,7 @@
 import { root, useState } from '@lynx-js/react'
 
 import {
-  SliderRange,
+  SliderIndicator,
   SliderRoot,
   SliderThumb,
   SliderTrack,
@@ -45,12 +45,12 @@ function App() {
                 setFullValue(value)
               }}
             >
-              <SliderTrack className='slider-track' />
-              <SliderRange className='slider-range'>
+              <SliderTrack className='slider-track'>
+                <SliderIndicator className='slider-indicator' />
                 <SliderThumb className='slider-thumb-wrapper'>
                   <view className='slider-thumb-dot' />
                 </SliderThumb>
-              </SliderRange>
+              </SliderTrack>
             </SliderRoot>
           </view>
 
@@ -65,14 +65,14 @@ function App() {
                 setGradientValue(value)
               }}
             >
-              <SliderTrack className='slider-track slider-track-gradient' />
-              <SliderRange className='slider-range slider-range-gradient'>
+              <SliderTrack className='slider-track slider-track-gradient'>
+                <SliderIndicator className='slider-indicator slider-indicator-gradient' />
                 <SliderThumb className='slider-thumb-wrapper slider-thumb-wrapper-gradient'>
                   <view className='slider-thumb-dot'>
                     <view className='slider-thumb-dot-ring' />
                   </view>
                 </SliderThumb>
-              </SliderRange>
+              </SliderTrack>
             </SliderRoot>
           </view>
 
@@ -87,12 +87,12 @@ function App() {
                 setSecondaryValue(value)
               }}
             >
-              <SliderTrack className='slider-track slider-track-secondary' />
-              <SliderRange className='slider-range slider-range-secondary'>
+              <SliderTrack className='slider-track slider-track-secondary'>
+                <SliderIndicator className='slider-indicator slider-indicator-secondary' />
                 <SliderThumb className='slider-thumb-wrapper'>
                   <view className='slider-thumb-ring' />
                 </SliderThumb>
-              </SliderRange>
+              </SliderTrack>
             </SliderRoot>
           </view>
 
@@ -107,14 +107,14 @@ function App() {
                 setInvertedRingValue(value)
               }}
             >
-              <SliderTrack className='slider-track slider-track-inverted' />
-              <SliderRange className='slider-range'>
+              <SliderTrack className='slider-track slider-track-inverted'>
+                <SliderIndicator className='slider-indicator' />
                 <SliderThumb className='slider-thumb-wrapper'>
                   <view className='slider-thumb-ring-inverted'>
                     <view className='slider-thumb-dot-ring-inverted' />
                   </view>
                 </SliderThumb>
-              </SliderRange>
+              </SliderTrack>
             </SliderRoot>
           </view>
 
@@ -129,12 +129,12 @@ function App() {
                 setPillValue(value)
               }}
             >
-              <SliderTrack className='slider-track-pill' />
-              <SliderRange className='slider-range-pill'>
+              <SliderTrack className='slider-track-pill'>
+                <SliderIndicator className='slider-indicator-pill' />
                 <SliderThumb className='slider-thumb-pill-wrapper'>
                   <view className='slider-thumb-bar' />
                 </SliderThumb>
-              </SliderRange>
+              </SliderTrack>
             </SliderRoot>
           </view>
         </view>

--- a/apps/examples/Slider/WithScrollView/index.css
+++ b/apps/examples/Slider/WithScrollView/index.css
@@ -89,7 +89,7 @@
   background-color: var(--neutral-faint);
 }
 
-.slider-range {
+.slider-indicator {
   width: 100%;
   height: 4px;
   border-radius: 9999px;
@@ -98,9 +98,6 @@
 }
 
 .slider-thumb-wrapper {
-  position: absolute;
-  top: 0;
-  right: -18px;
   width: 36px;
   height: 36px;
   display: flex;

--- a/apps/examples/Slider/WithScrollView/index.tsx
+++ b/apps/examples/Slider/WithScrollView/index.tsx
@@ -5,7 +5,7 @@
 import { root, useState } from '@lynx-js/react'
 
 import {
-  SliderRange,
+  SliderIndicator,
   SliderRoot,
   SliderThumb,
   SliderTrack,
@@ -33,12 +33,12 @@ function SliderCard({ index }: { index: number }) {
           setValue(v)
         }}
       >
-        <SliderTrack className='slider-track' />
-        <SliderRange className='slider-range'>
+        <SliderTrack className='slider-track'>
+          <SliderIndicator className='slider-indicator' />
           <SliderThumb className='slider-thumb-wrapper'>
             <view className='slider-thumb' />
           </SliderThumb>
-        </SliderRange>
+        </SliderTrack>
       </SliderRoot>
     </view>
   )

--- a/packages/lynx-ui-slider/CHANGELOG.md
+++ b/packages/lynx-ui-slider/CHANGELOG.md
@@ -5,9 +5,5 @@
 - Introduced primitives-first slider components:
   - `SliderRoot`
   - `SliderTrack`
-  - `SliderRange`
+  - `SliderIndicator`
   - `SliderThumb`
-- Added compatibility facade component `Slider`.
-- Added imperative API via `SliderRef` (`updateProgress`, `getProgress`).
-- Added export integration in aggregate package `@lynx-js/lynx-ui`.
-- Track/thumb visual customization is designed to be done via CSS classes or inline style instead of dedicated size/color props.

--- a/packages/lynx-ui-slider/README.md
+++ b/packages/lynx-ui-slider/README.md
@@ -6,16 +6,14 @@ A primitives-first slider component package for lynx-ui.
 
 ```bash
 # pnpm (recommended)
-pnpm add @lynx-js/lynx-ui
+pnpm add @lynx-js/lynx-ui-slider
 
 # npm
-npm install @lynx-js/lynx-ui
+npm install @lynx-js/lynx-ui-slider
 
 # yarn
-yarn add @lynx-js/lynx-ui
+yarn add @lynx-js/lynx-ui-slider
 ```
-
-_(If necessary, you can still install the standalone package via `pnpm add @lynx-js/lynx-ui-slider`)_
 
 ## Usage
 
@@ -25,9 +23,9 @@ _(If necessary, you can still install the standalone package via `pnpm add @lynx
 import {
   SliderRoot,
   SliderTrack,
-  SliderRange,
+  SliderIndicator,
   SliderThumb,
-} from '@lynx-js/lynx-ui'
+} from '@lynx-js/lynx-ui-slider'
 
 export function SliderPrimitiveDemo() {
   return (
@@ -36,12 +34,12 @@ export function SliderPrimitiveDemo() {
       onValueChange={(value, source) => console.log(value, source)}
       onValueCommit={(value) => console.log('commit', value)}
     >
-      <SliderTrack className='slider-track' />
-      <SliderRange className='slider-range'>
+      <SliderTrack className='slider-track'>
+        <SliderIndicator className='slider-indicator' />
         <SliderThumb className='slider-thumb-wrapper'>
           <view className='slider-thumb-dot' />
         </SliderThumb>
-      </SliderRange>
+      </SliderTrack>
     </SliderRoot>
   )
 }
@@ -51,35 +49,23 @@ export function SliderPrimitiveDemo() {
 
 ```tsx
 <SliderRoot>
-  <SliderTrack />
-  <SliderRange>
+  <SliderTrack>
+    <SliderIndicator />
     <SliderThumb>
       <view />
     </SliderThumb>
-  </SliderRange>
+  </SliderTrack>
 </SliderRoot>
 ```
 
 - **`SliderRoot`**: owns interaction logic and exposes `SliderRef` imperative methods in uncontrolled mode.
-- **`SliderTrack`**: renders background track.
-- **`SliderRange`**: renders the active progress range and owns its width.
-- **`SliderThumb`**: renders thumb content passed through `children`.
+- **`SliderTrack`**: establishes the measurement/layout coordinate space and renders the base rail.
+- **`SliderIndicator`**: renders the active progress indicator, with width driven by the current ratio.
+- **`SliderThumb`**: is positioned inside `SliderTrack` by the current ratio and renders custom thumb content.
 
 Styling for track/thumb size and colors is expected to be done through `className` or inline `style`, instead of dedicated style props.
 
-### About Track/Thumb Centering
-
-The slider internally aligns thumb and track with an implicit size relationship:
-
-- `thumb` vertical center aligns to the track center.
-- `thumb` horizontal anchor is the range end center point.
-
-If you override track/thumb sizes with custom CSS, keep this relationship to avoid visual offset:
-
-- progress bar top offset should follow: `(thumbHeight - trackHeight) / 2`
-- thumb wrapper right offset should follow: `-thumbWidth / 2`
-
-When these offsets are not updated together with your custom sizes, the thumb may look vertically or horizontally misaligned.
+`SliderIndicator` and `SliderThumb` are siblings inside `SliderTrack`, so the filled region stays purely visual while the thumb position is driven directly by value.
 
 ## License
 

--- a/packages/lynx-ui-slider/SKILL.md
+++ b/packages/lynx-ui-slider/SKILL.md
@@ -1,16 +1,16 @@
 # lynx-ui-slider SKILL
 
-`lynx-ui-slider` is a primitives-first slider package for ReactLynx. It provides composable building blocks (`SliderRoot`, `SliderTrack`, `SliderRange`, `SliderThumb`).
+`lynx-ui-slider` is a primitives-first slider package for ReactLynx. It provides composable building blocks (`SliderRoot`, `SliderTrack`, `SliderIndicator`, `SliderThumb`).
 
 ## 1. Core Capabilities
 
-- **Primitives Composition**: Build slider UI with `SliderRoot` + `SliderTrack` + `SliderRange` + `SliderThumb`.
+- **Primitives Composition**: Build slider UI with `SliderRoot` + `SliderTrack` + `SliderIndicator` + `SliderThumb`.
 - **Shared Base Props**: All primitives inherit `className` and `style` from `ComponentBasicProps`.
 - **Controlled & Uncontrolled Modes**: Use `value` + `onValueChange` for controlled mode, or `defaultValue` for uncontrolled mode.
 - **Imperative API** (uncontrolled only): Access `updateValue` and `getValue` through `SliderRef`. Throws in controlled mode.
-- **RTL Support**: Set `enableRTL` to reverse range direction (right-to-left).
+- **RTL Support**: Set `enableRTL` to make the indicator and thumb resolve right-to-left.
 - **Stepping**: Set `step` to snap values to discrete increments.
-- **Readonly Mode**: Set `readonly` to prevent dragging while still displaying the current value.
+- **Disabled Mode**: Set `disabled` to prevent dragging while still displaying the current value.
 - **Interaction Callbacks**: `onDragging(value)` when dragging starts, `onValueChange(value, source)` for slider-driven updates, `onValueCommit(value)` at drag end.
 - **Headless Styling**: Supports styling via `className` and `style` props on every primitive.
 
@@ -22,9 +22,9 @@
 import {
   SliderRoot,
   SliderTrack,
-  SliderRange,
+  SliderIndicator,
   SliderThumb,
-} from '@lynx-js/lynx-ui'
+} from '@lynx-js/lynx-ui-slider'
 
 function BasicSlider() {
   return (
@@ -32,12 +32,12 @@ function BasicSlider() {
       defaultValue={0.3}
       onValueCommit={(value) => console.log(value)}
     >
-      <SliderTrack className='track' />
-      <SliderRange className='range'>
+      <SliderTrack className='track'>
+        <SliderIndicator className='indicator' />
         <SliderThumb className='thumb'>
           <view />
         </SliderThumb>
-      </SliderRange>
+      </SliderTrack>
     </SliderRoot>
   )
 }
@@ -50,9 +50,9 @@ import { useState } from '@lynx-js/react'
 import {
   SliderRoot,
   SliderTrack,
-  SliderRange,
+  SliderIndicator,
   SliderThumb,
-} from '@lynx-js/lynx-ui'
+} from '@lynx-js/lynx-ui-slider'
 
 function ControlledSlider() {
   const [value, setValue] = useState(0.5)
@@ -62,12 +62,12 @@ function ControlledSlider() {
       value={value}
       onValueChange={(v) => setValue(v)}
     >
-      <SliderTrack className='track' />
-      <SliderRange className='range'>
+      <SliderTrack className='track'>
+        <SliderIndicator className='indicator' />
         <SliderThumb className='thumb'>
           <view />
         </SliderThumb>
-      </SliderRange>
+      </SliderTrack>
     </SliderRoot>
   )
 }
@@ -77,12 +77,12 @@ function ControlledSlider() {
 
 ```tsx
 <SliderRoot enableRTL defaultValue={0.4}>
-  <SliderTrack className='track' />
-  <SliderRange className='range'>
+  <SliderTrack className='track'>
+    <SliderIndicator className='indicator' />
     <SliderThumb className='thumb'>
       <view />
     </SliderThumb>
-  </SliderRange>
+  </SliderTrack>
 </SliderRoot>
 ```
 
@@ -94,20 +94,20 @@ function ControlledSlider() {
 
 - "Create a controlled slider with custom thumb UI and `onValueCommit` callback."
 - "Build a headless slider with `step={0.1}` and custom class names for each primitive."
-- "Add an RTL slider with `enableRTL` and `direction: rtl` CSS."
+- "Add an RTL slider with `enableRTL` and optional RTL container styling."
 
 ## 3. Props Reference
 
 ### SliderRootProps
 
-`SliderRootProps`, `SliderTrackProps`, `SliderRangeProps`, and `SliderThumbProps` all inherit `className` and `style` from `ComponentBasicProps`.
+`SliderRootProps`, `SliderTrackProps`, `SliderIndicatorProps`, and `SliderThumbProps` all inherit `className` and `style` from `ComponentBasicProps`.
 
 | Prop            | Type                              | Default | Description                                                                         |
 | --------------- | --------------------------------- | ------- | ----------------------------------------------------------------------------------- |
 | `value`         | `number`                          | —       | Controlled value `[0, 1]`. Do not use with `defaultValue`.                          |
 | `defaultValue`  | `number`                          | `0`     | Initial value for uncontrolled mode.                                                |
 | `step`          | `number`                          | —       | Snap interval in `[0, 1]`.                                                          |
-| `readonly`      | `boolean`                         | `false` | Prevent interaction while keeping the slider value visible.                         |
+| `disabled`      | `boolean`                         | `false` | Prevent interaction while keeping the slider value visible.                         |
 | `enableRTL`     | `boolean`                         | `false` | Reverse range direction (right-to-left).                                            |
 | `onDragging`    | `(value: number) => void`         | —       | Fires once when the interaction enters dragging state.                              |
 | `onValueChange` | `(value: number, source) => void` | —       | Fires for drag updates and `updateValue` calls. Source is `'drag'` or `'external'`. |
@@ -130,9 +130,9 @@ A: Use controlled (`value` + `onValueChange`) when you need to sync slider state
 
 A: `onDragging` fires once when dragging starts. `onValueChange` fires for slider-driven value updates during drag and imperative `updateValue` calls. `onValueCommit` fires once at drag end — useful for persisting the final value.
 
-**Q: Is `disabled` still supported?**
+**Q: How do I prevent user interaction while still showing the value?**
 
-A: Use `readonly` going forward. `disabled` is kept only as a deprecated compatibility alias.
+A: Set `disabled` on `SliderRoot`. The slider will display the current value but will not respond to touch or pointer events.
 
 **Q: What happens if I call `updateValue` / `getValue` in controlled mode?**
 
@@ -144,18 +144,15 @@ A: Input values are clamped to `[0, 1]` internally.
 
 **Q: How do I enable RTL?**
 
-A: Pass `enableRTL` to `SliderRoot` and add `direction: rtl` to the container CSS.
+A: Pass `enableRTL` to `SliderRoot`. Add `direction: rtl` only if you also want the surrounding container layout or text flow to follow RTL.
 
-**Q: I changed thumb/track size in CSS and now thumb is not centered. Why?**
+**Q: Which primitive should own the fill styling?**
 
-A: Thumb and track have an implicit centering relationship. If you change one size, also update the matching offsets in CSS:
-
-- vertical alignment offset: `(thumbHeight - trackHeight) / 2`
-- horizontal anchor offset: `-thumbWidth / 2`
+A: `SliderIndicator` is the pure visual fill layer. Keep `SliderThumb` as a sibling inside `SliderTrack`, and style the thumb content independently from the filled portion.
 
 ## 5. Sub Components
 
 - **`SliderRoot`**: Owns measurement, drag behavior, value management, and context provider.
-- **`SliderTrack`**: Background track bar.
-- **`SliderRange`**: Foreground range container with width bound to value. Supports RTL via `right: 0` positioning.
-- **`SliderThumb`**: Draggable thumb visual node, positioned at the end of the range.
+- **`SliderTrack`**: Base rail plus the measurement/layout coordinate space for its children.
+- **`SliderIndicator`**: Foreground visual indicator with width bound to value. Supports RTL via `right: 0` positioning.
+- **`SliderThumb`**: Visual thumb node positioned inside `SliderTrack` by the current ratio.

--- a/packages/lynx-ui-slider/docs/APIReference.mdx
+++ b/packages/lynx-ui-slider/docs/APIReference.mdx
@@ -6,6 +6,60 @@ import { UIApiTable } from "@lynx-ui/index";
   
 <UIApiTable source={[
   {
+    "name": "children",
+    "type": "ReactNode",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Usually includes "
+      },
+      {
+        "kind": "code",
+        "text": "`SliderIndicator`"
+      },
+      {
+        "kind": "text",
+        "text": " and optional "
+      },
+      {
+        "kind": "code",
+        "text": "`SliderThumb`"
+      },
+      {
+        "kind": "text",
+        "text": "."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "通常包含 "
+      },
+      {
+        "kind": "code",
+        "text": "`SliderIndicator`"
+      },
+      {
+        "kind": "text",
+        "text": " 以及可选的 "
+      },
+      {
+        "kind": "code",
+        "text": "`SliderThumb`"
+      },
+      {
+        "kind": "text",
+        "text": "。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
     "name": "className",
     "type": "string",
     "summary": [
@@ -24,7 +78,7 @@ import { UIApiTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": true,
+    "isSupportHarmony": false,
     "docTypeFallback": null
   },
   {
@@ -46,7 +100,7 @@ import { UIApiTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": true,
+    "isSupportHarmony": false,
     "docTypeFallback": null
   }
 ]}/>
@@ -97,7 +151,7 @@ import { UIApiTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": true,
+    "isSupportHarmony": false,
     "docTypeFallback": null
   },
   {
@@ -119,7 +173,7 @@ import { UIApiTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": true,
+    "isSupportHarmony": false,
     "docTypeFallback": null
   }
 ]}/>
@@ -136,50 +190,63 @@ import { UIApiTable } from "@lynx-ui/index";
     "summary": [
       {
         "kind": "text",
-        "text": "Primitive children composition, usually: SliderTrack"
+        "text": "Primitive children composition, usually: "
       },
       {
         "kind": "code",
-        "text": "` + `"
+        "text": "`SliderTrack`"
       },
       {
         "kind": "text",
-        "text": "SliderRange"
+        "text": " containing "
       },
       {
         "kind": "code",
-        "text": "` + `"
+        "text": "`SliderIndicator`"
       },
       {
         "kind": "text",
-        "text": "SliderThumb"
+        "text": " and optional "
       },
       {
         "kind": "code",
-        "text": "`.\n@zh 子原语组件组合，通常为：`"
+        "text": "`SliderThumb`"
       },
       {
         "kind": "text",
-        "text": "SliderTrack"
-      },
-      {
-        "kind": "code",
-        "text": "` + `"
-      },
-      {
-        "kind": "text",
-        "text": "SliderRange"
-      },
-      {
-        "kind": "code",
-        "text": "` + `"
-      },
-      {
-        "kind": "text",
-        "text": "SliderThumb`。"
+        "text": "."
       }
     ],
-    "summary_zh": [],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "子原语组件组合，通常为："
+      },
+      {
+        "kind": "code",
+        "text": "`SliderTrack`"
+      },
+      {
+        "kind": "text",
+        "text": " 内包含 "
+      },
+      {
+        "kind": "code",
+        "text": "`SliderIndicator`"
+      },
+      {
+        "kind": "text",
+        "text": " 以及可选的 "
+      },
+      {
+        "kind": "code",
+        "text": "`SliderThumb`"
+      },
+      {
+        "kind": "text",
+        "text": "。"
+      }
+    ],
     "defaultValue": "",
     "isOption": true,
     "isSupportIOS": false,
@@ -206,7 +273,7 @@ import { UIApiTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": true,
+    "isSupportHarmony": false,
     "docTypeFallback": null
   },
   {
@@ -234,9 +301,19 @@ import { UIApiTable } from "@lynx-ui/index";
   {
     "name": "disabled",
     "type": "boolean",
-    "summary": [],
-    "summary_zh": [],
-    "defaultValue": "",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Disable the slider and prevent pointer/touch interaction."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "禁用滑块，阻止指针/触摸交互。"
+      }
+    ],
+    "defaultValue": "false",
     "isOption": true,
     "isSupportIOS": false,
     "isSupportAndroid": false,
@@ -380,28 +457,6 @@ import { UIApiTable } from "@lynx-ui/index";
     "docTypeFallback": null
   },
   {
-    "name": "readonly",
-    "type": "boolean",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "Make the slider read-only and prevent pointer/touch interaction."
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "将滑块设为只读，阻止指针/触摸交互。"
-      }
-    ],
-    "defaultValue": "false",
-    "isOption": true,
-    "isSupportIOS": false,
-    "isSupportAndroid": false,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
-  },
-  {
     "name": "step",
     "type": "number",
     "summary": [
@@ -474,7 +529,7 @@ import { UIApiTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": true,
+    "isSupportHarmony": false,
     "docTypeFallback": null
   },
   {
@@ -535,48 +590,10 @@ import { UIApiTable } from "@lynx-ui/index";
     
       
 
-### SliderRangeProps
+### SliderIndicatorProps
 
 
 <UIApiTable source={[
-  {
-    "name": "children",
-    "type": "ReactNode",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "Usually includes "
-      },
-      {
-        "kind": "code",
-        "text": "`SliderThumb`"
-      },
-      {
-        "kind": "text",
-        "text": " and optional custom range content."
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "通常包含 "
-      },
-      {
-        "kind": "code",
-        "text": "`SliderThumb`"
-      },
-      {
-        "kind": "text",
-        "text": " 及可选的自定义范围内容。"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": true,
-    "isSupportIOS": false,
-    "isSupportAndroid": false,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
-  },
   {
     "name": "className",
     "type": "string",
@@ -596,7 +613,7 @@ import { UIApiTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": true,
+    "isSupportHarmony": false,
     "docTypeFallback": null
   },
   {
@@ -618,7 +635,7 @@ import { UIApiTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": true,
+    "isSupportHarmony": false,
     "docTypeFallback": null
   }
 ]}/>

--- a/packages/lynx-ui-slider/docs/README.mdx
+++ b/packages/lynx-ui-slider/docs/README.mdx
@@ -1,0 +1,9 @@
+# `Slider`
+
+A primitives-first slider component for selecting a value in the range `[0, 1]`.
+
+import Introduction from '../../introDocs/lynx-ui-slider/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
+<Introduction />
+<APIReference />

--- a/packages/lynx-ui-slider/docs/README.zh.mdx
+++ b/packages/lynx-ui-slider/docs/README.zh.mdx
@@ -1,0 +1,9 @@
+# `Slider`
+
+一个原语优先的滑块组件，用于选择 `[0, 1]` 范围内的值。
+
+import Introduction from '../../introDocs/lynx-ui-slider/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
+<Introduction />
+<APIReference />

--- a/packages/lynx-ui-slider/src/SliderIndicator/index.tsx
+++ b/packages/lynx-ui-slider/src/SliderIndicator/index.tsx
@@ -5,26 +5,27 @@
 import { memo } from '@lynx-js/react'
 
 import { useSliderContext } from '../context'
-import type { SliderRangeProps } from '../types'
+import type { SliderIndicatorProps } from '../types'
 
-export const SliderRange = memo(function SliderRange(props: SliderRangeProps) {
-  const { valueRef, currentValue, enableRTL } = useSliderContext()
-  const { children, className, style } = props
+export const SliderIndicator = memo(function SliderIndicator(
+  props: SliderIndicatorProps,
+) {
+  const { indicatorRef, currentValue, enableRTL } = useSliderContext()
+  const { className, style } = props
 
   return (
     <view
-      ref={valueRef}
+      ref={indicatorRef}
       style={{
         position: 'absolute',
         top: '0px',
-        ...(enableRTL ? { right: '0px' } : { left: '0px' }),
-        height: '100%',
+        bottom: '0px',
         overflow: 'visible',
+        ...(enableRTL ? { right: '0px' } : { left: '0px' }),
         width: `${currentValue.current * 100}%`,
       }}
     >
       <view className={className} style={style} />
-      {children}
     </view>
   )
 })

--- a/packages/lynx-ui-slider/src/SliderRoot/index.tsx
+++ b/packages/lynx-ui-slider/src/SliderRoot/index.tsx
@@ -22,7 +22,7 @@ import type {
   SliderUpdateValueOptions,
   SliderValueChangeSource,
 } from '../types'
-import { clamp01, getTouchX, snapToStep } from '../utils'
+import { clamp01, getTouchX, getVisualRatio, snapToStep } from '../utils'
 
 export const SliderRoot = memo(forwardRef(SliderRootImpl))
 
@@ -31,7 +31,6 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
     value: controlledValue,
     defaultValue = 0,
     step,
-    readonly = false,
     disabled = false,
     enableRTL = false,
     className,
@@ -46,12 +45,12 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
   const isWebPlatform = useRef<boolean>(SystemInfo.platform === 'web')
 
   const isWebMouseDown = useRef<boolean>(false)
-  const isReadonly = readonly || disabled
 
   const isControlled = controlledValue !== undefined
 
-  const containerRef = useRef<NodesRef>(null)
-  const valueRef = useRef<NodesRef>(null)
+  const trackRef = useRef<NodesRef>(null)
+  const indicatorRef = useRef<NodesRef>(null)
+  const thumbRef = useRef<NodesRef>(null)
 
   const bgWidth = useRef<number>(0)
   const bgLeft = useRef<number>(0)
@@ -64,10 +63,16 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
     snapToStep(clamp01(isControlled ? controlledValue : defaultValue), step),
   )
 
-  const applyNativeWidth = (next: number): void => {
-    valueRef.current
+  const applyNativeValue = (next: number): void => {
+    indicatorRef.current
       ?.setNativeProps?.({
         width: `${next * 100}%`,
+      })
+      ?.exec?.()
+
+    thumbRef.current
+      ?.setNativeProps?.({
+        left: `${getVisualRatio(next, enableRTL) * 100}%`,
       })
       ?.exec?.()
   }
@@ -75,7 +80,7 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
   const syncCurrentValue = (next: number): boolean => {
     if (currentValue.current === next) return false
     currentValue.current = next
-    applyNativeWidth(next)
+    applyNativeValue(next)
     return true
   }
 
@@ -141,10 +146,14 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
 
   const measureBounds = (): void => {
     if (isMeasuringBounds.current) return
+
+    const trackNode = trackRef.current
+    if (!trackNode?.invoke) return
+
     isMeasuringBounds.current = true
 
-    containerRef.current
-      ?.invoke?.({
+    trackNode
+      .invoke({
         method: 'boundingClientRect',
         params: { relativeTo: 'screen' },
         success: (res: unknown) => {
@@ -173,7 +182,7 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
   }
 
   const handleMoveX = (x: number): void => {
-    if (isReadonly) return
+    if (disabled) return
     if (!Number.isFinite(x)) return
 
     if (!leftMeasured.current || bgWidth.current <= 0) {
@@ -186,7 +195,7 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
   }
 
   const handleInteractionStart = (x: number): void => {
-    if (isReadonly) return
+    if (disabled) return
     if (!Number.isFinite(x)) return
 
     pendingMoveX.current = x
@@ -202,7 +211,7 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
     onValueCommit?.(value)
   }
 
-  const onLayoutChange = (event: {
+  const handleTrackLayoutChange = (event: {
     params: { width: number, height: number }
     detail?: { width: number, height: number }
   }): void => {
@@ -274,20 +283,22 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
   )
 
   const contextValue = {
-    valueRef,
+    trackRef,
+    indicatorRef,
+    thumbRef,
     currentValue,
     enableRTL,
+    onTrackLayoutChange: handleTrackLayoutChange,
   }
 
   return (
     <SliderContext.Provider value={contextValue}>
       <view
-        ref={containerRef}
         className={className}
         flatten={false}
         style={style}
-        block-native-event={true}
-        native-interaction-enabled={true}
+        // block-native-event={true}
+        // native-interaction-enabled={true}
         consume-slide-event={[[-180, 180]]}
         catchmousemove={(event: unknown) => {
           if (isWebPlatform.current && !isWebMouseDown.current) return
@@ -324,7 +335,6 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
           isWebMouseDown.current = false
           handleEnd()
         }}
-        bindlayoutchange={onLayoutChange}
       >
         {children}
       </view>

--- a/packages/lynx-ui-slider/src/SliderThumb/index.tsx
+++ b/packages/lynx-ui-slider/src/SliderThumb/index.tsx
@@ -4,22 +4,28 @@
 
 import { memo } from '@lynx-js/react'
 
+import { useSliderContext } from '../context'
 import type { SliderThumbProps } from '../types'
+import { getVisualRatio } from '../utils'
 
 export const SliderThumb = memo(function SliderThumb(props: SliderThumbProps) {
-  const {
-    children,
-    className,
-    style,
-  } = props
+  const { thumbRef, currentValue, enableRTL } = useSliderContext()
+  const { children, className, style } = props
 
   return (
-    children
-      ? (
-        <view className={className} style={style}>
-          {children}
-        </view>
-      )
-      : null
+    <view
+      ref={thumbRef}
+      style={{
+        position: 'absolute',
+        top: '50%',
+        left: `${getVisualRatio(currentValue.current, enableRTL) * 100}%`,
+        transform: 'translate(-50%, -50%)',
+        zIndex: 1,
+      }}
+    >
+      <view className={className} style={style}>
+        {children}
+      </view>
+    </view>
   )
 })

--- a/packages/lynx-ui-slider/src/SliderTrack/index.tsx
+++ b/packages/lynx-ui-slider/src/SliderTrack/index.tsx
@@ -4,10 +4,29 @@
 
 import { memo } from '@lynx-js/react'
 
+import { useSliderContext } from '../context'
 import type { SliderTrackProps } from '../types'
 
 export const SliderTrack = memo(function SliderTrack(props: SliderTrackProps) {
-  const { className, style } = props
+  const { trackRef, onTrackLayoutChange } = useSliderContext()
+  const { children, className, style } = props
 
-  return <view className={className} style={style} />
+  return (
+    <view
+      ref={trackRef}
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        overflow: 'visible',
+        zIndex: 0,
+      }}
+      bindlayoutchange={onTrackLayoutChange}
+    >
+      <view className={className} style={style} />
+      {children}
+    </view>
+  )
 })

--- a/packages/lynx-ui-slider/src/context/index.tsx
+++ b/packages/lynx-ui-slider/src/context/index.tsx
@@ -7,9 +7,15 @@ import { createContext, useContext } from '@lynx-js/react'
 import type { NodesRef } from '@lynx-js/types'
 
 export interface SliderContextValue {
-  valueRef: { current: NodesRef | null }
+  trackRef: { current: NodesRef | null }
+  indicatorRef: { current: NodesRef | null }
+  thumbRef: { current: NodesRef | null }
   currentValue: { current: number }
   enableRTL: boolean
+  onTrackLayoutChange: (event: {
+    params: { width: number, height: number }
+    detail?: { width: number, height: number }
+  }) => void
 }
 
 export const SliderContext = createContext<SliderContextValue | null>(null)

--- a/packages/lynx-ui-slider/src/index.tsx
+++ b/packages/lynx-ui-slider/src/index.tsx
@@ -4,11 +4,11 @@
 
 export { SliderRoot } from './SliderRoot'
 export { SliderTrack } from './SliderTrack'
-export { SliderRange } from './SliderRange'
+export { SliderIndicator } from './SliderIndicator'
 export { SliderThumb } from './SliderThumb'
 
 export type {
-  SliderRangeProps,
+  SliderIndicatorProps,
   SliderRef,
   SliderRootProps,
   SliderThumbProps,

--- a/packages/lynx-ui-slider/src/types/index.docs.ts
+++ b/packages/lynx-ui-slider/src/types/index.docs.ts
@@ -86,13 +86,9 @@ export interface SliderRootProps extends ComponentBasicProps {
    */
   step?: number
   /**
-   * Make the slider read-only and prevent pointer/touch interaction.
+   * Disable the slider and prevent pointer/touch interaction.
    * @defaultValue false
-   * @zh 将滑块设为只读，阻止指针/触摸交互。
-   */
-  readonly?: boolean
-  /**
-   * @deprecated Please use `readonly` instead.
+   * @zh 禁用滑块，阻止指针/触摸交互。
    */
   disabled?: boolean
   /**
@@ -117,38 +113,48 @@ export interface SliderRootProps extends ComponentBasicProps {
    */
   onValueCommit?: (value: number) => void
   /**
-   * Primitive children composition, usually: SliderTrack` + `SliderRange` + `SliderThumb`.
-   * @zh 子原语组件组合，通常为：`SliderTrack` + `SliderRange` + `SliderThumb`。
+   * Primitive children composition, usually: `SliderTrack` containing `SliderIndicator` and optional `SliderThumb`.
+   * @zh 子原语组件组合，通常为：`SliderTrack` 内包含 `SliderIndicator` 以及可选的 `SliderThumb`。
    */
   children?: ReactNode
 }
 
 /**
  * Track primitive props.
+ *
+ * `SliderTrack` establishes the measurement/layout coordinate space and renders the base rail.
+ *
  * @zh 轨道原语组件属性。
+ *
+ * `SliderTrack` 建立测量与布局坐标空间，并渲染基础轨道。
  */
-export interface SliderTrackProps extends ComponentBasicProps {}
-
-/**
- * Range primitive props.
- *
- * `SliderRange` width and foreground bar are controlled by root value.
- *
- * @zh 范围条原语组件属性。
- *
- * `SliderRange` 的宽度和前景条由根组件的值控制。
- */
-export interface SliderRangeProps extends ComponentBasicProps {
+export interface SliderTrackProps extends ComponentBasicProps {
   /**
-   * Usually includes `SliderThumb` and optional custom range content.
-   * @zh 通常包含 `SliderThumb` 及可选的自定义范围内容。
+   * Usually includes `SliderIndicator` and optional `SliderThumb`.
+   * @zh 通常包含 `SliderIndicator` 以及可选的 `SliderThumb`。
    */
   children?: ReactNode
 }
 
 /**
+ * Indicator primitive props.
+ *
+ * `SliderIndicator` is a pure visual layer whose width is controlled by root value.
+ *
+ * @zh 指示条原语组件属性。
+ *
+ * `SliderIndicator` 是纯视觉层，其宽度由根组件的值控制。
+ */
+export interface SliderIndicatorProps extends ComponentBasicProps {}
+
+/**
  * Thumb primitive props.
+ *
+ * `SliderThumb` is positioned by the current ratio inside `SliderTrack` and does not own interaction logic.
+ *
  * @zh 滑块拇指原语组件属性。
+ *
+ * `SliderThumb` 在 `SliderTrack` 内按照当前比例定位，不负责独立交互逻辑。
  */
 export interface SliderThumbProps extends ComponentBasicProps {
   /**

--- a/packages/lynx-ui-slider/src/utils/index.ts
+++ b/packages/lynx-ui-slider/src/utils/index.ts
@@ -7,6 +7,10 @@ export const clamp01 = (value: number): number => {
   return Math.min(Math.max(value, 0), 1)
 }
 
+export const getVisualRatio = (value: number, enableRTL: boolean): number => {
+  return enableRTL ? 1 - value : value
+}
+
 export const snapToStep = (value: number, step: number | undefined): number => {
   if (step === undefined || step <= 0) return value
   const snapped = Math.round(value / step) * step


### PR DESCRIPTION
Rename SliderRange to SliderIndicator for better semantic clarity and restructure the component hierarchy to make SliderIndicator and SliderThumb siblings under SliderTrack. This improves maintainability and makes the component relationships more intuitive.

Update all related CSS classes, documentation, and examples to reflect the new naming and structure. The change also includes RTL support improvements and better separation of concerns between visual indicators and interactive elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Slider visuals moved to an indicator model inside the track; thumb positioning no longer uses pinned offsets. Interaction now uses `disabled` across slider parts. Demo event handlers switched to onChange/onCommit; Controlled demo shows live and committed values and disabled state text updated.

* **Documentation**
  * READMEs, API docs, changelog and guides updated to reflect the indicator composition, prop/event renames, and disabled semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->