### PR TITLE
chore: tune coderabbit summary style

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,6 +5,12 @@ reviews:
   profile: "chill"
   request_changes_workflow: false
   high_level_summary: true
+  high_level_summary_instructions: |
+    Write the high-level summary in a commit-message style:
+    - Use the imperative mood and present tense, such as "Update reference links" or "Refine documentation formatting".
+    - Do not use past-tense verbs such as "Updated", "Refined", "Added", "Fixed", or "Changed".
+    - Keep each bullet concise and action-oriented, with one clear change per bullet.
+    - Prefer repository terminology exactly as written, especially `lynx-ui`.
   poem: false
   review_status: true
   collapse_walkthrough: false


### PR DESCRIPTION
## Summary

- Configure CodeRabbit high-level summaries to use commit-message style.
- Ask CodeRabbit to prefer imperative, present-tense bullets and avoid past-tense verbs.
- Preserve the repository naming convention for `lynx-ui`.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.coderabbit.yaml'); puts 'ok'"`
- `git diff --check -- .coderabbit.yaml`
- Pre-commit hooks ran during commit: dprint formatting and cspell lint for the staged YAML file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration settings for code review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->