### PR TITLE
docs(api-reference): add i18n support for state-based styling documen…

### DIFF
--- a/packages/lynx-ui-button/docs/APIReference.mdx
+++ b/packages/lynx-ui-button/docs/APIReference.mdx
@@ -4,9 +4,39 @@ import { useLang } from '@rspress/core/runtime';
 export const ClassRenderPropPreamble = () => {
   const isZh = useLang() === 'zh';
   if (isZh) {
-    return '基于状态的样式与渲染：该组件将每一项内部状态通过两条等价通道同时对外暴露，下表逐行给出两者的对应关系。一是 CSS className：根节点上会动态加上 ui-<state> 形式的类名，可直接用 .ui-<state> { ... } 选择器定制样式；二是 render-prop 字段：当 children 传入函数时，同一个状态会以 children({ <state>: boolean, ... }) 的形式作为参数传入，便于在运行时做条件渲染。两条通道指向完全相同的条件，你可以任选其一，也可以同时使用。';
+    return (
+      <>
+        <h3>基于状态的样式与渲染</h3>
+        <p>
+          该组件将每一项内部状态通过<strong>两条等价通道</strong>同时对外暴露，下表逐行给出两者的对应关系：
+        </p>
+        <ul>
+          <li>
+            <strong>CSS className</strong>：根节点上会动态加上 <code>{'ui-<state>'}</code> 形式的类名，可直接用 <code>{'.ui-<state> { ... }'}</code> 选择器定制样式；
+          </li>
+          <li>
+            <strong>Render-prop 字段</strong>：当 <code>children</code> 传入函数时，同一个状态会以 <code>{'children({ <state>: boolean, ... })'}</code> 的形式作为参数传入，便于在运行时做条件渲染。
+          </li>
+        </ul>
+      </>
+    );
   }
-  return 'State-based styling & rendering: this component exposes each of its internal states through two interchangeable channels, and the table below maps them one-to-one. First, a CSS className like ui-<state> is toggled on the root node, so you can style it with selectors such as .ui-<state> { ... }. Second, a render-prop field: when children is a function, the same state is passed in via children({ <state>: boolean, ... }) for runtime-driven rendering. Both channels reflect the exact same condition, so you can pick either one, or use both together.';
+  return (
+    <>
+      <h3>State-based styling & rendering</h3>
+      <p>
+        This component exposes each of its internal states through <strong>two interchangeable channels</strong>, and the table below maps them one-to-one:
+      </p>
+      <ul>
+        <li>
+          <strong>CSS className</strong> — a class like <code>{'ui-<state>'}</code> is toggled on the root node, so you can style it with selectors such as <code>{'.ui-<state> { ... }'}</code>.
+        </li>
+        <li>
+          <strong>Render-prop field</strong> — when <code>children</code> is a function, the same state is passed in via <code>{'children({ <state>: boolean, ... })'}</code> for runtime-driven rendering.
+        </li>
+      </ul>
+    </>
+  );
 };
 
   

--- a/packages/lynx-ui-button/docs/APIReference.mdx
+++ b/packages/lynx-ui-button/docs/APIReference.mdx
@@ -1,4 +1,14 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+import { useLang } from '@rspress/core/runtime';
+
+export const ClassRenderPropPreamble = () => {
+  const isZh = useLang() === 'zh';
+  if (isZh) {
+    return '基于状态的样式与渲染：该组件将每一项内部状态通过两条等价通道同时对外暴露，下表逐行给出两者的对应关系。一是 CSS className：根节点上会动态加上 ui-<state> 形式的类名，可直接用 .ui-<state> { ... } 选择器定制样式；二是 render-prop 字段：当 children 传入函数时，同一个状态会以 children({ <state>: boolean, ... }) 的形式作为参数传入，便于在运行时做条件渲染。两条通道指向完全相同的条件，你可以任选其一，也可以同时使用。';
+  }
+  return 'State-based styling & rendering: this component exposes each of its internal states through two interchangeable channels, and the table below maps them one-to-one. First, a CSS className like ui-<state> is toggled on the root node, so you can style it with selectors such as .ui-<state> { ... }. Second, a render-prop field: when children is a function, the same state is passed in via children({ <state>: boolean, ... }) for runtime-driven rendering. Both channels reflect the exact same condition, so you can pick either one, or use both together.';
+};
+
   
 
 ### Button 
@@ -149,6 +159,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     }
   }
 ]}/>
+<ClassRenderPropPreamble />
 <ClassRenderPropTable source={[
   {
     "className": "ui-active",

--- a/packages/lynx-ui-checkbox/docs/APIReference.mdx
+++ b/packages/lynx-ui-checkbox/docs/APIReference.mdx
@@ -1,4 +1,14 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+import { useLang } from '@rspress/core/runtime';
+
+export const ClassRenderPropPreamble = () => {
+  const isZh = useLang() === 'zh';
+  if (isZh) {
+    return '基于状态的样式与渲染：该组件将每一项内部状态通过两条等价通道同时对外暴露，下表逐行给出两者的对应关系。一是 CSS className：根节点上会动态加上 ui-<state> 形式的类名，可直接用 .ui-<state> { ... } 选择器定制样式；二是 render-prop 字段：当 children 传入函数时，同一个状态会以 children({ <state>: boolean, ... }) 的形式作为参数传入，便于在运行时做条件渲染。两条通道指向完全相同的条件，你可以任选其一，也可以同时使用。';
+  }
+  return 'State-based styling & rendering: this component exposes each of its internal states through two interchangeable channels, and the table below maps them one-to-one. First, a CSS className like ui-<state> is toggled on the root node, so you can style it with selectors such as .ui-<state> { ... }. Second, a render-prop field: when children is a function, the same state is passed in via children({ <state>: boolean, ... }) for runtime-driven rendering. Both channels reflect the exact same condition, so you can pick either one, or use both together.';
+};
+
   
 
 ### Checkbox 
@@ -215,6 +225,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     }
   }
 ]}/>
