### PR TITLE
refactor(docs): clean up API reference files and consolidate imports

### DIFF
--- a/packages/lynx-ui-button/docs/APIReference.mdx
+++ b/packages/lynx-ui-button/docs/APIReference.mdx
@@ -1,43 +1,4 @@
-import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
-import { useLang } from '@rspress/core/runtime';
-
-export const ClassRenderPropPreamble = () => {
-  const isZh = useLang() === 'zh';
-  if (isZh) {
-    return (
-      <>
-        <h3>基于状态的样式与渲染</h3>
-        <p>
-          该组件将每一项内部状态通过<strong>两条等价通道</strong>同时对外暴露，下表逐行给出两者的对应关系：
-        </p>
-        <ul>
-          <li>
-            <strong>CSS className</strong>：根节点上会动态加上 <code>{'ui-<state>'}</code> 形式的类名，可直接用 <code>{'.ui-<state> { ... }'}</code> 选择器定制样式；
-          </li>
-          <li>
-            <strong>Render-prop 字段</strong>：当 <code>children</code> 传入函数时，同一个状态会以 <code>{'children({ <state>: boolean, ... })'}</code> 的形式作为参数传入，便于在运行时做条件渲染。
-          </li>
-        </ul>
-      </>
-    );
-  }
-  return (
-    <>
-      <h3>State-based styling & rendering</h3>
-      <p>
-        This component exposes each of its internal states through <strong>two interchangeable channels</strong>, and the table below maps them one-to-one:
-      </p>
-      <ul>
-        <li>
-          <strong>CSS className</strong> — a class like <code>{'ui-<state>'}</code> is toggled on the root node, so you can style it with selectors such as <code>{'.ui-<state> { ... }'}</code>.
-        </li>
-        <li>
-          <strong>Render-prop field</strong> — when <code>children</code> is a function, the same state is passed in via <code>{'children({ <state>: boolean, ... })'}</code> for runtime-driven rendering.
-        </li>
-      </ul>
-    </>
-  );
-};
+import { UIApiTable, ClassRenderPropTable, ClassRenderPropPreamble } from "@lynx-ui/index";
 
   
 

--- a/packages/lynx-ui-checkbox/docs/APIReference.mdx
+++ b/packages/lynx-ui-checkbox/docs/APIReference.mdx
@@ -1,43 +1,4 @@
-import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
-import { useLang } from '@rspress/core/runtime';
-
-export const ClassRenderPropPreamble = () => {
-  const isZh = useLang() === 'zh';
-  if (isZh) {
-    return (
-      <>
-        <h3>基于状态的样式与渲染</h3>
-        <p>
-          该组件将每一项内部状态通过<strong>两条等价通道</strong>同时对外暴露，下表逐行给出两者的对应关系：
-        </p>
-        <ul>
-          <li>
-            <strong>CSS className</strong>：根节点上会动态加上 <code>{'ui-<state>'}</code> 形式的类名，可直接用 <code>{'.ui-<state> { ... }'}</code> 选择器定制样式；
-          </li>
-          <li>
-            <strong>Render-prop 字段</strong>：当 <code>children</code> 传入函数时，同一个状态会以 <code>{'children({ <state>: boolean, ... })'}</code> 的形式作为参数传入，便于在运行时做条件渲染。
-          </li>
-        </ul>
-      </>
-    );
-  }
-  return (
-    <>
-      <h3>State-based styling & rendering</h3>
-      <p>
-        This component exposes each of its internal states through <strong>two interchangeable channels</strong>, and the table below maps them one-to-one:
-      </p>
-      <ul>
-        <li>
-          <strong>CSS className</strong> — a class like <code>{'ui-<state>'}</code> is toggled on the root node, so you can style it with selectors such as <code>{'.ui-<state> { ... }'}</code>.
-        </li>
-        <li>
-          <strong>Render-prop field</strong> — when <code>children</code> is a function, the same state is passed in via <code>{'children({ <state>: boolean, ... })'}</code> for runtime-driven rendering.
-        </li>
-      </ul>
-    </>
-  );
-};
+import { UIApiTable, ClassRenderPropTable, ClassRenderPropPreamble } from "@lynx-ui/index";
 
   
 

