### PR TITLE
docs: move MDX imports to top-level for rspress compatibility

### DIFF
--- a/packages/lynx-ui-button/docs/README.mdx
+++ b/packages/lynx-ui-button/docs/README.mdx
@@ -1,6 +1,9 @@
+import descriptions from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-button/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Button>`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-button']}
 
@@ -10,8 +13,6 @@ You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main
 
 :::
 
-import Introduction from '../../introDocs/lynx-ui-button/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-button/docs/README.zh.mdx
+++ b/packages/lynx-ui-button/docs/README.zh.mdx
@@ -1,3 +1,6 @@
+import Introduction from '../../introDocs/lynx-ui-button/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Button>`
 
 一个基础的 button 实现，提供高亮和选中状态。
@@ -10,8 +13,6 @@
 
 :::
 
-import Introduction from '../../introDocs/lynx-ui-button/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-checkbox/docs/README.mdx
+++ b/packages/lynx-ui-checkbox/docs/README.mdx
@@ -1,11 +1,12 @@
+import descriptions from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-checkbox/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Checkbox>`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-checkbox']}
 
-import Introduction from '../../introDocs/lynx-ui-checkbox/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-checkbox/docs/README.zh.mdx
+++ b/packages/lynx-ui-checkbox/docs/README.zh.mdx
@@ -1,9 +1,10 @@
+import Introduction from '../../introDocs/lynx-ui-checkbox/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Checkbox>`
 
 `<Checkbox>` 允许用户选择一个或多个选项。
 
-import Introduction from '../../introDocs/lynx-ui-checkbox/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-dialog/docs/README.mdx
+++ b/packages/lynx-ui-dialog/docs/README.mdx
@@ -1,11 +1,12 @@
+import descriptions from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-dialog/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `Dialog`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-dialog']}
 
-import Introduction from '../../introDocs/lynx-ui-dialog/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-dialog/docs/README.zh.mdx
+++ b/packages/lynx-ui-dialog/docs/README.zh.mdx
@@ -1,9 +1,10 @@
+import Introduction from '../../introDocs/lynx-ui-dialog/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `Dialog`
 
 弹窗组件，用于在当前视图上方展示内容，支持背景遮罩和自定义动画。
 
-import Introduction from '../../introDocs/lynx-ui-dialog/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-draggable/docs/README.mdx
+++ b/packages/lynx-ui-draggable/docs/README.mdx
@@ -1,11 +1,12 @@
+import descriptions from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-draggable/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Draggable>`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-draggable']}
 
-import Introduction from '../../introDocs/lynx-ui-draggable/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-draggable/docs/README.zh.mdx
+++ b/packages/lynx-ui-draggable/docs/README.zh.mdx
@@ -1,9 +1,10 @@
+import Introduction from '../../introDocs/lynx-ui-draggable/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Draggable>`
 
 一个基础的可拖拽组件.
 
-import Introduction from '../../introDocs/lynx-ui-draggable/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-feed-list/docs/README.mdx
+++ b/packages/lynx-ui-feed-list/docs/README.mdx
@@ -1,13 +1,14 @@
-# `<FeedList>`
-
 import descriptions from '../../lynx-ui-intros';
-
 import { Go, UIApiTable } from '@lynx-ui/index';
 import { PageTabs, PageTab } from '@theme';
-
 import Introduction from '../../introDocs/lynx-ui-feed-list/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 import RefreshDocIntroduction from './useRefresh.mdx';
+
+# `<FeedList>`
+
+
+
 
 {descriptions['lynx-ui-feed-list']}
 

--- a/packages/lynx-ui-feed-list/docs/README.mdx
+++ b/packages/lynx-ui-feed-list/docs/README.mdx
@@ -7,9 +7,6 @@ import RefreshDocIntroduction from './useRefresh.mdx';
 
 # `<FeedList>`
 
-
-
-
 {descriptions['lynx-ui-feed-list']}
 
 :::info

--- a/packages/lynx-ui-feed-list/docs/README.zh.mdx
+++ b/packages/lynx-ui-feed-list/docs/README.zh.mdx
@@ -6,8 +6,6 @@ import RefreshDocIntroduction from './useRefresh.zh.mdx';
 
 # `<FeedList>`
 
-
-
 一个基于[`<List>`](/lynx-ui/Components/List.html)封装的可滚动容器。
 增加基于 MTS 实现的 refresh 和 bounceable 能力，同时支持自定义 LoadMore 状态的 footer 和数据加载完毕状态的 footer。
 