+<ClassRenderPropPreamble />
 <ClassRenderPropTable source={[
   {
     "className": "ui-checked",

--- a/packages/lynx-ui-checkbox/docs/APIReference.mdx
+++ b/packages/lynx-ui-checkbox/docs/APIReference.mdx
@@ -4,9 +4,39 @@ import { useLang } from '@rspress/core/runtime';
 export const ClassRenderPropPreamble = () => {
   const isZh = useLang() === 'zh';
   if (isZh) {
-    return '基于状态的样式与渲染：该组件将每一项内部状态通过两条等价通道同时对外暴露，下表逐行给出两者的对应关系。一是 CSS className：根节点上会动态加上 ui-<state> 形式的类名，可直接用 .ui-<state> { ... } 选择器定制样式；二是 render-prop 字段：当 children 传入函数时，同一个状态会以 children({ <state>: boolean, ... }) 的形式作为参数传入，便于在运行时做条件渲染。两条通道指向完全相同的条件，你可以任选其一，也可以同时使用。';
+    return (
+      <>
+        <h3>基于状态的样式与渲染</h3>
+        <p>
+          该组件将每一项内部状态通过<strong>两条等价通道</strong>同时对外暴露，下表逐行给出两者的对应关系：
+        </p>
+        <ul>
+          <li>
+            <strong>CSS className</strong>：根节点上会动态加上 <code>{'ui-<state>'}</code> 形式的类名，可直接用 <code>{'.ui-<state> { ... }'}</code> 选择器定制样式；
+          </li>
+          <li>
+            <strong>Render-prop 字段</strong>：当 <code>children</code> 传入函数时，同一个状态会以 <code>{'children({ <state>: boolean, ... })'}</code> 的形式作为参数传入，便于在运行时做条件渲染。
+          </li>
+        </ul>
+      </>
+    );
   }
-  return 'State-based styling & rendering: this component exposes each of its internal states through two interchangeable channels, and the table below maps them one-to-one. First, a CSS className like ui-<state> is toggled on the root node, so you can style it with selectors such as .ui-<state> { ... }. Second, a render-prop field: when children is a function, the same state is passed in via children({ <state>: boolean, ... }) for runtime-driven rendering. Both channels reflect the exact same condition, so you can pick either one, or use both together.';
+  return (
+    <>
+      <h3>State-based styling & rendering</h3>
+      <p>
+        This component exposes each of its internal states through <strong>two interchangeable channels</strong>, and the table below maps them one-to-one:
+      </p>
+      <ul>
+        <li>
+          <strong>CSS className</strong> — a class like <code>{'ui-<state>'}</code> is toggled on the root node, so you can style it with selectors such as <code>{'.ui-<state> { ... }'}</code>.
+        </li>
+        <li>
+          <strong>Render-prop field</strong> — when <code>children</code> is a function, the same state is passed in via <code>{'children({ <state>: boolean, ... })'}</code> for runtime-driven rendering.
+        </li>
+      </ul>
+    </>
+  );
 };
 
   

--- a/packages/lynx-ui-dialog/docs/APIReference.mdx
+++ b/packages/lynx-ui-dialog/docs/APIReference.mdx
@@ -1,4 +1,14 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+import { useLang } from '@rspress/core/runtime';
+
+export const ClassRenderPropPreamble = () => {
+  const isZh = useLang() === 'zh';
+  if (isZh) {
+    return '基于状态的样式与渲染：该组件将每一项内部状态通过两条等价通道同时对外暴露，下表逐行给出两者的对应关系。一是 CSS className：根节点上会动态加上 ui-<state> 形式的类名，可直接用 .ui-<state> { ... } 选择器定制样式；二是 render-prop 字段：当 children 传入函数时，同一个状态会以 children({ <state>: boolean, ... }) 的形式作为参数传入，便于在运行时做条件渲染。两条通道指向完全相同的条件，你可以任选其一，也可以同时使用。';
+  }
+  return 'State-based styling & rendering: this component exposes each of its internal states through two interchangeable channels, and the table below maps them one-to-one. First, a CSS className like ui-<state> is toggled on the root node, so you can style it with selectors such as .ui-<state> { ... }. Second, a render-prop field: when children is a function, the same state is passed in via children({ <state>: boolean, ... }) for runtime-driven rendering. Both channels reflect the exact same condition, so you can pick either one, or use both together.';
+};
+
   
 ### DialogRoot 
     The root component of the Dialog, containing all of its child components.
@@ -200,6 +210,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "docTypeFallback": null
   }
 ]}/>
