### PR TITLE
docs: update component descriptions to use shared json file

### DIFF
--- a/packages/lynx-ui-button/docs/README.mdx
+++ b/packages/lynx-ui-button/docs/README.mdx
@@ -1,6 +1,8 @@
 # `<Button>`
 
-A basic button implementation that provides highlight and selected states.
+import descriptions from '../../lynx-ui-intros.json';
+
+{descriptions['lynx-ui-button']}
 
 :::info
 

--- a/packages/lynx-ui-checkbox/docs/README.mdx
+++ b/packages/lynx-ui-checkbox/docs/README.mdx
@@ -1,6 +1,8 @@
 # `<Checkbox>`
 
-`<Checkbox>` lets users select one or more options.
+import descriptions from '../../lynx-ui-intros.json';
+
+{descriptions['lynx-ui-checkbox']}
 
 import Introduction from '../../introDocs/lynx-ui-checkbox/Introduction.mdx';
 import APIReference from './APIReference.mdx';

--- a/packages/lynx-ui-dialog/docs/README.mdx
+++ b/packages/lynx-ui-dialog/docs/README.mdx
@@ -1,6 +1,8 @@
 # `Dialog`
 
-A dialog component that displays content above the current view, supporting background backdrop and custom animations.
+import descriptions from '../../lynx-ui-intros.json';
+
+{descriptions['lynx-ui-dialog']}
 
 import Introduction from '../../introDocs/lynx-ui-dialog/Introduction.mdx';
 import APIReference from './APIReference.mdx';

--- a/packages/lynx-ui-draggable/docs/README.mdx
+++ b/packages/lynx-ui-draggable/docs/README.mdx
@@ -1,6 +1,8 @@
 # `<Draggable>`
 
-A basic draggable item component.
+import descriptions from '../../lynx-ui-intros.json';
+
+{descriptions['lynx-ui-draggable']}
 
 import Introduction from '../../introDocs/lynx-ui-draggable/Introduction.mdx';
 import APIReference from './APIReference.mdx';

--- a/packages/lynx-ui-feed-list/docs/README.mdx
+++ b/packages/lynx-ui-feed-list/docs/README.mdx
@@ -1,5 +1,7 @@
 # `<FeedList>`
 
+import descriptions from '../../lynx-ui-intros.json';
+
 import { Go, UIApiTable } from '@lynx-ui/index';
 import { PageTabs, PageTab } from '@theme';
 
@@ -7,8 +9,7 @@ import Introduction from '../../introDocs/lynx-ui-feed-list/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 import RefreshDocIntroduction from './useRefresh.mdx';
 
-A scrollable container based on [`<List>`](/lynx-ui/Components/List.html).
-Adds refresh and bounceable capabilities implemented by MTS, and also supports custom footers for LoadMore status and data load completion status.
+{descriptions['lynx-ui-feed-list']}
 
 :::info
 

--- a/packages/lynx-ui-form/docs/README.mdx
+++ b/packages/lynx-ui-form/docs/README.mdx
@@ -1,6 +1,8 @@
 # `<Form>`
 
-Form is a form component used to collect and submit data.
+import descriptions from '../../lynx-ui-intros.json';
+
+{descriptions['lynx-ui-form']}
 
 import Introduction from '../../introDocs/lynx-ui-form/Introduction.mdx';
 import APIReference from './APIReference.mdx';

--- a/packages/lynx-ui-input/docs/README.mdx
+++ b/packages/lynx-ui-input/docs/README.mdx
@@ -1,6 +1,8 @@
 # `<Input>`
 
-Input component that supports controlled and uncontrolled modes, as well as keyboard avoidance capabilities.
+import descriptions from '../../lynx-ui-intros.json';
+
+{descriptions['lynx-ui-input']}
 
 import Introduction from '../../introDocs/lynx-ui-input/Introduction.mdx';
 import APIReference from './APIReference.mdx';

--- a/packages/lynx-ui-lazy-component/docs/README.mdx
+++ b/packages/lynx-ui-lazy-component/docs/README.mdx
@@ -1,8 +1,10 @@
 # `<LazyComponent>`
 