--- a/packages/lynx-ui-feed-list/docs/README.zh.mdx
+++ b/packages/lynx-ui-feed-list/docs/README.zh.mdx
@@ -1,11 +1,12 @@
-# `<FeedList>`
-
 import { Go, UIApiTable } from '@lynx-ui/index';
 import { PageTabs, PageTab } from '@theme';
-
 import Introduction from '../../introDocs/lynx-ui-feed-list/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';  
 import RefreshDocIntroduction from './useRefresh.zh.mdx';
+
+# `<FeedList>`
+
+
 
 一个基于[`<List>`](/lynx-ui/Components/List.html)封装的可滚动容器。
 增加基于 MTS 实现的 refresh 和 bounceable 能力，同时支持自定义 LoadMore 状态的 footer 和数据加载完毕状态的 footer。

--- a/packages/lynx-ui-form/docs/README.mdx
+++ b/packages/lynx-ui-form/docs/README.mdx
@@ -1,11 +1,12 @@
+import descriptions from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-form/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Form>`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-form']}
 
-import Introduction from '../../introDocs/lynx-ui-form/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-form/docs/README.zh.mdx
+++ b/packages/lynx-ui-form/docs/README.zh.mdx
@@ -1,9 +1,10 @@
+import Introduction from '../../introDocs/lynx-ui-form/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Form>`
 
 Form 是一个用于收集和提交数据的表单组件。
 
-import Introduction from '../../introDocs/lynx-ui-form/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-input/docs/README.mdx
+++ b/packages/lynx-ui-input/docs/README.mdx
@@ -1,11 +1,12 @@
+import descriptions from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-input/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Input>`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-input']}
 
-import Introduction from '../../introDocs/lynx-ui-input/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-input/docs/README.zh.mdx
+++ b/packages/lynx-ui-input/docs/README.zh.mdx
@@ -1,9 +1,10 @@
+import Introduction from '../../introDocs/lynx-ui-input/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Input>`
 
 输入框组件，支持受控、非受控及键盘避让能力。
 
-import Introduction from '../../introDocs/lynx-ui-input/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-lazy-component/docs/README.mdx
+++ b/packages/lynx-ui-lazy-component/docs/README.mdx
@@ -5,9 +5,6 @@ import APIReference from './APIReference.mdx';
 
 # `<LazyComponent>`
 
