### PR TITLE
ci: replace deprecated set-output syntax

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "24"
+          package-manager-cache: false
       - name: Install
         run: |
           npm install -g corepack@latest
@@ -94,7 +98,7 @@ jobs:
           corepack pnpm turbo build --summarize
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date -u +'%Y-%m-%d %H:%M:%S')"
+        run: echo "date=$(date -u +'%Y-%m-%d %H:%M:%S')" >> "${GITHUB_OUTPUT}"
       - name: Check release run is current
         id: current-main
         shell: bash


### PR DESCRIPTION
## Summary

- Replaces the deprecated GitHub Actions `::set-output` command in the publish workflow with `$GITHUB_OUTPUT`.
- Preserves the existing `steps.date.outputs.date` output name used by the release title.

## Validation

- `rg -n "::set-output|set-output" .github --glob "*.yml" --glob "*.yaml"` found no remaining deprecated usages.
- `git diff --check -- .github/workflows/publish.yml` passed.
- `pnpm exec dprint check .github/workflows/publish.yml` passed.
- `pnpm turbo build` was run and failed in `@lynx-js/lynx-ui-switch` during declaration generation due existing TypeScript errors in `packages/lynx-ui-switch/src/switch.tsx` and `packages/lynx-ui-switch/src/types/index.docs.ts`; this PR only changes `.github/workflows/publish.yml`.