+import descriptions from '../../lynx-ui-intros.json';
+
 > - For ReactLynx 2, refer to the [old official website](https://lynx-doc.cn.goofy.app/docs/frontend/lynx-ui/button)
 
-A general lazy loading component based on global exposure.
+{descriptions['lynx-ui-lazy-component']}
 
 import LazyComponentImg from '@assets/LazyComponent/lazy_component.jpeg';
 

--- a/packages/lynx-ui-list/docs/README.mdx
+++ b/packages/lynx-ui-list/docs/README.mdx
@@ -1,6 +1,8 @@
 # `<List>`
 
-A scrollable container with built-in lazy loading and recycling reuse mechanism. It is a wrapper around the underlying `<list/>` component.
+import descriptions from '../../lynx-ui-intros.json';
+
+{descriptions['lynx-ui-list']}
 
 :::info
 

--- a/packages/lynx-ui-overlay/docs/README.mdx
+++ b/packages/lynx-ui-overlay/docs/README.mdx
@@ -1,6 +1,8 @@
 # `Overlay`
 
-A drop-in replacement for `x-overlay-ng` that handles platform differences. It renders as a normal `view` or `x-overlay-ng` depending on whether a container is provided.
+import descriptions from '../../lynx-ui-intros.json';
+
+{descriptions['lynx-ui-overlay']}
 
 import Introduction from '../../introDocs/lynx-ui-overlay/Introduction.mdx';
 import APIReference from './APIReference.mdx';

--- a/packages/lynx-ui-popover/docs/README.mdx
+++ b/packages/lynx-ui-popover/docs/README.mdx
@@ -1,6 +1,8 @@
 # `Popover`
 
-The popover component allows you to set different positioning strategies and styles, supports custom content, and supports custom arrows.
+import descriptions from '../../lynx-ui-intros.json';
+
+{descriptions['lynx-ui-popover']}
 
 import Introduction from '../../introDocs/lynx-ui-popover/Introduction.mdx';
 import APIReference from './APIReference.mdx';

--- a/packages/lynx-ui-radio-group/docs/README.mdx
+++ b/packages/lynx-ui-radio-group/docs/README.mdx
@@ -1,6 +1,8 @@
 # `RadioGroup`
 
-A radioGroup is a set of checkable buttons—known as radio buttons—where only one can be selected at a time.
+import descriptions from '../../lynx-ui-intros.json';
+
+{descriptions['lynx-ui-radio-group']}
 
 import Introduction from '../../introDocs/lynx-ui-radio-group/Introduction.mdx';
 import APIReference from './APIReference.mdx';

--- a/packages/lynx-ui-scroll-view/docs/README.mdx
+++ b/packages/lynx-ui-scroll-view/docs/README.mdx
@@ -7,9 +7,11 @@ import BounceDocIntroduction from './useBounce.mdx';
 
 # `<Scrollview>`
 
+import descriptions from '../../lynx-ui-intros.json';
+
 > - For ReactLynx 2, refer to the [old official website](https://lynx-doc.cn.goofy.app/docs/frontend/lynx-ui/scroll-view)
 
-A wrapper for `<scroll-view>`
+{descriptions['lynx-ui-scroll-view']}
 
 - Lazy-loading optimized container powered by LazyComponent, designed to reduce first-screen rendering time
 

--- a/packages/lynx-ui-sheet/docs/README.mdx
+++ b/packages/lynx-ui-sheet/docs/README.mdx
@@ -1,6 +1,8 @@
 # `<Sheet>`
 
-A bottom sheet component for presenting supplemental content with drag gestures, snap points, auto height, and backdrop dismissal.
+import descriptions from '../../lynx-ui-intros.json';
+
+{descriptions['lynx-ui-sheet']}
 
 - Supports controlled and uncontrolled visibility.
 - Supports snap points, including percentages and content-driven height.

--- a/packages/lynx-ui-sortable/docs/README.mdx
+++ b/packages/lynx-ui-sortable/docs/README.mdx
@@ -1,6 +1,8 @@
 # `<Sortable>`
 
-A sorting component implemented based on the Draggable component. Currently, it only supports child items of equal height, and there should be no gaps (such as margins) between child items.
+import descriptions from '../../lynx-ui-intros.json';
+
+{descriptions['lynx-ui-sortable']}
 
 import Introduction from '../../introDocs/lynx-ui-sortable/Introduction.mdx';
 import APIReference from './APIReference.mdx';

--- a/packages/lynx-ui-swipe-action/docs/README.mdx
+++ b/packages/lynx-ui-swipe-action/docs/README.mdx
@@ -1,6 +1,8 @@
 # `<SwipeAction>`
 
-A touch-enabled swipe component powered by the touch system and [MTS](https://lynx.bytedance.net/api/lynx-api/main-thread.html).
+import descriptions from '../../lynx-ui-intros.json';
+
+{descriptions['lynx-ui-swipe-action']}
 
 - Key Composition:
 

--- a/packages/lynx-ui-swiper/docs/README.mdx
+++ b/packages/lynx-ui-swiper/docs/README.mdx
@@ -1,12 +1,14 @@
 # `<Swiper>`
 
+import descriptions from '../../lynx-ui-intros.json';
+
 import { UIApiTable, Columns } from '@lynx-ui/index';
 import { PageTabs, PageTab } from '@theme';
 import Introduction from '../../introDocs/lynx-ui-swiper/Introduction.mdx';
 import Advanced from './advanced.mdx';
 import APIReference from './APIReference.mdx';
 
-A high-performance swiper component built on the touch system and [MTS](https://lynx.bytedance.net/api/lynx-api/main-thread.html). Provides gesture responsiveness, paging, looping, bounces, and other capabilities, along with highly customizable features.
+{descriptions['lynx-ui-swiper']}
 
 :::info
 

--- a/packages/lynx-ui-switch/docs/README.mdx
+++ b/packages/lynx-ui-switch/docs/README.mdx
@@ -1,6 +1,8 @@
 # `<Switch>`
 
-A `<Switch>` is a simple control that lets users toggle a setting `on` or `off`.
+import descriptions from '../../lynx-ui-intros.json';
+
+{descriptions['lynx-ui-switch']}
 
 import Introduction from '../../introDocs/lynx-ui-switch/Introduction.mdx';
 import APIReference from './APIReference.mdx';


### PR DESCRIPTION
Replace hardcoded component descriptions in README files with dynamic imports from lynx-ui-intros.json to centralize and maintain descriptions in a single location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified documentation intros for 18 UI components to pull descriptions from a shared source, ensuring consistent, centrally managed introductory text across component docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->