+<ClassRenderPropPreamble />
 <ClassRenderPropTable source={[
   {
     "className": "ui-animating",
@@ -710,6 +721,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     }
   }
 ]}/>
+<ClassRenderPropPreamble />
 <ClassRenderPropTable source={[
   {
     "className": "ui-open",

--- a/packages/lynx-ui-dialog/docs/APIReference.mdx
+++ b/packages/lynx-ui-dialog/docs/APIReference.mdx
@@ -4,9 +4,39 @@ import { useLang } from '@rspress/core/runtime';
 export const ClassRenderPropPreamble = () => {
   const isZh = useLang() === 'zh';
   if (isZh) {
-    return '基于状态的样式与渲染：该组件将每一项内部状态通过两条等价通道同时对外暴露，下表逐行给出两者的对应关系。一是 CSS className：根节点上会动态加上 ui-<state> 形式的类名，可直接用 .ui-<state> { ... } 选择器定制样式；二是 render-prop 字段：当 children 传入函数时，同一个状态会以 children({ <state>: boolean, ... }) 的形式作为参数传入，便于在运行时做条件渲染。两条通道指向完全相同的条件，你可以任选其一，也可以同时使用。';
+    return (
+      <>
+        <h3>基于状态的样式与渲染</h3>
+        <p>
+          该组件将每一项内部状态通过<strong>两条等价通道</strong>同时对外暴露，下表逐行给出两者的对应关系：
+        </p>
+        <ul>
+          <li>
+            <strong>CSS className</strong>：根节点上会动态加上 <code>{'ui-<state>'}</code> 形式的类名，可直接用 <code>{'.ui-<state> { ... }'}</code> 选择器定制样式；
+          </li>
+          <li>
+            <strong>Render-prop 字段</strong>：当 <code>children</code> 传入函数时，同一个状态会以 <code>{'children({ <state>: boolean, ... })'}</code> 的形式作为参数传入，便于在运行时做条件渲染。
+          </li>
+        </ul>
+      </>
+    );
   }
-  return 'State-based styling & rendering: this component exposes each of its internal states through two interchangeable channels, and the table below maps them one-to-one. First, a CSS className like ui-<state> is toggled on the root node, so you can style it with selectors such as .ui-<state> { ... }. Second, a render-prop field: when children is a function, the same state is passed in via children({ <state>: boolean, ... }) for runtime-driven rendering. Both channels reflect the exact same condition, so you can pick either one, or use both together.';
+  return (
+    <>
+      <h3>State-based styling & rendering</h3>
+      <p>
+        This component exposes each of its internal states through <strong>two interchangeable channels</strong>, and the table below maps them one-to-one:
+      </p>
+      <ul>
+        <li>
+          <strong>CSS className</strong> — a class like <code>{'ui-<state>'}</code> is toggled on the root node, so you can style it with selectors such as <code>{'.ui-<state> { ... }'}</code>.
+        </li>
+        <li>
+          <strong>Render-prop field</strong> — when <code>children</code> is a function, the same state is passed in via <code>{'children({ <state>: boolean, ... })'}</code> for runtime-driven rendering.
+        </li>
+      </ul>
+    </>
+  );
 };
 
   

--- a/packages/lynx-ui-draggable/docs/APIReference.mdx
+++ b/packages/lynx-ui-draggable/docs/APIReference.mdx
@@ -1,4 +1,6 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+
+
   
 ### Draggable 
     

--- a/packages/lynx-ui-feed-list/docs/APIReference.mdx
+++ b/packages/lynx-ui-feed-list/docs/APIReference.mdx
@@ -1,5 +1,7 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
+
+
   
 ## FeedListProps
     

--- a/packages/lynx-ui-form/docs/APIReference.mdx
+++ b/packages/lynx-ui-form/docs/APIReference.mdx
@@ -1,4 +1,14 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+import { useLang } from '@rspress/core/runtime';
+
+export const ClassRenderPropPreamble = () => {
+  const isZh = useLang() === 'zh';
+  if (isZh) {
+    return '基于状态的样式与渲染：该组件将每一项内部状态通过两条等价通道同时对外暴露，下表逐行给出两者的对应关系。一是 CSS className：根节点上会动态加上 ui-<state> 形式的类名，可直接用 .ui-<state> { ... } 选择器定制样式；二是 render-prop 字段：当 children 传入函数时，同一个状态会以 children({ <state>: boolean, ... }) 的形式作为参数传入，便于在运行时做条件渲染。两条通道指向完全相同的条件，你可以任选其一，也可以同时使用。';
+  }
+  return 'State-based styling & rendering: this component exposes each of its internal states through two interchangeable channels, and the table below maps them one-to-one. First, a CSS className like ui-<state> is toggled on the root node, so you can style it with selectors such as .ui-<state> { ... }. Second, a render-prop field: when children is a function, the same state is passed in via children({ <state>: boolean, ... }) for runtime-driven rendering. Both channels reflect the exact same condition, so you can pick either one, or use both together.';
+};
+
   
 ### FormRoot 
     
@@ -813,13 +823,15 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     }
   }
 ]}/>