--- a/packages/lynx-ui-dialog/docs/APIReference.mdx
+++ b/packages/lynx-ui-dialog/docs/APIReference.mdx
@@ -1,43 +1,4 @@
-import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
-import { useLang } from '@rspress/core/runtime';
-
-export const ClassRenderPropPreamble = () => {
-  const isZh = useLang() === 'zh';
-  if (isZh) {
-    return (
-      <>
-        <h3>基于状态的样式与渲染</h3>
-        <p>
-          该组件将每一项内部状态通过<strong>两条等价通道</strong>同时对外暴露，下表逐行给出两者的对应关系：
-        </p>
-        <ul>
-          <li>
-            <strong>CSS className</strong>：根节点上会动态加上 <code>{'ui-<state>'}</code> 形式的类名，可直接用 <code>{'.ui-<state> { ... }'}</code> 选择器定制样式；
-          </li>
-          <li>
-            <strong>Render-prop 字段</strong>：当 <code>children</code> 传入函数时，同一个状态会以 <code>{'children({ <state>: boolean, ... })'}</code> 的形式作为参数传入，便于在运行时做条件渲染。
-          </li>
-        </ul>
-      </>
-    );
-  }
-  return (
-    <>
-      <h3>State-based styling & rendering</h3>
-      <p>
-        This component exposes each of its internal states through <strong>two interchangeable channels</strong>, and the table below maps them one-to-one:
-      </p>
-      <ul>
-        <li>
-          <strong>CSS className</strong> — a class like <code>{'ui-<state>'}</code> is toggled on the root node, so you can style it with selectors such as <code>{'.ui-<state> { ... }'}</code>.
-        </li>
-        <li>
-          <strong>Render-prop field</strong> — when <code>children</code> is a function, the same state is passed in via <code>{'children({ <state>: boolean, ... })'}</code> for runtime-driven rendering.
-        </li>
-      </ul>
-    </>
-  );
-};
+import { UIApiTable, ClassRenderPropTable, ClassRenderPropPreamble } from "@lynx-ui/index";
 
   
 ### DialogRoot 

--- a/packages/lynx-ui-draggable/docs/APIReference.mdx
+++ b/packages/lynx-ui-draggable/docs/APIReference.mdx
@@ -1,6 +1,5 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
-
   
 ### Draggable 
     

--- a/packages/lynx-ui-feed-list/docs/APIReference.mdx
+++ b/packages/lynx-ui-feed-list/docs/APIReference.mdx
@@ -1,7 +1,6 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
 
-
   
 ## FeedListProps
     

--- a/packages/lynx-ui-form/docs/APIReference.mdx
+++ b/packages/lynx-ui-form/docs/APIReference.mdx
@@ -1,43 +1,4 @@
-import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
-import { useLang } from '@rspress/core/runtime';
-
-export const ClassRenderPropPreamble = () => {
-  const isZh = useLang() === 'zh';
-  if (isZh) {
-    return (
-      <>
-        <h3>基于状态的样式与渲染</h3>
-        <p>
-          该组件将每一项内部状态通过<strong>两条等价通道</strong>同时对外暴露，下表逐行给出两者的对应关系：
-        </p>
-        <ul>
-          <li>
-            <strong>CSS className</strong>：根节点上会动态加上 <code>{'ui-<state>'}</code> 形式的类名，可直接用 <code>{'.ui-<state> { ... }'}</code> 选择器定制样式；
-          </li>
-          <li>
-            <strong>Render-prop 字段</strong>：当 <code>children</code> 传入函数时，同一个状态会以 <code>{'children({ <state>: boolean, ... })'}</code> 的形式作为参数传入，便于在运行时做条件渲染。
-          </li>
-        </ul>
-      </>
-    );
-  }
-  return (
-    <>
-      <h3>State-based styling & rendering</h3>
-      <p>
-        This component exposes each of its internal states through <strong>two interchangeable channels</strong>, and the table below maps them one-to-one:
-      </p>
-      <ul>
-        <li>
-          <strong>CSS className</strong> — a class like <code>{'ui-<state>'}</code> is toggled on the root node, so you can style it with selectors such as <code>{'.ui-<state> { ... }'}</code>.
-        </li>
-        <li>
-          <strong>Render-prop field</strong> — when <code>children</code> is a function, the same state is passed in via <code>{'children({ <state>: boolean, ... })'}</code> for runtime-driven rendering.
-        </li>
-      </ul>
-    </>
-  );
-};
+import { UIApiTable, ClassRenderPropTable, ClassRenderPropPreamble } from "@lynx-ui/index";
 
   
 ### FormRoot 

