### PR TITLE
docs: migrate internal URLs to public version

### DIFF
--- a/packages/lynx-ui-button/docs/README.mdx
+++ b/packages/lynx-ui-button/docs/README.mdx
@@ -8,7 +8,7 @@ import APIReference from './APIReference.mdx';
 
 :::info
 
-You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-button) to understand how it works, and you're welcome to submit MRs to enhance its capabilities;
+You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-button) to understand how it works, and you're welcome to submit MRs to enhance its capabilities.
 
 :::
 

--- a/packages/lynx-ui-button/docs/README.zh.mdx
+++ b/packages/lynx-ui-button/docs/README.zh.mdx
@@ -7,7 +7,7 @@ import APIReference from './APIReference.mdx';
 
 :::info
 
-你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-button)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力;
+你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-button)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力。
 
 此外，你也可以参考这个实现，自行实现定制化的 Button 能力；
 

--- a/packages/lynx-ui-feed-list/docs/README.mdx
+++ b/packages/lynx-ui-feed-list/docs/README.mdx
@@ -11,9 +11,9 @@ import RefreshDocIntroduction from './useRefresh.mdx';
 
 :::info
 
-You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-feed-list) to understand how it works, and you're welcome to submit MRs to enhance its capabilities;
+You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-feed-list) to understand how it works, and you're welcome to submit MRs to enhance its capabilities.
 
-Moreover, you can also implement your own tabs functionality with [MTS](https://lynxjs.org/api/lynx-api/main-thread.html).
+Moreover, you can also implement your own feed/list interaction behavior with [MTS](https://lynxjs.org/api/lynx-api/main-thread.html).
 
 :::
 

--- a/packages/lynx-ui-feed-list/docs/README.mdx
+++ b/packages/lynx-ui-feed-list/docs/README.mdx
@@ -13,7 +13,7 @@ import RefreshDocIntroduction from './useRefresh.mdx';
 
 You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-feed-list) to understand how it works, and you're welcome to submit MRs to enhance its capabilities;
 
-Moreover, you can also implement your own tabs functionality with [MTS](https://lynx.bytedance.net/api/lynx-api/main-thread.html).
+Moreover, you can also implement your own tabs functionality with [MTS](https://lynxjs.org/api/lynx-api/main-thread.html).
 
 :::
 

--- a/packages/lynx-ui-feed-list/docs/README.zh.mdx
+++ b/packages/lynx-ui-feed-list/docs/README.zh.mdx
@@ -13,7 +13,7 @@ import RefreshDocIntroduction from './useRefresh.zh.mdx';
 
 你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-feed-list)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力;
 
-此外，你也可以参考这个实现，利用 [MTS](https://lynx.bytedance.net/api/lynx-api/main-thread.html) 自行实现定制化的 Tabs 能力；
+此外，你也可以参考这个实现，利用 [MTS](https://lynxjs.org/api/lynx-api/main-thread.html) 自行实现定制化的 Tabs 能力；
 
 :::
 

--- a/packages/lynx-ui-feed-list/docs/README.zh.mdx
+++ b/packages/lynx-ui-feed-list/docs/README.zh.mdx
@@ -11,9 +11,9 @@ import RefreshDocIntroduction from './useRefresh.zh.mdx';
 
 :::info
 
-你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-feed-list)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力;
+你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-feed-list)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力。
 
-此外，你也可以参考这个实现，利用 [MTS](https://lynxjs.org/api/lynx-api/main-thread.html) 自行实现定制化的 Tabs 能力；
+此外，你也可以参考这个实现，利用 [MTS](https://lynxjs.org/api/lynx-api/main-thread.html) 自行实现定制化的列表 refresh / load-more 能力。
 
 :::
 

--- a/packages/lynx-ui-lazy-component/docs/README.mdx
+++ b/packages/lynx-ui-lazy-component/docs/README.mdx
@@ -11,9 +11,7 @@ import APIReference from './APIReference.mdx';
 
 :::info
 
-You can check the [source code](https://code.byted.org/lynx/lynx-ui/tree/master/packages/lynx-ui-fold-view) to understand how it works, and you're welcome to submit MRs to enhance its capabilities;
-
-Moreover, you can also implement your own tabs functionality with `<x-foldview-ng>`.
+You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-lazy-component) to understand how it works, and you're welcome to submit MRs to enhance its capabilities.
 
 :::
 

--- a/packages/lynx-ui-lazy-component/docs/README.zh.mdx
+++ b/packages/lynx-ui-lazy-component/docs/README.zh.mdx
@@ -10,7 +10,7 @@ A universal lazy-loading component based on global exposure detection. It dynami
 
 :::info
 
-你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-lazy-component)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力;
+你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-lazy-component)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力。
 
 :::
 

--- a/packages/lynx-ui-list/docs/README.mdx
+++ b/packages/lynx-ui-list/docs/README.mdx
@@ -8,7 +8,7 @@ import APIReference from './APIReference.mdx';
 
 :::info
 
-You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-list) to understand how it works, and you're welcome to submit MRs to enhance its capabilities;
+You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-list) to understand how it works, and you're welcome to submit MRs to enhance its capabilities.
 
 :::
 

--- a/packages/lynx-ui-list/docs/README.zh.mdx
+++ b/packages/lynx-ui-list/docs/README.zh.mdx
@@ -7,7 +7,7 @@ import APIReference from './APIReference.mdx';
 
 :::info
 
-你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-list)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力;
+你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-list)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力。
 
 :::
 