+<ClassRenderPropPreamble />
 <ClassRenderPropTable source={[
   {
     "className": "ui-active",
     "Render Prop": "active",
     "item": {
       "type": "boolean",
-      "description": "Render function state: active.\nApplied when `status.active` is true."
+      "description": "Whether the button is currently being pressed (and not disabled).\nApplied when `status.active` is true.",
+      "description_zh": "按钮当前是否处于按下态（且未被禁用）。\n当 status.active 为 true 时生效，可用于 `.ui-active { ... }`。"
     }
   },
   {
@@ -827,7 +839,8 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "Render Prop": "disabled",
     "item": {
       "type": "boolean",
-      "description": "Render function state: disabled.\nApplied when `status.disabled` is true."
+      "description": "Whether the button is disabled.\nApplied when `status.disabled` is true.",
+      "description_zh": "按钮是否处于禁用态。\n当 status.disabled 为 true 时生效，可用于 `.ui-disabled { ... }`。"
     }
   }
 ]}/>

--- a/packages/lynx-ui-form/docs/APIReference.mdx
+++ b/packages/lynx-ui-form/docs/APIReference.mdx
@@ -4,9 +4,39 @@ import { useLang } from '@rspress/core/runtime';
 export const ClassRenderPropPreamble = () => {
   const isZh = useLang() === 'zh';
   if (isZh) {
-    return '基于状态的样式与渲染：该组件将每一项内部状态通过两条等价通道同时对外暴露，下表逐行给出两者的对应关系。一是 CSS className：根节点上会动态加上 ui-<state> 形式的类名，可直接用 .ui-<state> { ... } 选择器定制样式；二是 render-prop 字段：当 children 传入函数时，同一个状态会以 children({ <state>: boolean, ... }) 的形式作为参数传入，便于在运行时做条件渲染。两条通道指向完全相同的条件，你可以任选其一，也可以同时使用。';
+    return (
+      <>
+        <h3>基于状态的样式与渲染</h3>
+        <p>
+          该组件将每一项内部状态通过<strong>两条等价通道</strong>同时对外暴露，下表逐行给出两者的对应关系：
+        </p>
+        <ul>
+          <li>
+            <strong>CSS className</strong>：根节点上会动态加上 <code>{'ui-<state>'}</code> 形式的类名，可直接用 <code>{'.ui-<state> { ... }'}</code> 选择器定制样式；
+          </li>
+          <li>
+            <strong>Render-prop 字段</strong>：当 <code>children</code> 传入函数时，同一个状态会以 <code>{'children({ <state>: boolean, ... })'}</code> 的形式作为参数传入，便于在运行时做条件渲染。
+          </li>
+        </ul>
+      </>
+    );
   }
-  return 'State-based styling & rendering: this component exposes each of its internal states through two interchangeable channels, and the table below maps them one-to-one. First, a CSS className like ui-<state> is toggled on the root node, so you can style it with selectors such as .ui-<state> { ... }. Second, a render-prop field: when children is a function, the same state is passed in via children({ <state>: boolean, ... }) for runtime-driven rendering. Both channels reflect the exact same condition, so you can pick either one, or use both together.';
+  return (
+    <>
+      <h3>State-based styling & rendering</h3>
+      <p>
+        This component exposes each of its internal states through <strong>two interchangeable channels</strong>, and the table below maps them one-to-one:
+      </p>
+      <ul>
+        <li>
+          <strong>CSS className</strong> — a class like <code>{'ui-<state>'}</code> is toggled on the root node, so you can style it with selectors such as <code>{'.ui-<state> { ... }'}</code>.
+        </li>
+        <li>
+          <strong>Render-prop field</strong> — when <code>children</code> is a function, the same state is passed in via <code>{'children({ <state>: boolean, ... })'}</code> for runtime-driven rendering.
+        </li>
+      </ul>
+    </>
+  );
 };
 
   

--- a/packages/lynx-ui-input/docs/APIReference.mdx
+++ b/packages/lynx-ui-input/docs/APIReference.mdx
@@ -1,5 +1,7 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
+
+
   
 ## TextAreaProps
     

--- a/packages/lynx-ui-lazy-component/docs/APIReference.mdx
+++ b/packages/lynx-ui-lazy-component/docs/APIReference.mdx
@@ -1,5 +1,7 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
+
+
   
 ## LazyComponentProps
     

--- a/packages/lynx-ui-list/docs/APIReference.mdx
+++ b/packages/lynx-ui-list/docs/APIReference.mdx
@@ -1,5 +1,7 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
+
+
   
 ## ListProps
     

--- a/packages/lynx-ui-overlay/docs/APIReference.mdx
+++ b/packages/lynx-ui-overlay/docs/APIReference.mdx
@@ -1,5 +1,7 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
+
+
   
 ## OverlayViewProps
     

