### PR TITLE
feat(swiper): infer item metadata from context

### DIFF
--- a/.changeset/swiper-item-context.md
+++ b/.changeset/swiper-item-context.md
@@ -1,0 +1,14 @@
+---
+"@lynx-js/lynx-ui-swiper": minor
+---
+
+Allow SwiperItem to receive item metadata from Swiper context. In normal usage, users can now write `<SwiperItem>` directly without passing `index`, `realIndex`, or `key={realIndex}`.
+
+```diff
+ {({ index, realIndex }) => (
+-  <SwiperItem index={index} realIndex={realIndex} key={realIndex}>
++  <SwiperItem>
+     {content}
+   </SwiperItem>
+ )}
+```

--- a/apps/examples/Swiper/Basic/index.tsx
+++ b/apps/examples/Swiper/Basic/index.tsx
@@ -49,10 +49,10 @@ function SwiperEntry(): JSX.Element {
             overflow: 'visible',
           }}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <Card
-                index={realIndex}
+                index={index}
                 style={{
                   height: '250px',
                 }}

--- a/apps/examples/Swiper/BasicDynamic/index.tsx
+++ b/apps/examples/Swiper/BasicDynamic/index.tsx
@@ -57,10 +57,10 @@ function SwiperEntry(): JSX.Element {
             overflow: 'visible',
           }}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <Card
-                index={realIndex}
+                index={index}
                 style={{
                   height: '250px',
                 }}

--- a/apps/examples/Swiper/BasicUpdateSize/index.tsx
+++ b/apps/examples/Swiper/BasicUpdateSize/index.tsx
@@ -56,10 +56,10 @@ function SwiperEntry(): JSX.Element {
             overflow: 'visible',
           }}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <Card
-                index={realIndex}
+                index={index}
                 style={{
                   height: '250px',
                 }}

--- a/apps/examples/Swiper/Bounces/index.tsx
+++ b/apps/examples/Swiper/Bounces/index.tsx
@@ -64,10 +64,10 @@ function SwiperEntry() {
           }}
           onChange={setCurrentIndex}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <Card
-                index={realIndex}
+                index={index}
                 style={{
                   height: `${ITEM_HEIGHT}px`,
                 }}

--- a/apps/examples/Swiper/Custom/index.tsx
+++ b/apps/examples/Swiper/Custom/index.tsx
@@ -62,10 +62,10 @@ function SwiperEntry(): JSX.Element {
             overflow: 'visible',
           }}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <Card
-                index={realIndex}
+                index={index}
                 style={{
                   height: '250px',
                 }}

--- a/apps/examples/Swiper/CustomScale/index.tsx
+++ b/apps/examples/Swiper/CustomScale/index.tsx
@@ -91,10 +91,10 @@ function SwiperEntry(): JSX.Element {
             overflow: 'visible',
           }}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <Card
-                index={realIndex}
+                index={index}
                 style={{
                   height: '250px',
                 }}

--- a/apps/examples/Swiper/CustomTinder/index.tsx
+++ b/apps/examples/Swiper/CustomTinder/index.tsx
@@ -85,8 +85,8 @@ function SwiperEntry() {
           overflow: 'visible',
         }}
       >