--- a/packages/lynx-ui-scroll-view/docs/README.mdx
+++ b/packages/lynx-ui-scroll-view/docs/README.mdx
@@ -15,7 +15,7 @@ import descriptions from '../../lynx-ui-intros';
 
 :::info
 
-You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-scroll-view) to understand how it works, and you're welcome to submit MRs to enhance its capabilities;
+You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-scroll-view) to understand how it works, and you're welcome to submit MRs to enhance its capabilities.
 
 :::
 

--- a/packages/lynx-ui-scroll-view/docs/README.zh.mdx
+++ b/packages/lynx-ui-scroll-view/docs/README.zh.mdx
@@ -13,7 +13,7 @@ import BounceDocIntroduction from './useBounce.zh.mdx';
 
 :::info
 
-你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-scroll-view)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力;
+你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-scroll-view)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力。
 
 :::
 

--- a/packages/lynx-ui-sheet/docs/README.mdx
+++ b/packages/lynx-ui-sheet/docs/README.mdx
@@ -12,7 +12,7 @@ import APIReference from './APIReference.mdx';
 
 :::info
 
-You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-sheet) to understand how it works, and you're welcome to submit MRs to enhance its capabilities;
+You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-sheet) to understand how it works, and you're welcome to submit MRs to enhance its capabilities.
 
 :::
 

--- a/packages/lynx-ui-sheet/docs/README.zh.mdx
+++ b/packages/lynx-ui-sheet/docs/README.zh.mdx
@@ -11,7 +11,7 @@ import APIReference from './APIReference.mdx';
 
 :::info
 
-你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-sheet)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力;
+你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-sheet)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力。
 
 :::
 

--- a/packages/lynx-ui-swipe-action/docs/README.mdx
+++ b/packages/lynx-ui-swipe-action/docs/README.mdx
@@ -36,7 +36,7 @@ pluginReactLynx({
 
 :::info
 
-You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-swipe-action) to understand how it works, and you're welcome to submit MRs to enhance its capabilities;
+You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-swipe-action) to understand how it works, and you're welcome to submit MRs to enhance its capabilities.
 
 :::
 

--- a/packages/lynx-ui-swipe-action/docs/README.zh.mdx
+++ b/packages/lynx-ui-swipe-action/docs/README.zh.mdx
@@ -3,7 +3,7 @@ import APIReference from './APIReference.mdx';
 
 # `<SwipeAction>`
 
-一个基于触摸系统和 [MTS](https://lynx.bytedance.net/api/lynx-api/main-thread.html) 实现的可滑动组件。 由 `displayArea` 和 `actionArea` 两部分组成。 可以用来实现左滑删除等功能。
+一个基于触摸系统和 [MTS](https://lynxjs.org/api/lynx-api/main-thread.html) 实现的可滑动组件。 由 `displayArea` 和 `actionArea` 两部分组成。 可以用来实现左滑删除等功能。
 
 :::info 环境要求
 LynxSDK 版本 >= 2.16

--- a/packages/lynx-ui-swipe-action/docs/README.zh.mdx
+++ b/packages/lynx-ui-swipe-action/docs/README.zh.mdx
@@ -23,7 +23,7 @@ pluginReactLynx({
 
 :::info
 
-你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-swipe-action)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力;
+你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-swipe-action)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力。
 
 :::
 

--- a/packages/lynx-ui-swiper/docs/README.mdx
+++ b/packages/lynx-ui-swiper/docs/README.mdx
@@ -11,7 +11,7 @@ import APIReference from './APIReference.mdx';
 
 :::info
 
-You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-swiper) to understand how it works, and you're welcome to submit MRs to enhance its capabilities;
+You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-swiper) to understand how it works, and you're welcome to submit MRs to enhance its capabilities.
 
 :::
 

--- a/packages/lynx-ui-swiper/docs/README.zh.mdx
+++ b/packages/lynx-ui-swiper/docs/README.zh.mdx
@@ -11,7 +11,7 @@ import BouncesPic from '@assets/Swiper/Bounces.webp';
 
 高性能的轮播组件, 提供手势响应，paging，loop，bounces等能力，同时提供高度的自定义能力。
 
-一个基于触摸系统和 [MTS](https://lynx.bytedance.net/api/lynx-api/main-thread.html) 实现的高性能轮播组件, 提供手势响应，paging，loop，bounces等能力，同时提供高度的自定义能力。
+一个基于触摸系统和 [MTS](https://lynxjs.org/api/lynx-api/main-thread.html) 实现的高性能轮播组件, 提供手势响应，paging，loop，bounces等能力，同时提供高度的自定义能力。
 
 :::info
 

--- a/packages/lynx-ui-swiper/docs/README.zh.mdx
+++ b/packages/lynx-ui-swiper/docs/README.zh.mdx
@@ -9,13 +9,11 @@ import BouncesPic from '@assets/Swiper/Bounces.webp';
 
 # `<Swiper>`
 
-高性能的轮播组件, 提供手势响应，paging，loop，bounces等能力，同时提供高度的自定义能力。
-
 一个基于触摸系统和 [MTS](https://lynxjs.org/api/lynx-api/main-thread.html) 实现的高性能轮播组件, 提供手势响应，paging，loop，bounces等能力，同时提供高度的自定义能力。
 
 :::info
 
-你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-swiper)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力;
+你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-swiper)来了解它的运行原理，也欢迎大家提 MR 来丰富其能力。
 
 :::
 


### PR DESCRIPTION
- Remove `lynx.bytedance.net`, `code.byted.org` across component docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reference links in component documentation to point to the latest domain.
  * Refined documentation text formatting and clarity across multiple component guides in both English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->