--- a/packages/lynx-ui-popover/docs/APIReference.mdx
+++ b/packages/lynx-ui-popover/docs/APIReference.mdx
@@ -1,4 +1,14 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+import { useLang } from '@rspress/core/runtime';
+
+export const ClassRenderPropPreamble = () => {
+  const isZh = useLang() === 'zh';
+  if (isZh) {
+    return '基于状态的样式与渲染：该组件将每一项内部状态通过两条等价通道同时对外暴露，下表逐行给出两者的对应关系。一是 CSS className：根节点上会动态加上 ui-<state> 形式的类名，可直接用 .ui-<state> { ... } 选择器定制样式；二是 render-prop 字段：当 children 传入函数时，同一个状态会以 children({ <state>: boolean, ... }) 的形式作为参数传入，便于在运行时做条件渲染。两条通道指向完全相同的条件，你可以任选其一，也可以同时使用。';
+  }
+  return 'State-based styling & rendering: this component exposes each of its internal states through two interchangeable channels, and the table below maps them one-to-one. First, a CSS className like ui-<state> is toggled on the root node, so you can style it with selectors such as .ui-<state> { ... }. Second, a render-prop field: when children is a function, the same state is passed in via children({ <state>: boolean, ... }) for runtime-driven rendering. Both channels reflect the exact same condition, so you can pick either one, or use both together.';
+};
+
   
 ### PopoverRoot 
     The root component of the Popover, containing all of its child components.
@@ -580,6 +590,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     }
   }
 ]}/>
+<ClassRenderPropPreamble />
 <ClassRenderPropTable source={[
   {
     "className": "ui-open",

--- a/packages/lynx-ui-popover/docs/APIReference.mdx
+++ b/packages/lynx-ui-popover/docs/APIReference.mdx
@@ -4,9 +4,39 @@ import { useLang } from '@rspress/core/runtime';
 export const ClassRenderPropPreamble = () => {
   const isZh = useLang() === 'zh';
   if (isZh) {
-    return '基于状态的样式与渲染：该组件将每一项内部状态通过两条等价通道同时对外暴露，下表逐行给出两者的对应关系。一是 CSS className：根节点上会动态加上 ui-<state> 形式的类名，可直接用 .ui-<state> { ... } 选择器定制样式；二是 render-prop 字段：当 children 传入函数时，同一个状态会以 children({ <state>: boolean, ... }) 的形式作为参数传入，便于在运行时做条件渲染。两条通道指向完全相同的条件，你可以任选其一，也可以同时使用。';
+    return (
+      <>
+        <h3>基于状态的样式与渲染</h3>
+        <p>
+          该组件将每一项内部状态通过<strong>两条等价通道</strong>同时对外暴露，下表逐行给出两者的对应关系：
+        </p>
+        <ul>
+          <li>
+            <strong>CSS className</strong>：根节点上会动态加上 <code>{'ui-<state>'}</code> 形式的类名，可直接用 <code>{'.ui-<state> { ... }'}</code> 选择器定制样式；
+          </li>
+          <li>
+            <strong>Render-prop 字段</strong>：当 <code>children</code> 传入函数时，同一个状态会以 <code>{'children({ <state>: boolean, ... })'}</code> 的形式作为参数传入，便于在运行时做条件渲染。
+          </li>
+        </ul>
+      </>
+    );
   }
-  return 'State-based styling & rendering: this component exposes each of its internal states through two interchangeable channels, and the table below maps them one-to-one. First, a CSS className like ui-<state> is toggled on the root node, so you can style it with selectors such as .ui-<state> { ... }. Second, a render-prop field: when children is a function, the same state is passed in via children({ <state>: boolean, ... }) for runtime-driven rendering. Both channels reflect the exact same condition, so you can pick either one, or use both together.';
+  return (
+    <>
+      <h3>State-based styling & rendering</h3>
+      <p>
+        This component exposes each of its internal states through <strong>two interchangeable channels</strong>, and the table below maps them one-to-one:
+      </p>
+      <ul>
+        <li>
+          <strong>CSS className</strong> — a class like <code>{'ui-<state>'}</code> is toggled on the root node, so you can style it with selectors such as <code>{'.ui-<state> { ... }'}</code>.
+        </li>
+        <li>
+          <strong>Render-prop field</strong> — when <code>children</code> is a function, the same state is passed in via <code>{'children({ <state>: boolean, ... })'}</code> for runtime-driven rendering.
+        </li>
+      </ul>
+    </>
+  );
 };
 
   

--- a/packages/lynx-ui-radio-group/docs/APIReference.mdx
+++ b/packages/lynx-ui-radio-group/docs/APIReference.mdx
@@ -1,4 +1,6 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+
+
   
 ### RadioGroupRoot 
     The root component of the RadioGroup, containing all of its child components.

--- a/packages/lynx-ui-scroll-view/docs/APIReference.mdx
+++ b/packages/lynx-ui-scroll-view/docs/APIReference.mdx
@@ -1,5 +1,7 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
+
+
   
 ## ScrollViewProps
     

--- a/packages/lynx-ui-sheet/docs/APIReference.mdx
+++ b/packages/lynx-ui-sheet/docs/APIReference.mdx
@@ -1,4 +1,6 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+
+
   
 ### SheetRoot 
     The root component of the Sheet, containing all of its child components.

--- a/packages/lynx-ui-slider/docs/APIReference.mdx
+++ b/packages/lynx-ui-slider/docs/APIReference.mdx
@@ -1,5 +1,7 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
+
+
   
 ## SliderTrackProps
     
@@ -78,7 +80,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": false,
+    "isSupportHarmony": true,
     "docTypeFallback": null
   },
   {
@@ -100,7 +102,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": false,
+    "isSupportHarmony": true,
     "docTypeFallback": null
   }
 ]}/>