-        {({ index, realIndex }) => (
-          <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+        {({ index }) => (
+          <SwiperItem>
             <view
               class='block-view'
               style={{

--- a/apps/examples/Swiper/DifferentHeight/index.tsx
+++ b/apps/examples/Swiper/DifferentHeight/index.tsx
@@ -53,12 +53,12 @@ function SwiperEntry(): JSX.Element {
             alignItems: 'end',
           }}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <Card
-                index={realIndex}
+                index={index}
                 style={{
-                  height: `${itemHeights[realIndex % itemHeights.length]}px`,
+                  height: `${itemHeights[index % itemHeights.length]}px`,
                 }}
               />
             </SwiperItem>

--- a/apps/examples/Swiper/Direction/index.tsx
+++ b/apps/examples/Swiper/Direction/index.tsx
@@ -14,15 +14,13 @@ const itemArr: number[] = [1, 2, 3, 4]
 
 function renderCard({
   index,
-  realIndex,
 }: {
   index: number
-  realIndex: number
 }) {
   return (
-    <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+    <SwiperItem>
       <Card
-        index={realIndex}
+        index={index}
         style={{
           height: '200px',
         }}

--- a/apps/examples/Swiper/EmptyDataBug/index.tsx
+++ b/apps/examples/Swiper/EmptyDataBug/index.tsx
@@ -102,9 +102,9 @@ function EmptyDataWithAutoPlay(): JSX.Element {
         autoPlayInterval={2000}
         modeConfig={{ align: 'center' }}
       >
-        {({ index, realIndex }) => (
-          <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
-            <Card index={realIndex} style={{ height: '200px' }} />
+        {({ index }) => (
+          <SwiperItem>
+            <Card index={index} style={{ height: '200px' }} />
           </SwiperItem>
         )}
       </Swiper>
@@ -187,9 +187,9 @@ function EmptyDataWithManualSwipe(): JSX.Element {
         onSwipeStart={handleSwipeStart}
         onSwipeStop={handleSwipeStop}
       >
-        {({ index, realIndex }) => (
-          <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
-            <Card index={realIndex} style={{ height: '200px' }} />
+        {({ index }) => (
+          <SwiperItem>
+            <Card index={index} style={{ height: '200px' }} />
           </SwiperItem>
         )}
       </Swiper>
@@ -264,9 +264,9 @@ function DataBecomesEmpty(): JSX.Element {
         autoPlayInterval={3000}
         modeConfig={{ align: 'center' }}
       >
-        {({ index, realIndex }) => (
-          <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
-            <Card index={realIndex} style={{ height: '200px' }} />
+        {({ index }) => (
+          <SwiperItem>
+            <Card index={index} style={{ height: '200px' }} />
           </SwiperItem>
         )}
       </Swiper>
@@ -330,9 +330,9 @@ function ResetWithCorruptedIndex(): JSX.Element {
         autoPlay={false}
         modeConfig={{ align: 'center' }}
       >
-        {({ index, realIndex }) => (
-          <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
-            <Card index={realIndex} style={{ height: '200px' }} />
+        {({ index }) => (
+          <SwiperItem>
+            <Card index={index} style={{ height: '200px' }} />
           </SwiperItem>
         )}
       </Swiper>

--- a/apps/examples/Swiper/Indicator/index.tsx
+++ b/apps/examples/Swiper/Indicator/index.tsx
@@ -48,10 +48,10 @@ function SwiperEntry() {
             overflow: 'visible',
           }}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <Card
-                index={realIndex}
+                index={index}
                 style={{
                   height: '250px',
                 }}

--- a/apps/examples/Swiper/Lazy/index.tsx
+++ b/apps/examples/Swiper/Lazy/index.tsx
@@ -51,15 +51,15 @@ function SwiperEntry() {
             overflow: 'visible',
           }}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <LazyComponent
                 scene='scene'
-                pid={`pid_${realIndex}`}
+                pid={`pid_${index}`}
                 estimatedStyle={{ width: '100%', height: '100%' }}
               >
                 <Card
-                  index={realIndex}
+                  index={index}
                   style={{
                     height: '250px',
                   }}

--- a/apps/examples/Swiper/Loop/index.tsx
+++ b/apps/examples/Swiper/Loop/index.tsx
@@ -50,10 +50,10 @@ function SwiperEntry() {
             overflow: 'visible',
           }}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <Card
-                index={realIndex}
+                index={index}
                 style={{
                   height: '250px',
                 }}

--- a/apps/examples/Swiper/RTL/index.tsx
+++ b/apps/examples/Swiper/RTL/index.tsx
@@ -66,10 +66,10 @@ function SwiperEntry(): JSX.Element {
             },
           }}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <Card
-                index={realIndex}
+                index={index}
                 style={{
                   height: '250px',
                 }}

--- a/apps/examples/Swiper/RTLCustom/index.tsx
+++ b/apps/examples/Swiper/RTLCustom/index.tsx
@@ -90,10 +90,10 @@ function SwiperEntry(): JSX.Element {
             overflow: 'visible',
           }}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <Card
-                index={realIndex}
+                index={index}
                 style={{
                   height: '250px',
                 }}

--- a/apps/examples/Swiper/RTLLoop/index.tsx
+++ b/apps/examples/Swiper/RTLLoop/index.tsx
@@ -49,10 +49,10 @@ function SwiperEntry(): JSX.Element {
             overflow: 'visible',
           }}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <Card
-                index={realIndex}
+                index={index}
                 style={{
                   height: '250px',
                 }}

--- a/apps/examples/Swiper/RTLLoopLynxRTL/index.tsx
+++ b/apps/examples/Swiper/RTLLoopLynxRTL/index.tsx
@@ -49,10 +49,10 @@ function SwiperEntry(): JSX.Element {
             overflow: 'visible',
           }}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <Card
-                index={realIndex}
+                index={index}
                 style={{
                   height: '250px',
                 }}

--- a/apps/examples/Swiper/WithGap/index.tsx
+++ b/apps/examples/Swiper/WithGap/index.tsx
@@ -49,10 +49,10 @@ function SwiperEntry(): JSX.Element {
             overflow: 'visible',
           }}
         >
-          {({ index, realIndex }) => (
-            <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+          {({ index }) => (
+            <SwiperItem>
               <Card
-                index={realIndex}
+                index={index}
                 style={{
                   height: '250px',
                 }}

--- a/packages/lynx-ui-swiper/README.md
+++ b/packages/lynx-ui-swiper/README.md
@@ -31,8 +31,8 @@ The `Swiper` component is composed of the following sub-components:
 
 ```tsx
 <Swiper>
-  {({ index, realIndex }) => (
-    <SwiperItem index={index} realIndex={realIndex} key={realIndex}>
+  {({ index }) => (
+    <SwiperItem>
       {/* Your item content */}
     </SwiperItem>
   )}

--- a/packages/lynx-ui-swiper/SKILL.md
+++ b/packages/lynx-ui-swiper/SKILL.md
@@ -18,7 +18,7 @@
 
 ### Minimal Usable Example
 
-Each `<Swiper>` must provide `data`, `itemWidth`, and render children via a function that returns a `<SwiperItem>`. Use `realIndex` for React `key`, especially in loop mode.
+Each `<Swiper>` must provide `data`, `itemWidth`, and render children via a function that returns a `<SwiperItem>`.
 
 ```tsx
 import { Swiper, SwiperItem } from '@lynx-js/lynx-ui'
@@ -28,8 +28,8 @@ const data = ['red', 'green', 'blue']
 function Example() {
   return (
     <Swiper data={data} itemWidth={300}>
-      {({ item, index, realIndex }) => (
-        <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+      {({ item, index }) => (
+        <SwiperItem>
           <view
             style={{ width: '100%', height: '200px', backgroundColor: item }}
           >
@@ -44,10 +44,9 @@ function Example() {
 
 ### Render Props Mechanics
 
-- `<Swiper>` calls your children function once per item with `{ item, index, realIndex }`.
+- `<Swiper>` calls your children function once per item with `{ item, index }`.
 - You must return a single `<SwiperItem>` as the root of that function; place your content inside it.
-- `index` is the logical index in `data`; `realIndex` is the physical index (differs in loop mode). Use `realIndex` for the React `key`.
-- When `loop={false}`, `index === realIndex`.
+- Use `index` for app content such as labels, item lookup, and indicators.
 
 ### Recommended Prompt Formula
 
@@ -62,7 +61,7 @@ Examples:
 ## 3. Use Cases & Best Practices
 
 - Basic Horizontal: `mode='normal'` with `modeConfig.align` (`start`/`center`/`end`) and optional `spaceBetween`.
-- Loop & Auto Play: set `loop={true}` and `autoPlay={true}` with `autoPlayInterval`. Use `realIndex` as React `key` in children.
+- Loop & Auto Play: set `loop={true}` and `autoPlay={true}` with `autoPlayInterval`.
 - Bounces: configure `bounceConfig` with `startBounceItem`/`endBounceItem` and widths; release callbacks fire with `{ type, offset }`. Bounces are ignored when `loop=true`.
 - Custom Animation: switch to `mode='custom'` and provide `main-thread:customAnimation(value, index) => style`. Duplicate this logic in `customAnimationFirstScreen` for first-screen rendering.
 - RTL: set `RTL={true}` or `RTL={'lynx-rtl'}`. The latter applies Lynx’s `direction: lynx-rtl` explicitly.
@@ -85,8 +84,8 @@ Examples:
   modeConfig={{ align: 'start', spaceBetween: 8 }}
   experimentalHorizontalSwipeOnly
 >
-  {({ item, index, realIndex }) => (
-    <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+  {({ item, index }) => (
+    <SwiperItem>
       <view style={{ width: '100%', height: '100%', backgroundColor: item }} />
       <text>Number.{index}</text>
     </SwiperItem>
@@ -115,8 +114,8 @@ Examples:
     },
   }}
 >
-  {({ index, realIndex }) => (
-    <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+  {({ index }) => (
+    <SwiperItem>
       {/* content */}
     </SwiperItem>
   )}
@@ -167,8 +166,8 @@ function customAnimationFirstScreen(value: number) {
   main-thread:customAnimation={customAnimation}
   customAnimationFirstScreen={customAnimationFirstScreen}
 >
-  {({ index, realIndex }) => (
-    <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+  {({ index }) => (
+    <SwiperItem>
       {/* content */}
     </SwiperItem>
   )}
@@ -186,8 +185,8 @@ function customAnimationFirstScreen(value: number) {
   modeConfig={{ align: 'start', spaceBetween: 8 }}
   RTL={true}
 >
-  {({ index, realIndex }) => (
-    <SwiperItem index={index} key={realIndex} realIndex={realIndex}>
+  {({ index }) => (
+    <SwiperItem>
       {/* content */}
     </SwiperItem>
   )}
@@ -228,8 +227,7 @@ interface SwiperRef {
 
 ## 6. FAQ
 
-- Do children have to be a function? Yes. It receives `{ item, index, realIndex }` and must return `<SwiperItem>`.
-- Why both `index` and `realIndex`? In loop mode, clones shift indices; use `realIndex` for React `key`.
+- Do children have to be a function? Yes. It receives `{ item, index }` and must return `<SwiperItem>`.
 - Why doesn’t `initialIndex` update after mount? It is only applied at first screen; later updates are ignored. Use `swiperKey` or `resetOnReuse` to reset.
 - My last item leaves a blank area when `align='start'`. Provide `offsetLimit={[0, containerWidth - itemWidth]}` to clamp the range.
 - Bounces don’t trigger when `loop=true`. Correct—bounce is ignored in looping.

--- a/packages/lynx-ui-swiper/docs/APIReference.mdx
+++ b/packages/lynx-ui-swiper/docs/APIReference.mdx
@@ -670,8 +670,18 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
   {
     "name": "index",
     "type": "number",
-    "summary": [],
-    "summary_zh": [],
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Logical index of current SwiperItem in Swiper's data."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "当前 SwiperItem 在 Swiper 数据中的逻辑索引。"
+      }
+    ],
     "defaultValue": "",
     "isOption": false,
     "isSupportIOS": false,
@@ -682,8 +692,18 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
   {
     "name": "item",
     "type": "T",
-    "summary": [],
-    "summary_zh": [],
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Data item of current SwiperItem."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "当前 SwiperItem 对应的数据项。"
+      }
+    ],
     "defaultValue": "",
     "isOption": false,
     "isSupportIOS": false,
@@ -694,8 +714,18 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
   {
     "name": "realIndex",
     "type": "number",
-    "summary": [],
-    "summary_zh": [],
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Physical index of current SwiperItem.\nKept for compatibility with existing manual SwiperItem wiring.\nSwiperItem receives this automatically when rendered inside Swiper's\nchildren function."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "当前 SwiperItem 的物理索引，为兼容已有手动传参用法保留。SwiperItem 在 Swiper 的 children 函数内渲染时会自动获取该值。"
+      }
+    ],
     "defaultValue": "",
     "isOption": false,
     "isSupportIOS": false,

--- a/packages/lynx-ui-swiper/src/Swiper/index.tsx
+++ b/packages/lynx-ui-swiper/src/Swiper/index.tsx
@@ -25,7 +25,7 @@ import { useModeConfig } from '../hooks/useModeConfig'
 import { useOffset } from '../hooks/useOffset'
 import { useOffsetLimit } from '../hooks/useOffsetLimit'
 import { useReset } from '../hooks/useReset'
-import { SwiperContext } from '../store'
+import { SwiperContext, SwiperItemContext } from '../store'
 import type {
   SwipeDirection,
   SwiperProps,
@@ -326,6 +326,24 @@ const Swiper = forwardRef(
       cancelAnimation: cancelAnimationJS,
     }))
 
+    function renderSwiperItem(props: {
+      item: T
+      index: number
+      realIndex: number
+    }) {
+      return (
+        <SwiperItemContext.Provider
+          key={props.realIndex}
+          value={{
+            index: props.index,
+            realIndex: props.realIndex,
+          }}
+        >
+          {children(props)}
+        </SwiperItemContext.Provider>
+      )
+    }
+
     const { bounceStartView, bounceEndView } = useBounceView({
       startBounceItem,
       endBounceItem,
@@ -366,7 +384,7 @@ const Swiper = forwardRef(
                     { length: loopDuplicateCount },
                     (_, i) => loopDuplicateCount - i - 1,
                   ).map((i) =>
-                    children({
+                    renderSwiperItem({
                       index: data.length - i - 1,
                       item: data[data.length - i - 1],
                       realIndex: -i - 1,
@@ -376,7 +394,7 @@ const Swiper = forwardRef(
               )
               : null}
             {data.map((item: T, index: number) =>
-              children({
+              renderSwiperItem({
                 index,
                 item,
                 realIndex: index,
@@ -388,7 +406,7 @@ const Swiper = forwardRef(
                   {Array.from({ length: loopDuplicateCount }, (_, i) => i).map((
                     i,
                   ) =>
-                    children({
+                    renderSwiperItem({
                       index: i,
                       item: data[i],
                       realIndex: data.length + i,

--- a/packages/lynx-ui-swiper/src/SwiperItem/index.tsx
+++ b/packages/lynx-ui-swiper/src/SwiperItem/index.tsx
@@ -14,7 +14,7 @@ import type { ReactElement, RefObject } from '@lynx-js/react'
 
 import type { CSSProperties, MainThread } from '@lynx-js/types'
 
-import { SwiperContext } from '../store'
+import { SwiperContext, SwiperItemContext } from '../store'
 import type { CompoundModeConfig, SwiperContextProps } from '../types'
 
 export interface SwiperItemProps {
@@ -24,7 +24,7 @@ export interface SwiperItemProps {
    * @iOS
    * @Harmony
    */
-  index: number
+  index?: number
   /**
    * Children of SwiperItem
    * @Android
@@ -40,8 +40,9 @@ export interface SwiperItemProps {
    */
   style?: CSSProperties
   /**
-   * Real index of current SwiperItem, out of Swiper's data.
-   * Same with `index`, but will be different from `index` when in loop mode.
+   * Physical index of current SwiperItem.
+   * Kept for compatibility with existing manual usage. This is resolved
+   * automatically when SwiperItem is rendered inside Swiper's children function.
    * @Android
    * @iOS
    * @Harmony
@@ -156,7 +157,7 @@ function useFirstScreenStyle(props: IFirstScreenStyle) {
 }
 
 const SwiperItem = (
-  { index, realIndex = index, children, overlap }: SwiperItemProps,
+  { index, realIndex, children, overlap }: SwiperItemProps,
 ) => {
   const {
     itemWidth,
@@ -168,6 +169,11 @@ const SwiperItem = (
     spaceBetween,
     RTL,
   } = useContext(SwiperContext)
+  const itemContext = useContext(SwiperItemContext)
+  const resolvedIndex = index ?? itemContext?.index
+  const resolvedRealIndex = realIndex ?? itemContext?.realIndex ?? resolvedIndex
+  const hasResolvedIndex = resolvedIndex !== undefined
+  const effectiveRealIndex = resolvedRealIndex ?? 0
   const swiperItemRef = useMainThreadRef<MainThread.Element>()
 
   const { containerStyle } = useFirstScreenStyle({
@@ -176,16 +182,22 @@ const SwiperItem = (
     spaceBetween,
     itemRef: swiperItemRef,
     modeConfig,
-    realIndex,
+    realIndex: effectiveRealIndex,
     initialIndex,
     customAnimationFirstScreen,
     RTL,
   })
 
+  if (!hasResolvedIndex) {
+    throw new Error(
+      'SwiperItem must be rendered inside Swiper children or receive an index prop.',
+    )
+  }
+
   function setRef(ref: MainThread.Element) {
     'main thread'
     swiperItemRef.current = ref
-    setChildrenRef(ref, realIndex ?? index)
+    setChildrenRef(ref, effectiveRealIndex)
   }
 
   return (

--- a/packages/lynx-ui-swiper/src/store/index.ts
+++ b/packages/lynx-ui-swiper/src/store/index.ts
@@ -8,6 +8,11 @@ import { noop } from '@lynx-js/lynx-ui-common'
 
 import type { SwiperContextProps } from '../types'
 
+export interface SwiperItemContextProps {
+  index: number
+  realIndex: number
+}
+
 export const SwiperContext = createContext<SwiperContextProps>({
   itemWidth: 350,
   itemHeight: 'auto',
@@ -21,3 +26,7 @@ export const SwiperContext = createContext<SwiperContextProps>({
   spaceBetween: 0,
   RTL: false,
 })
+
+export const SwiperItemContext = createContext<
+  SwiperItemContextProps | undefined
+>(undefined)

--- a/packages/lynx-ui-swiper/src/types/index.docs.ts
+++ b/packages/lynx-ui-swiper/src/types/index.docs.ts
@@ -44,7 +44,7 @@ export interface SwiperProps<T> {
    *   itemWidth={350}
    *  >
    *    {({ index, item }) => (
-   *      <SwiperItem index={index} key={index}>
+   *      <SwiperItem>
    *        <image class="image" src={`${item}`}></image>
    *        <text class="image-text">Number.{index}</text>
    *      </SwiperItem>
@@ -459,7 +459,22 @@ export interface onBounceParams {
 }
 
 export interface RenderFunctionProps<T> {
+  /**
+   * Data item of current SwiperItem.
+   * @zh 当前 SwiperItem 对应的数据项。
+   */
   item: T
+  /**
+   * Logical index of current SwiperItem in Swiper's data.
+   * @zh 当前 SwiperItem 在 Swiper 数据中的逻辑索引。
+   */
   index: number
+  /**
+   * Physical index of current SwiperItem.
+   * Kept for compatibility with existing manual SwiperItem wiring.
+   * SwiperItem receives this automatically when rendered inside Swiper's
+   * children function.
+   * @zh 当前 SwiperItem 的物理索引，为兼容已有手动传参用法保留。SwiperItem 在 Swiper 的 children 函数内渲染时会自动获取该值。
+   */
   realIndex: number
 }


### PR DESCRIPTION
## Summary

- Add per-item SwiperItem context so Swiper owns physical item metadata and keys.
- Let SwiperItem resolve index/realIndex from context while keeping explicit props as an advanced/backward-compatible path.
- Update swiper examples, README, API docs, SKILL.md, and add a changeset.

## Validation

- pnpm install
- pnpm turbo build
- pnpm check:changed
- pnpm check:manypkg
- pnpm check:sherif (passes with existing warning: packages/lynx-ui-skills/package.json does not exist)
- pnpm exec biome check --no-errors-on-unmatched --files-ignore-unknown=true packages/lynx-ui-swiper/src/Swiper/index.tsx packages/lynx-ui-swiper/src/SwiperItem/index.tsx packages/lynx-ui-swiper/src/store/index.ts packages/lynx-ui-swiper/src/types/index.docs.ts apps/examples/Swiper/Basic/index.tsx apps/examples/Swiper/Loop/index.tsx apps/examples/Swiper/Lazy/index.tsx apps/examples/Swiper/Direction/index.tsx
- pnpm exec dprint check packages/lynx-ui-swiper/docs/APIReference.mdx packages/lynx-ui-swiper/README.md packages/lynx-ui-swiper/SKILL.md .changeset/swiper-item-context.md
- pnpm --filter @lynx-js/lynx-ui-swiper exec vitest run --passWithNoTests (no test files found)
- pnpm tsx tools/typedoc/index.ts lynx-ui-swiper

Known unrelated check issues:
- pnpm check:all fails during repo-wide ESLint with broad import/no-unresolved errors for workspace packages such as @lynx-js/lynx-ui and @lynx-js/lynx-ui-common.
- pnpm check:exports fails because lynx-ui-skills has no entry point/package.json.
