### PR TITLE
fix: remove transform style and ensure z-index update on drag

### DIFF
--- a/.changeset/deep-donuts-warn.md
+++ b/.changeset/deep-donuts-warn.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-sortable": patch
+---
+
+Improve robustness for unstable input data.

--- a/packages/lynx-ui-sortable/src/useSortable.tsx
+++ b/packages/lynx-ui-sortable/src/useSortable.tsx
@@ -55,7 +55,6 @@ export function useSortable(
     const item = itemMTSRefMap.current[sortingKey]
 
     item?.MTSSetOtherStyles({
-      'transform': `translateZ(${zIndex}px)`,
       'z-index': `${zIndex}`,
     })
   }, [itemMTSRefMap])
@@ -284,9 +283,10 @@ export function useSortable(
     ) => {
       'main thread'
       switchHandler(delta.y, sortingKey)
+      changeItemZIndex(10000, sortingKey)
       mtsLog(debugLog, '[event drag move]', event)
     },
-    [switchHandler],
+    [switchHandler, changeItemZIndex],
   )
 
   const sortArray = useCallback((sortingKey: string) => {


### PR DESCRIPTION
The transform style was causing rendering issues and is unnecessary since we only need z-index changes. Also ensure z-index is properly updated to avoid the resetStyles triggering unexpectedly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dragged items now rely only on z-index (no transform) and update their stacking on every move so dragged elements consistently appear above others.

* **Chores**
  * Added a patch release note indicating improved robustness when handling unstable input data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->