@@ -151,7 +153,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": false,
+    "isSupportHarmony": true,
     "docTypeFallback": null
   },
   {
@@ -173,7 +175,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": false,
+    "isSupportHarmony": true,
     "docTypeFallback": null
   }
 ]}/>
@@ -273,7 +275,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": false,
+    "isSupportHarmony": true,
     "docTypeFallback": null
   },
   {
@@ -529,7 +531,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": false,
+    "isSupportHarmony": true,
     "docTypeFallback": null
   },
   {
@@ -613,7 +615,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": false,
+    "isSupportHarmony": true,
     "docTypeFallback": null
   },
   {
@@ -635,7 +637,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": false,
+    "isSupportHarmony": true,
     "docTypeFallback": null
   }
 ]}/>

--- a/packages/lynx-ui-sortable/docs/APIReference.mdx
+++ b/packages/lynx-ui-sortable/docs/APIReference.mdx
@@ -1,5 +1,7 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
+
+
   
 ## SortableRootProps
     

--- a/packages/lynx-ui-swipe-action/docs/APIReference.mdx
+++ b/packages/lynx-ui-swipe-action/docs/APIReference.mdx
@@ -1,5 +1,7 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
+
+
   
 ## SwipeActionProps
     

--- a/packages/lynx-ui-swiper/docs/APIReference.mdx
+++ b/packages/lynx-ui-swiper/docs/APIReference.mdx
@@ -1,5 +1,7 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
+
+
   
 ## SwiperProps
     

--- a/packages/lynx-ui-switch/docs/APIReference.mdx
+++ b/packages/lynx-ui-switch/docs/APIReference.mdx
@@ -1,4 +1,14 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+import { useLang } from '@rspress/core/runtime';
+
+export const ClassRenderPropPreamble = () => {
+  const isZh = useLang() === 'zh';
+  if (isZh) {
+    return '基于状态的样式与渲染：该组件将每一项内部状态通过两条等价通道同时对外暴露，下表逐行给出两者的对应关系。一是 CSS className：根节点上会动态加上 ui-<state> 形式的类名，可直接用 .ui-<state> { ... } 选择器定制样式；二是 render-prop 字段：当 children 传入函数时，同一个状态会以 children({ <state>: boolean, ... }) 的形式作为参数传入，便于在运行时做条件渲染。两条通道指向完全相同的条件，你可以任选其一，也可以同时使用。';
+  }
+  return 'State-based styling & rendering: this component exposes each of its internal states through two interchangeable channels, and the table below maps them one-to-one. First, a CSS className like ui-<state> is toggled on the root node, so you can style it with selectors such as .ui-<state> { ... }. Second, a render-prop field: when children is a function, the same state is passed in via children({ <state>: boolean, ... }) for runtime-driven rendering. Both channels reflect the exact same condition, so you can pick either one, or use both together.';
+};
+
   
 ### SwitchTrack 
     The track of the Switch.
@@ -398,6 +408,7 @@ The draggable/clickable handle that toggles the state.
     }
   }
 ]}/>
