### PR TITLE
docs(sheet): add missing Introduction to Sheet docs

### DIFF
--- a/packages/lynx-ui-sheet/docs/README.mdx
+++ b/packages/lynx-ui-sheet/docs/README.mdx
@@ -1,5 +1,6 @@
 import descriptions from '../../lynx-ui-intros';
-import APIReference from "./APIReference.mdx";
+import Introduction from '../../introDocs/lynx-ui-sheet/Introduction.mdx';
+import APIReference from './APIReference.mdx';
 
 # `<Sheet>`
 
@@ -15,4 +16,5 @@ You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main
 
 :::
 
+<Introduction />
 <APIReference />

--- a/packages/lynx-ui-sheet/docs/README.zh.mdx
+++ b/packages/lynx-ui-sheet/docs/README.zh.mdx
@@ -1,4 +1,5 @@
-import APIReference from "./APIReference.mdx";
+import Introduction from '../../introDocs/lynx-ui-sheet/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
 
 # `<Sheet>`
 
@@ -14,4 +15,5 @@ import APIReference from "./APIReference.mdx";
 
 :::
 
+<Introduction />
 <APIReference />


### PR DESCRIPTION
Add the missing Introduction import and render before APIReference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced sheet component documentation with an introduction section for both English and Chinese versions, providing better guidance before the API reference material.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->