--- a/packages/lynx-ui-input/docs/APIReference.mdx
+++ b/packages/lynx-ui-input/docs/APIReference.mdx
@@ -1,7 +1,6 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
 
-
   
 ## TextAreaProps
     

--- a/packages/lynx-ui-lazy-component/docs/APIReference.mdx
+++ b/packages/lynx-ui-lazy-component/docs/APIReference.mdx
@@ -1,7 +1,6 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
 
-
   
 ## LazyComponentProps
     

--- a/packages/lynx-ui-list/docs/APIReference.mdx
+++ b/packages/lynx-ui-list/docs/APIReference.mdx
@@ -1,7 +1,6 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
 
-
   
 ## ListProps
     

--- a/packages/lynx-ui-overlay/docs/APIReference.mdx
+++ b/packages/lynx-ui-overlay/docs/APIReference.mdx
@@ -1,7 +1,6 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
 
-
   
 ## OverlayViewProps
     

--- a/packages/lynx-ui-popover/docs/APIReference.mdx
+++ b/packages/lynx-ui-popover/docs/APIReference.mdx
@@ -1,43 +1,4 @@
-import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
-import { useLang } from '@rspress/core/runtime';
-
-export const ClassRenderPropPreamble = () => {
-  const isZh = useLang() === 'zh';
-  if (isZh) {
-    return (
-      <>
-        <h3>基于状态的样式与渲染</h3>
-        <p>
-          该组件将每一项内部状态通过<strong>两条等价通道</strong>同时对外暴露，下表逐行给出两者的对应关系：
-        </p>
-        <ul>
-          <li>
-            <strong>CSS className</strong>：根节点上会动态加上 <code>{'ui-<state>'}</code> 形式的类名，可直接用 <code>{'.ui-<state> { ... }'}</code> 选择器定制样式；
-          </li>
-          <li>
-            <strong>Render-prop 字段</strong>：当 <code>children</code> 传入函数时，同一个状态会以 <code>{'children({ <state>: boolean, ... })'}</code> 的形式作为参数传入，便于在运行时做条件渲染。
-          </li>
-        </ul>
-      </>
-    );
-  }
-  return (
-    <>
-      <h3>State-based styling & rendering</h3>
-      <p>
-        This component exposes each of its internal states through <strong>two interchangeable channels</strong>, and the table below maps them one-to-one:
-      </p>
-      <ul>
-        <li>
-          <strong>CSS className</strong> — a class like <code>{'ui-<state>'}</code> is toggled on the root node, so you can style it with selectors such as <code>{'.ui-<state> { ... }'}</code>.
-        </li>
-        <li>
-          <strong>Render-prop field</strong> — when <code>children</code> is a function, the same state is passed in via <code>{'children({ <state>: boolean, ... })'}</code> for runtime-driven rendering.
-        </li>
-      </ul>
-    </>
-  );
-};
+import { UIApiTable, ClassRenderPropTable, ClassRenderPropPreamble } from "@lynx-ui/index";
 
   
 ### PopoverRoot 

--- a/packages/lynx-ui-radio-group/docs/APIReference.mdx
+++ b/packages/lynx-ui-radio-group/docs/APIReference.mdx
@@ -1,6 +1,5 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
-
   
 ### RadioGroupRoot 
     The root component of the RadioGroup, containing all of its child components.

