### PR TITLE
ci: prevent stale release reruns

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
     if: github.repository == 'lynx-family/lynx-ui'
     concurrency:
       group: ${{ github.workflow }}-publish-${{ github.ref }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     environment: npm
     permissions:
       contents: write
@@ -69,6 +69,13 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Check release run is current
+        id: current-main
+        shell: bash
+        run: |
+          set -eu
+          read -r latest_main_sha _ < <(git ls-remote --exit-code origin refs/heads/main)
+          echo "sha=${latest_main_sha}" >> "${GITHUB_OUTPUT}"
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
@@ -96,6 +103,7 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date -u +'%Y-%m-%d %H:%M:%S')"
       - name: publish
+        if: github.sha == steps.current-main.outputs.sha
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
     if: github.repository == 'lynx-family/lynx-ui'
     concurrency:
       group: ${{ github.workflow }}-publish-${{ github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     environment: npm
     permissions:
       contents: write
@@ -69,13 +69,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Check release run is current
-        id: current-main
-        shell: bash
-        run: |
-          set -eu
-          read -r latest_main_sha _ < <(git ls-remote --exit-code origin refs/heads/main)
-          echo "sha=${latest_main_sha}" >> "${GITHUB_OUTPUT}"
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
@@ -102,6 +95,13 @@ jobs:
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date -u +'%Y-%m-%d %H:%M:%S')"
+      - name: Check release run is current
+        id: current-main
+        shell: bash
+        run: |
+          set -eu
+          read -r latest_main_sha _ < <(git ls-remote --exit-code origin refs/heads/main)
+          echo "sha=${latest_main_sha}" >> "${GITHUB_OUTPUT}"
       - name: publish
         if: github.sha == steps.current-main.outputs.sha
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3


### PR DESCRIPTION
## Summary

- cancel in-progress deploy publish jobs for newer `main` pushes
- capture the current remote `main` SHA before running Changesets
- skip `changesets/action` when a re-run is for a stale commit

## Why

Manual re-runs keep the original `GITHUB_SHA`, so an old Deploy run can force-push `changeset-release/main` backward and erase a newer Changesets release PR. This keeps the mutating release step limited to the current `main` tip.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "YAML OK"'`
- `pnpm exec dprint check .github/workflows/publish.yml`
- `pnpm exec cspell lint --config cspell.jsonc --gitignore --no-progress --no-must-find-files .github/workflows/publish.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced the release pipeline to avoid publishing from outdated commits, cancel duplicate deployment runs, and ensure publish steps only run for the latest main commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->