+<ClassRenderPropPreamble />
 <ClassRenderPropTable source={[
   {
     "className": "ui-checked",

--- a/packages/lynx-ui-switch/docs/APIReference.mdx
+++ b/packages/lynx-ui-switch/docs/APIReference.mdx
@@ -4,9 +4,39 @@ import { useLang } from '@rspress/core/runtime';
 export const ClassRenderPropPreamble = () => {
   const isZh = useLang() === 'zh';
   if (isZh) {
-    return '基于状态的样式与渲染：该组件将每一项内部状态通过两条等价通道同时对外暴露，下表逐行给出两者的对应关系。一是 CSS className：根节点上会动态加上 ui-<state> 形式的类名，可直接用 .ui-<state> { ... } 选择器定制样式；二是 render-prop 字段：当 children 传入函数时，同一个状态会以 children({ <state>: boolean, ... }) 的形式作为参数传入，便于在运行时做条件渲染。两条通道指向完全相同的条件，你可以任选其一，也可以同时使用。';
+    return (
+      <>
+        <h3>基于状态的样式与渲染</h3>
+        <p>
+          该组件将每一项内部状态通过<strong>两条等价通道</strong>同时对外暴露，下表逐行给出两者的对应关系：
+        </p>
+        <ul>
+          <li>
+            <strong>CSS className</strong>：根节点上会动态加上 <code>{'ui-<state>'}</code> 形式的类名，可直接用 <code>{'.ui-<state> { ... }'}</code> 选择器定制样式；
+          </li>
+          <li>
+            <strong>Render-prop 字段</strong>：当 <code>children</code> 传入函数时，同一个状态会以 <code>{'children({ <state>: boolean, ... })'}</code> 的形式作为参数传入，便于在运行时做条件渲染。
+          </li>
+        </ul>
+      </>
+    );
   }
-  return 'State-based styling & rendering: this component exposes each of its internal states through two interchangeable channels, and the table below maps them one-to-one. First, a CSS className like ui-<state> is toggled on the root node, so you can style it with selectors such as .ui-<state> { ... }. Second, a render-prop field: when children is a function, the same state is passed in via children({ <state>: boolean, ... }) for runtime-driven rendering. Both channels reflect the exact same condition, so you can pick either one, or use both together.';
+  return (
+    <>
+      <h3>State-based styling & rendering</h3>
+      <p>
+        This component exposes each of its internal states through <strong>two interchangeable channels</strong>, and the table below maps them one-to-one:
+      </p>
+      <ul>
+        <li>
+          <strong>CSS className</strong> — a class like <code>{'ui-<state>'}</code> is toggled on the root node, so you can style it with selectors such as <code>{'.ui-<state> { ... }'}</code>.
+        </li>
+        <li>
+          <strong>Render-prop field</strong> — when <code>children</code> is a function, the same state is passed in via <code>{'children({ <state>: boolean, ... })'}</code> for runtime-driven rendering.
+        </li>
+      </ul>
+    </>
+  );
 };
 
   

--- a/tools/typedoc/tpl.ts
+++ b/tools/typedoc/tpl.ts
@@ -609,10 +609,11 @@ const doGenTplWithData = async (
   //
   // - `import { useLang }` uses Rspress's runtime hook to detect the current
   //   documentation locale at render time.
-  // - `ClassRenderPropPreamble` is a locale-aware wrapper component that
-  //   appears above every <ClassRenderPropTable/> in the body. It returns the
-  //   copy as a plain string so the output stays free of HTML tags such as
-  //   <h3>, <p>, <ul>, <strong>, <code>, etc.
+  // - `ClassRenderPropPreamble` is a locale-aware wrapper component rendered
+  //   above every <ClassRenderPropTable/> in the body. It emits an <h3>
+  //   subtitle, a short lead paragraph, a two-item <ul> that maps the CSS
+  //   className channel and the render-prop channel side by side, and a
+  //   closing note explaining that both channels are interchangeable.
   const mdxHeader =
     `import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 import { useLang } from '@rspress/core/runtime';
@@ -620,9 +621,39 @@ import { useLang } from '@rspress/core/runtime';
 export const ClassRenderPropPreamble = () => {
   const isZh = useLang() === 'zh';
   if (isZh) {
-    return '基于状态的样式与渲染：该组件将每一项内部状态通过两条等价通道同时对外暴露，下表逐行给出两者的对应关系。一是 CSS className：根节点上会动态加上 ui-<state> 形式的类名，可直接用 .ui-<state> { ... } 选择器定制样式；二是 render-prop 字段：当 children 传入函数时，同一个状态会以 children({ <state>: boolean, ... }) 的形式作为参数传入，便于在运行时做条件渲染。两条通道指向完全相同的条件，你可以任选其一，也可以同时使用。';
+    return (
+      <>
+        <h3>基于状态的样式与渲染</h3>
+        <p>
+          该组件将每一项内部状态通过<strong>两条等价通道</strong>同时对外暴露，下表逐行给出两者的对应关系：
+        </p>
+        <ul>
+          <li>
+            <strong>CSS className</strong>：根节点上会动态加上 <code>{'ui-<state>'}</code> 形式的类名，可直接用 <code>{'.ui-<state> { ... }'}</code> 选择器定制样式；
+          </li>
+          <li>
+            <strong>Render-prop 字段</strong>：当 <code>children</code> 传入函数时，同一个状态会以 <code>{'children({ <state>: boolean, ... })'}</code> 的形式作为参数传入，便于在运行时做条件渲染。
+          </li>
+        </ul>
+      </>
+    );
   }
-  return 'State-based styling & rendering: this component exposes each of its internal states through two interchangeable channels, and the table below maps them one-to-one. First, a CSS className like ui-<state> is toggled on the root node, so you can style it with selectors such as .ui-<state> { ... }. Second, a render-prop field: when children is a function, the same state is passed in via children({ <state>: boolean, ... }) for runtime-driven rendering. Both channels reflect the exact same condition, so you can pick either one, or use both together.';
+  return (
+    <>
+      <h3>State-based styling & rendering</h3>
+      <p>
+        This component exposes each of its internal states through <strong>two interchangeable channels</strong>, and the table below maps them one-to-one:
+      </p>
+      <ul>
+        <li>
+          <strong>CSS className</strong> — a class like <code>{'ui-<state>'}</code> is toggled on the root node, so you can style it with selectors such as <code>{'.ui-<state> { ... }'}</code>.
+        </li>
+        <li>
+          <strong>Render-prop field</strong> — when <code>children</code> is a function, the same state is passed in via <code>{'children({ <state>: boolean, ... })'}</code> for runtime-driven rendering.
+        </li>
+      </ul>
+    </>
+  );
 };
 `
 

--- a/tools/typedoc/tpl.ts
+++ b/tools/typedoc/tpl.ts
@@ -462,8 +462,15 @@ ${
         2,
       )
 
+      // Inject a single-tag reference to <ClassRenderPropPreamble />. The actual
+      // component (which picks the current locale via Rspress's `useLang()` hook
+      // and renders the corresponding copy) is defined once at the top of every
+      // generated APIReference.mdx that contains at least one ClassRenderPropTable.
+      const classRenderPropPreamble = `<ClassRenderPropPreamble />`
+
       context += `
 <UIApiTable source={${renderSourceString}}/>
+${classRenderPropPreamble}
 <ClassRenderPropTable source={${mergedTableSource}}/>
       `
     }
@@ -598,51 +605,81 @@ const doGenTplWithData = async (
     fs.mkdirSync(saveDir, { recursive: true })
   }
 
+  // Shared MDX header injected into every generated APIReference.mdx.
+  //
+  // - `import { useLang }` uses Rspress's runtime hook to detect the current
+  //   documentation locale at render time.
+  // - `ClassRenderPropPreamble` is a locale-aware wrapper component that
+  //   appears above every <ClassRenderPropTable/> in the body. It returns the
+  //   copy as a plain string so the output stays free of HTML tags such as
+  //   <h3>, <p>, <ul>, <strong>, <code>, etc.
+  const mdxHeader =
+    `import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+import { useLang } from '@rspress/core/runtime';
+
+export const ClassRenderPropPreamble = () => {
+  const isZh = useLang() === 'zh';
+  if (isZh) {
+    return '基于状态的样式与渲染：该组件将每一项内部状态通过两条等价通道同时对外暴露，下表逐行给出两者的对应关系。一是 CSS className：根节点上会动态加上 ui-<state> 形式的类名，可直接用 .ui-<state> { ... } 选择器定制样式；二是 render-prop 字段：当 children 传入函数时，同一个状态会以 children({ <state>: boolean, ... }) 的形式作为参数传入，便于在运行时做条件渲染。两条通道指向完全相同的条件，你可以任选其一，也可以同时使用。';
+  }
+  return 'State-based styling & rendering: this component exposes each of its internal states through two interchangeable channels, and the table below maps them one-to-one. First, a CSS className like ui-<state> is toggled on the root node, so you can style it with selectors such as .ui-<state> { ... }. Second, a render-prop field: when children is a function, the same state is passed in via children({ <state>: boolean, ... }) for runtime-driven rendering. Both channels reflect the exact same condition, so you can pick either one, or use both together.';
+};
+`
+
   if (multipleProps) {
-    content =
-      `import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+    content = `${mdxHeader}
   ${
-        sortedData.map((item: any) => {
-          if (renderPropsTitlesToSkip.has(item.title)) return ''
-          if (!titleOrder.includes(item.title.replace(/Props$/, ''))) {
-            return
-          }
-          if (item.title.includes('Props')) {
-            return genProps(item, multipleProps, isZh)
-          }
-          if (item.title.includes('Ref')) {
-            return genRef(item)
-          }
+      sortedData.map((item: any) => {
+        if (renderPropsTitlesToSkip.has(item.title)) return ''
+        if (!titleOrder.includes(item.title.replace(/Props$/, ''))) {
           return
-        }).join('\n')
-      }
+        }
+        if (item.title.includes('Props')) {
+          return genProps(item, multipleProps, isZh)
+        }
+        if (item.title.includes('Ref')) {
+          return genRef(item)
+        }
+        return
+      }).join('\n')
+    }
   `
-
-    fs.writeFileSync(savePath, content)
   } else {
-    content =
-      `import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+    content = `${mdxHeader}
 
   ${
-        sortedData.map((item: any) => {
-          if (renderPropsTitlesToSkip.has(item.title)) return ''
-          if (item.title.includes('Props')) {
-            if (!hasProcessedFirstProps) {
-              hasProcessedFirstProps = true
-              return genProps(item, false, isZh)
-            }
-            return doGenMdx([item], isZh)
-          }
-          if (item.title.includes('Ref')) {
-            return genRef(item)
+      sortedData.map((item: any) => {
+        if (renderPropsTitlesToSkip.has(item.title)) return ''
+        if (item.title.includes('Props')) {
+          if (!hasProcessedFirstProps) {
+            hasProcessedFirstProps = true
+            return genProps(item, false, isZh)
           }
           return doGenMdx([item], isZh)
-        }).join('\n')
-      }
+        }
+        if (item.title.includes('Ref')) {
+          return genRef(item)
+        }
+        return doGenMdx([item], isZh)
+      }).join('\n')
+    }
   `
-
-    fs.writeFileSync(savePath, content)
   }
+
+  // Strip the locale-aware preamble scaffolding when the generated body does
+  // not actually contain any <ClassRenderPropTable/>. This keeps the output
+  // minimal for components without render-prop state and avoids shipping
+  // unused `useLang` imports through the docs pipeline.
+  if (!content.includes('<ClassRenderPropPreamble />')) {
+    content = content
+      .replace(/^import \{ useLang \} from '@rspress\/core\/runtime';\n/m, '')
+      .replace(
+        /export const ClassRenderPropPreamble = \(\) => \{[\s\S]*?\n\};\n/,
+        '',
+      )
+  }
+
+  fs.writeFileSync(savePath, content)
 }
 
 export { doGenTplWithData }


### PR DESCRIPTION
…tation

add locale-aware preamble for ClassRenderPropTable components and update harmony platform support flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added bilingual (Chinese/English) explanations in API references describing how component states map to CSS classes and render props across multiple UI components
  * Enhanced documentation structure with clearer state mapping guidance

* **Other Changes**
  * Updated Slider component Harmony compatibility support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->