--- a/packages/lynx-ui-scroll-view/docs/APIReference.mdx
+++ b/packages/lynx-ui-scroll-view/docs/APIReference.mdx
@@ -1,7 +1,6 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
 
-
   
 ## ScrollViewProps
     

--- a/packages/lynx-ui-sheet/docs/APIReference.mdx
+++ b/packages/lynx-ui-sheet/docs/APIReference.mdx
@@ -1,6 +1,5 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
-
   
 ### SheetRoot 
     The root component of the Sheet, containing all of its child components.

--- a/packages/lynx-ui-slider/docs/APIReference.mdx
+++ b/packages/lynx-ui-slider/docs/APIReference.mdx
@@ -1,7 +1,6 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
 
-
   
 ## SliderTrackProps
     

--- a/packages/lynx-ui-sortable/docs/APIReference.mdx
+++ b/packages/lynx-ui-sortable/docs/APIReference.mdx
@@ -1,7 +1,6 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
 
-
   
 ## SortableRootProps
     

--- a/packages/lynx-ui-swipe-action/docs/APIReference.mdx
+++ b/packages/lynx-ui-swipe-action/docs/APIReference.mdx
@@ -1,7 +1,6 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
 
-
   
 ## SwipeActionProps
     

--- a/packages/lynx-ui-swiper/docs/APIReference.mdx
+++ b/packages/lynx-ui-swiper/docs/APIReference.mdx
@@ -1,7 +1,6 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
 
-
   
 ## SwiperProps
     

--- a/packages/lynx-ui-switch/docs/APIReference.mdx
+++ b/packages/lynx-ui-switch/docs/APIReference.mdx
@@ -1,43 +1,4 @@
-import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
-import { useLang } from '@rspress/core/runtime';
-
-export const ClassRenderPropPreamble = () => {
-  const isZh = useLang() === 'zh';
-  if (isZh) {
-    return (
-      <>
-        <h3>基于状态的样式与渲染</h3>
-        <p>
-          该组件将每一项内部状态通过<strong>两条等价通道</strong>同时对外暴露，下表逐行给出两者的对应关系：
-        </p>
-        <ul>
-          <li>
-            <strong>CSS className</strong>：根节点上会动态加上 <code>{'ui-<state>'}</code> 形式的类名，可直接用 <code>{'.ui-<state> { ... }'}</code> 选择器定制样式；
-          </li>
-          <li>
-            <strong>Render-prop 字段</strong>：当 <code>children</code> 传入函数时，同一个状态会以 <code>{'children({ <state>: boolean, ... })'}</code> 的形式作为参数传入，便于在运行时做条件渲染。
-          </li>
-        </ul>
-      </>
-    );
-  }
-  return (
-    <>
-      <h3>State-based styling & rendering</h3>
-      <p>
-        This component exposes each of its internal states through <strong>two interchangeable channels</strong>, and the table below maps them one-to-one:
-      </p>
-      <ul>
-        <li>
-          <strong>CSS className</strong> — a class like <code>{'ui-<state>'}</code> is toggled on the root node, so you can style it with selectors such as <code>{'.ui-<state> { ... }'}</code>.
-        </li>
-        <li>
-          <strong>Render-prop field</strong> — when <code>children</code> is a function, the same state is passed in via <code>{'children({ <state>: boolean, ... })'}</code> for runtime-driven rendering.
-        </li>
-      </ul>
-    </>
-  );
-};
+import { UIApiTable, ClassRenderPropTable, ClassRenderPropPreamble } from "@lynx-ui/index";
 
   
 ### SwitchTrack 