-
-> - For ReactLynx 2, refer to the [old official website](https://lynx-doc.cn.goofy.app/docs/frontend/lynx-ui/button)
-
 {descriptions['lynx-ui-lazy-component']}
 
 

--- a/packages/lynx-ui-lazy-component/docs/README.mdx
+++ b/packages/lynx-ui-lazy-component/docs/README.mdx
@@ -1,12 +1,15 @@
+import descriptions from '../../lynx-ui-intros';
+import LazyComponentImg from '@assets/LazyComponent/lazy_component.jpeg';
+import Introduction from '../../introDocs/lynx-ui-lazy-component/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<LazyComponent>`
 
-import descriptions from '../../lynx-ui-intros';
 
 > - For ReactLynx 2, refer to the [old official website](https://lynx-doc.cn.goofy.app/docs/frontend/lynx-ui/button)
 
 {descriptions['lynx-ui-lazy-component']}
 
-import LazyComponentImg from '@assets/LazyComponent/lazy_component.jpeg';
 
 <img src={LazyComponentImg} />
 
@@ -18,8 +21,6 @@ Moreover, you can also implement your own tabs functionality with `<x-foldview-n
 
 :::
 
-import Introduction from '../../introDocs/lynx-ui-lazy-component/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-lazy-component/docs/README.zh.mdx
+++ b/packages/lynx-ui-lazy-component/docs/README.zh.mdx
@@ -1,8 +1,11 @@
+import LazyComponentImg from '@assets/LazyComponent/lazy_component.jpeg';
+import Introduction from '../../introDocs/lynx-ui-lazy-component/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<LazyComponent>`
 
 A universal lazy-loading component based on global exposure detection. It dynamically renders nodes only when they enter the viewport boundary, significantly improving performance by skipping off-screen elements.
 
-import LazyComponentImg from '@assets/LazyComponent/lazy_component.jpeg';
 
 <img src={LazyComponentImg} />
 
@@ -12,8 +15,6 @@ import LazyComponentImg from '@assets/LazyComponent/lazy_component.jpeg';
 
 :::
 
-import Introduction from '../../introDocs/lynx-ui-lazy-component/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-list/docs/README.mdx
+++ b/packages/lynx-ui-list/docs/README.mdx
@@ -1,6 +1,9 @@
+import descriptions from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-list/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<List>`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-list']}
 
@@ -10,8 +13,6 @@ You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main
 
 :::
 
-import Introduction from '../../introDocs/lynx-ui-list/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-list/docs/README.zh.mdx
+++ b/packages/lynx-ui-list/docs/README.zh.mdx
@@ -1,3 +1,6 @@
+import Introduction from '../../introDocs/lynx-ui-list/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<List>`
 
 一个内置懒加载、回收复用机制的可滚动容器。是对 `<list/>` 底层组件的封装。
@@ -8,8 +11,6 @@
 
 :::
 
-import Introduction from '../../introDocs/lynx-ui-list/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-overlay/docs/README.mdx
+++ b/packages/lynx-ui-overlay/docs/README.mdx
@@ -1,11 +1,12 @@
+import descriptions from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-overlay/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `Overlay`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-overlay']}
 
-import Introduction from '../../introDocs/lynx-ui-overlay/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-overlay/docs/README.zh.mdx
+++ b/packages/lynx-ui-overlay/docs/README.zh.mdx
@@ -1,9 +1,10 @@
+import Introduction from '../../introDocs/lynx-ui-overlay/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `Overlay`
 
 x-overlay-ng 的即用替代组件，屏蔽了平台差异。根据是否提供 container 属性，自动渲染为普通 view 或 x-overlay-ng。
 
-import Introduction from '../../introDocs/lynx-ui-overlay/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-popover/docs/README.mdx
+++ b/packages/lynx-ui-popover/docs/README.mdx
@@ -1,11 +1,12 @@
+import descriptions from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-popover/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `Popover`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-popover']}
 
-import Introduction from '../../introDocs/lynx-ui-popover/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-popover/docs/README.zh.mdx
+++ b/packages/lynx-ui-popover/docs/README.zh.mdx
@@ -1,9 +1,10 @@
+import Introduction from '../../introDocs/lynx-ui-popover/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `Popover`
 
 弹窗组件，可设置不同定位策略和样式，支持自定义内容，支持自定义箭头。
 
-import Introduction from '../../introDocs/lynx-ui-popover/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-radio-group/docs/README.mdx
+++ b/packages/lynx-ui-radio-group/docs/README.mdx
@@ -1,11 +1,12 @@
+import descriptions from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-radio-group/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `RadioGroup`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-radio-group']}
 
-import Introduction from '../../introDocs/lynx-ui-radio-group/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-radio-group/docs/README.zh.mdx
+++ b/packages/lynx-ui-radio-group/docs/README.zh.mdx
@@ -1,9 +1,10 @@
+import Introduction from '../../introDocs/lynx-ui-radio-group/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `RadioGroup`
 
 单选组是一组可勾选的按钮（即单选按钮），一次只能选择其中一个。
 
-import Introduction from '../../introDocs/lynx-ui-radio-group/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-scroll-view/docs/README.mdx
+++ b/packages/lynx-ui-scroll-view/docs/README.mdx
@@ -1,13 +1,12 @@
 import { Go } from '@lynx-ui/index';
 import { PageTabs, PageTab } from '@theme';
-
 import Introduction from '../../introDocs/lynx-ui-scroll-view/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 import BounceDocIntroduction from './useBounce.mdx';
+import descriptions from '../../lynx-ui-intros';
 
 # `<Scrollview>`
 
-import descriptions from '../../lynx-ui-intros';
 
 > - For ReactLynx 2, refer to the [old official website](https://lynx-doc.cn.goofy.app/docs/frontend/lynx-ui/scroll-view)
 

--- a/packages/lynx-ui-scroll-view/docs/README.mdx
+++ b/packages/lynx-ui-scroll-view/docs/README.mdx
@@ -7,9 +7,6 @@ import descriptions from '../../lynx-ui-intros';
 
 # `<Scrollview>`
 
-
-> - For ReactLynx 2, refer to the [old official website](https://lynx-doc.cn.goofy.app/docs/frontend/lynx-ui/scroll-view)
-
 {descriptions['lynx-ui-scroll-view']}
 
 - Lazy-loading optimized container powered by LazyComponent, designed to reduce first-screen rendering time

--- a/packages/lynx-ui-scroll-view/docs/README.zh.mdx
+++ b/packages/lynx-ui-scroll-view/docs/README.zh.mdx
@@ -1,8 +1,6 @@
 import { PageTabs, PageTab } from '@theme';
-
 import Introduction from '../../introDocs/lynx-ui-scroll-view/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
-
 import { Go, UIApiTable } from '@lynx-ui/index';
 import BounceDocIntroduction from './useBounce.zh.mdx';
 

--- a/packages/lynx-ui-sheet/docs/README.mdx
+++ b/packages/lynx-ui-sheet/docs/README.mdx
@@ -1,6 +1,8 @@
+import descriptions from '../../lynx-ui-intros';
+import APIReference from "./APIReference.mdx";
+
 # `<Sheet>`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-sheet']}
 
@@ -14,5 +16,4 @@ You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main
 
 :::
 
-import APIReference from "./APIReference.mdx";
 <APIReference />

--- a/packages/lynx-ui-sheet/docs/README.zh.mdx
+++ b/packages/lynx-ui-sheet/docs/README.zh.mdx
@@ -1,3 +1,5 @@
+import APIReference from "./APIReference.mdx";
+
 # `<Sheet>`
 
 一个支持拖拽手势、吸附点、自动高度与遮罩关闭的底部面板组件。
@@ -12,6 +14,5 @@
 
 :::
 
-import APIReference from "./APIReference.mdx";
 
 <APIReference />

--- a/packages/lynx-ui-slider/docs/README.mdx
+++ b/packages/lynx-ui-slider/docs/README.mdx
@@ -1,11 +1,12 @@
+import descriptions from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-slider/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Slider>`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-slider']}
 
-import Introduction from '../../introDocs/lynx-ui-slider/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-slider/docs/README.zh.mdx
+++ b/packages/lynx-ui-slider/docs/README.zh.mdx
@@ -1,9 +1,10 @@
+import Introduction from '../../introDocs/lynx-ui-slider/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Slider>`
 
 一个滑块组件，用于选择 `[0, 1]` 范围内的值。
 
-import Introduction from '../../introDocs/lynx-ui-slider/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-sortable/docs/README.mdx
+++ b/packages/lynx-ui-sortable/docs/README.mdx
@@ -1,11 +1,12 @@
+import descriptions from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-sortable/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Sortable>`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-sortable']}
 
-import Introduction from '../../introDocs/lynx-ui-sortable/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-sortable/docs/README.zh.mdx
+++ b/packages/lynx-ui-sortable/docs/README.zh.mdx
@@ -1,9 +1,10 @@
+import Introduction from '../../introDocs/lynx-ui-sortable/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Sortable>`
 
 一个排序组件，基于 Draggable 组件实现。目前仅支持等高子项，并且子项之间不可有间距，如 margin。
 
-import Introduction from '../../introDocs/lynx-ui-sortable/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-swipe-action/docs/README.mdx
+++ b/packages/lynx-ui-swipe-action/docs/README.mdx
@@ -1,6 +1,9 @@
+import descriptions from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-swipe-action/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<SwipeAction>`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-swipe-action']}
 
@@ -38,8 +41,6 @@ You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main
 
 :::
 
-import Introduction from '../../introDocs/lynx-ui-swipe-action/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-swipe-action/docs/README.zh.mdx
+++ b/packages/lynx-ui-swipe-action/docs/README.zh.mdx
@@ -1,3 +1,6 @@
+import Introduction from '../../introDocs/lynx-ui-swipe-action/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<SwipeAction>`
 
 一个基于触摸系统和 [MTS](https://lynx.bytedance.net/api/lynx-api/main-thread.html) 实现的可滑动组件。 由 `displayArea` 和 `actionArea` 两部分组成。 可以用来实现左滑删除等功能。
@@ -24,8 +27,6 @@ pluginReactLynx({
 
 :::
 
-import Introduction from '../../introDocs/lynx-ui-swipe-action/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-swiper/docs/README.mdx
+++ b/packages/lynx-ui-swiper/docs/README.mdx
@@ -1,12 +1,13 @@
-# `<Swiper>`
-
 import descriptions from '../../lynx-ui-intros';
-
 import { UIApiTable, Columns } from '@lynx-ui/index';
 import { PageTabs, PageTab } from '@theme';
 import Introduction from '../../introDocs/lynx-ui-swiper/Introduction.mdx';
 import Advanced from './advanced.mdx';
 import APIReference from './APIReference.mdx';
+
+# `<Swiper>`
+
+
 
 {descriptions['lynx-ui-swiper']}
 

--- a/packages/lynx-ui-swiper/docs/README.zh.mdx
+++ b/packages/lynx-ui-swiper/docs/README.zh.mdx
@@ -1,5 +1,3 @@
-# `<Swiper>`
-
 import { UIApiTable, Columns } from '@lynx-ui/index';
 import { PageTabs, PageTab } from '@theme';
 import Introduction from '../../introDocs/lynx-ui-swiper/Introduction.zh.mdx';
@@ -8,6 +6,9 @@ import Advanced from './advanced.zh.mdx';
 import BasicPic from '@assets/Swiper/Basic.webp';
 import LoopPic from '@assets/Swiper/Loop.webp';
 import BouncesPic from '@assets/Swiper/Bounces.webp';
+
+# `<Swiper>`
+
 
 高性能的轮播组件, 提供手势响应，paging，loop，bounces等能力，同时提供高度的自定义能力。
 

--- a/packages/lynx-ui-swiper/docs/advanced.mdx
+++ b/packages/lynx-ui-swiper/docs/advanced.mdx
@@ -1,12 +1,12 @@
-## Advanced Usage
-
-`<Swiper>` supports complete customization of layout and animations, with the key features being `customAnimation` and `mode`
-
 import { Columns, Go } from '@lynx-ui/index';
 import CustomAnimationValue0Pic from '@assets/Swiper/custom_animation_value_0.png';
 import ModeNormalPic from '@assets/Swiper/mode_normal.png';
 import ModeCustomPic from '@assets/Swiper/mode_custom.png';
 import DemoCustomPic from '@assets/Swiper/Custom.webp';
+
+## Advanced Usage
+
+`<Swiper>` supports complete customization of layout and animations, with the key features being `customAnimation` and `mode`
 
 ### Understanding `customAnimation`
 

--- a/packages/lynx-ui-swiper/docs/advanced.zh.mdx
+++ b/packages/lynx-ui-swiper/docs/advanced.zh.mdx
@@ -1,13 +1,12 @@
-## 进阶用法
-
-`<Swiper>`支持布局和动画的完全自定义，其中的关键是 `customAnimation` 和 `mode`
-
 import { Columns, Go } from '@lynx-ui/index';
-
 import CustomAnimationValue0Pic from '@assets/Swiper/custom_animation_value_0.png';
 import ModeNormalPic from '@assets/Swiper/mode_normal.png';
 import ModeCustomPic from '@assets/Swiper/mode_custom.png';
 import DemoCustomPic from '@assets/Swiper/Custom.webp';
+
+## 进阶用法
+
+`<Swiper>`支持布局和动画的完全自定义，其中的关键是 `customAnimation` 和 `mode`
 
 ### 理解 `customAnimation`
 

--- a/packages/lynx-ui-switch/docs/README.mdx
+++ b/packages/lynx-ui-switch/docs/README.mdx
@@ -1,11 +1,12 @@
+import descriptions from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-switch/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Switch>`
 
-import descriptions from '../../lynx-ui-intros';
 
 {descriptions['lynx-ui-switch']}
 
-import Introduction from '../../introDocs/lynx-ui-switch/Introduction.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-switch/docs/README.zh.mdx
+++ b/packages/lynx-ui-switch/docs/README.zh.mdx
@@ -1,9 +1,10 @@
+import Introduction from '../../introDocs/lynx-ui-switch/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+
 # `<Switch>`
 
 `<Switch>` 开关是一种简单的控件，用于切换设置的开启或关闭。
 
-import Introduction from '../../introDocs/lynx-ui-switch/Introduction.zh.mdx';
-import APIReference from './APIReference.mdx';
 
 <Introduction />
 <APIReference />


### PR DESCRIPTION
Rspress uses an MDX v2 / ESM-compatible compilation pipeline, where
top-level import/export statements must appear before any Markdown or JSX
content.

Some lynx-ui docs placed import statements after headings or prose, which
caused MDX compile failures during downstream sync and build.

This change:
- hoists top-level imports in docs/*.mdx to the file header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized documentation structure across multiple UI components, moving import statements to the top of files for improved consistency and readability.

* **Refactor**
  * Standardized the layout of component documentation files to follow a uniform structure across English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->