--- a/tools/typedoc/tpl.ts
+++ b/tools/typedoc/tpl.ts
@@ -607,54 +607,14 @@ const doGenTplWithData = async (
 
   // Shared MDX header injected into every generated APIReference.mdx.
   //
-  // - `import { useLang }` uses Rspress's runtime hook to detect the current
-  //   documentation locale at render time.
-  // - `ClassRenderPropPreamble` is a locale-aware wrapper component rendered
-  //   above every <ClassRenderPropTable/> in the body. It emits an <h3>
-  //   subtitle, a short lead paragraph, a two-item <ul> that maps the CSS
-  //   className channel and the render-prop channel side by side, and a
-  //   closing note explaining that both channels are interchangeable.
+  // `ClassRenderPropPreamble` is a locale-aware wrapper component (now owned
+  // by the `@lynx-ui/index` entry, not this repository) that is rendered
+  // above every <ClassRenderPropTable/> in the body. We always import it
+  // eagerly here and strip it from the import statement at the end if the
+  // generated body does not actually use it, so components without any
+  // render-prop table don't ship an unused import.
   const mdxHeader =
-    `import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
-import { useLang } from '@rspress/core/runtime';
-
-export const ClassRenderPropPreamble = () => {
-  const isZh = useLang() === 'zh';
-  if (isZh) {
-    return (
-      <>
-        <h3>基于状态的样式与渲染</h3>
-        <p>
-          该组件将每一项内部状态通过<strong>两条等价通道</strong>同时对外暴露，下表逐行给出两者的对应关系：
-        </p>
-        <ul>
-          <li>
-            <strong>CSS className</strong>：根节点上会动态加上 <code>{'ui-<state>'}</code> 形式的类名，可直接用 <code>{'.ui-<state> { ... }'}</code> 选择器定制样式；
-          </li>
-          <li>
-            <strong>Render-prop 字段</strong>：当 <code>children</code> 传入函数时，同一个状态会以 <code>{'children({ <state>: boolean, ... })'}</code> 的形式作为参数传入，便于在运行时做条件渲染。
-          </li>
-        </ul>
-      </>
-    );
-  }
-  return (
-    <>
-      <h3>State-based styling & rendering</h3>
-      <p>
-        This component exposes each of its internal states through <strong>two interchangeable channels</strong>, and the table below maps them one-to-one:
-      </p>
-      <ul>
-        <li>
-          <strong>CSS className</strong> — a class like <code>{'ui-<state>'}</code> is toggled on the root node, so you can style it with selectors such as <code>{'.ui-<state> { ... }'}</code>.
-        </li>
-        <li>
-          <strong>Render-prop field</strong> — when <code>children</code> is a function, the same state is passed in via <code>{'children({ <state>: boolean, ... })'}</code> for runtime-driven rendering.
-        </li>
-      </ul>
-    </>
-  );
-};
+    `import { UIApiTable, ClassRenderPropTable, ClassRenderPropPreamble } from "@lynx-ui/index";
 `
 
   if (multipleProps) {
@@ -697,17 +657,14 @@ export const ClassRenderPropPreamble = () => {
   `
   }
 
-  // Strip the locale-aware preamble scaffolding when the generated body does
-  // not actually contain any <ClassRenderPropTable/>. This keeps the output
-  // minimal for components without render-prop state and avoids shipping
-  // unused `useLang` imports through the docs pipeline.
+  // Drop `ClassRenderPropPreamble` from the import statement when the body
+  // does not reference it, so components without any render-prop state do
+  // not pull in an unused symbol.
   if (!content.includes('<ClassRenderPropPreamble />')) {
-    content = content
-      .replace(/^import \{ useLang \} from '@rspress\/core\/runtime';\n/m, '')
-      .replace(
-        /export const ClassRenderPropPreamble = \(\) => \{[\s\S]*?\n\};\n/,
-        '',
-      )
+    content = content.replace(
+      'import { UIApiTable, ClassRenderPropTable, ClassRenderPropPreamble } from "@lynx-ui/index";',
+      'import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";',
+    )
   }
 
   fs.writeFileSync(savePath, content)


### PR DESCRIPTION
- Remove redundant empty lines in multiple API reference files
- Consolidate ClassRenderPropPreamble imports from @lynx-ui/index
- Update typedoc template to optimize imports and remove unused preamble

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated shared documentation components across multiple packages, improving code organization and maintainability.
  * Removed duplicate component definitions from individual documentation files.

* **Chores**
  * Cleaned up whitespace formatting in documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->