### PR TITLE
feat: add command refresh example

### DIFF
--- a/.changeset/soft-forks-battle.md
+++ b/.changeset/soft-forks-battle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/lynx-ui-feed-list": patch
+---
+
+feat: Implement new FeedListRefresh example with refresh functionality

--- a/apps/examples/FeedList/Refresh/RectangleCard.tsx
+++ b/apps/examples/FeedList/Refresh/RectangleCard.tsx
@@ -1,0 +1,23 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+interface RectangleCardProps {
+  cardKey: string
+  letter: string
+  height: number
+}
+
+export function RectangleCard(props: RectangleCardProps) {
+  const { letter, height = 422 } = props
+
+  return (
+    <view style={{ width: '100%', height: 'max-content' }}>
+      <view className='rectangle-card' style={{ height: `${height}px` }}>
+        <text className='rectangle-card__letter'>{letter}</text>
+        <text className='rectangle-card__title'>FeedList</text>
+        <text className='rectangle-card__subtitle'>@lynx-js/lynx-ui</text>
+      </view>
+    </view>
+  )
+}

--- a/apps/examples/FeedList/Refresh/RefreshHeader.tsx
+++ b/apps/examples/FeedList/Refresh/RefreshHeader.tsx
@@ -1,0 +1,15 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export function RefreshHeader() {
+  return (
+    <view className='refresh-header'>
+      <image
+        src='https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/loading.gif'
+        className='refresh-header__spinner'
+      />
+      <text className='refresh-header__text'>Refreshing</text>
+    </view>
+  )
+}

--- a/apps/examples/FeedList/Refresh/data.ts
+++ b/apps/examples/FeedList/Refresh/data.ts
@@ -1,0 +1,29 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export interface LetterItem {
+  key: string
+  letter: string
+}
+
+export const FEED_INITIAL: LetterItem[] = [
+  { key: 'initial-F', letter: 'F' },
+  { key: 'initial-E1', letter: 'E' },
+  { key: 'initial-E2', letter: 'E' },
+  { key: 'initial-D', letter: 'D' },
+  { key: 'initial-L', letter: 'L' },
+  { key: 'initial-I', letter: 'I' },
+  { key: 'initial-S', letter: 'S' },
+  { key: 'initial-T', letter: 'T' },
+]
+
+export const FEED_REFRESH: LetterItem[] = [
+  { key: 'refresh-R1', letter: 'R' },
+  { key: 'refresh-E3', letter: 'E' },
+  { key: 'refresh-F2', letter: 'F' },
+  { key: 'refresh-R2', letter: 'R' },
+  { key: 'refresh-E4', letter: 'E' },
+  { key: 'refresh-S2', letter: 'S' },
+  { key: 'refresh-H', letter: 'H' },
+]

--- a/apps/examples/FeedList/Refresh/index.css
+++ b/apps/examples/FeedList/Refresh/index.css
@@ -1,0 +1,119 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.demo-container {
+  position: relative;
+  background-color: var(--canvas-ambient);
+  width: 100%;
+  height: 100%;
+  padding-top: 48px;
+}
+
+.demo-actions {
+  position: absolute;
+  bottom: 24px;
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 12px;
+  background-color: var(--neutral-content);
+  border-top: 1px;
+  border-color: var(--line);
+}
+
+.command-button {
+  width: 100%;
+  background-color: var(--neutral);
+  border-radius: 999px;
+  padding: 14px 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.command-button.ui-active {
+  background-color: var(--neutral-2);
+}
+
+.command-button--secondary {
+  background-color: var(--fill-primary);
+}
+
+.command-button__text {
+  color: var(--content-inverse, #111111);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.feed-list {
+  width: 100%;
+  height: 100%;
+  background-color: var(--canvas-ambient);
+}
+
+.bottom-spacer {
+  width: 100%;
+  height: 168px;
+}
+
+.refresh-header {
+  width: 100%;
+  height: 56px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+
+.refresh-header__spinner {
+  width: 32px;
+  height: 32px;
+}
+
+.refresh-header__text {
+  font-size: 14px;
+  color: var(--content-subtle);
+}
+
+.rectangle-card {
+  background-color: var(--canvas);
+  border-color: var(--line);
+  border-width: 1px;
+  border-radius: 16px;
+  margin-left: 16px;
+  margin-right: 16px;
+  margin-bottom: 12px;
+  padding-top: 80px;
+  padding-bottom: 80px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.rectangle-card__letter {
+  font-size: 224px;
+  font-weight: 600;
+  padding-left: 48px;
+  padding-right: 48px;
+  color: var(--canvas);
+  border-radius: 16px;
+  background: linear-gradient(
+    150deg,
+    var(--primary) 8.42%,
+    var(--primary-2) 81.71%
+  );
+}
+
+.rectangle-card__title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-top: auto;
+  color: var(--content);
+}
+
+.rectangle-card__subtitle {
+  font-size: 12px;
+  color: var(--content-subtle);
+}

--- a/apps/examples/FeedList/Refresh/index.tsx
+++ b/apps/examples/FeedList/Refresh/index.tsx
@@ -1,0 +1,112 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useEffect, useMemo, useRef, useState } from '@lynx-js/react'
+
+import { Button, FeedList } from '@lynx-js/lynx-ui'
+import type { FeedListRef } from '@lynx-js/lynx-ui'
+
+import { FEED_INITIAL, FEED_REFRESH } from './data'
+import type { LetterItem } from './data'
+import { RectangleCard } from './RectangleCard'
+import { RefreshHeader } from './RefreshHeader'
+import './index.css'
+
+function App() {
+  const feedListRef = useRef<FeedListRef>(null)
+  const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const refreshing = useRef(false)
+  const showRefreshSet = useRef(false)
+
+  const [items, setItems] = useState<LetterItem[]>(FEED_INITIAL)
+
+  useEffect(() => {
+    return () => {
+      if (refreshTimer.current) {
+        clearTimeout(refreshTimer.current)
+      }
+    }
+  }, [])
+
+  const refreshHeader = useMemo(
+    () => <RefreshHeader />,
+    [],
+  )
+
+  const startRefresh = () => {
+    if (refreshing.current) {
+      return
+    }
+
+    feedListRef.current?.startRefresh()
+  }
+
+  const handleStartRefresh = (
+    _event: { triggeredBy: 'startRefresh' | 'drag' },
+  ) => {
+    refreshing.current = true
+
+    if (refreshTimer.current) {
+      clearTimeout(refreshTimer.current)
+    }
+
+    refreshTimer.current = setTimeout(() => {
+      showRefreshSet.current = !showRefreshSet.current
+      const nextItems = showRefreshSet.current ? FEED_REFRESH : FEED_INITIAL
+      setItems(nextItems)
+
+      feedListRef.current?.finishRefresh()
+      refreshing.current = false
+    }, 1500)
+  }
+
+  return (
+    <view className='lunaris-dark demo-container'>
+      <FeedList
+        className='feed-list'
+        listId='feedListRefresh'
+        ref={feedListRef}
+        listType='single'
+        spanCount={1}
+        scrollOrientation='vertical'
+        refreshOptions={{
+          enableRefresh: true,
+          headerContent: refreshHeader,
+          onStartRefresh: handleStartRefresh,
+        }}
+        useRefactorList={true}
+        bounces={false}
+      >
+        {items.map((item: LetterItem) => (
+          <list-item key={item.key} item-key={item.key}>
+            <RectangleCard
+              cardKey={item.key}
+              letter={item.letter}
+              height={500}
+            />
+          </list-item>
+        ))}
+        <list-item
+          item-key='commandRefreshFooterSpace'
+          key='commandRefreshFooterSpace'
+        >
+          <view className='bottom-spacer' />
+        </list-item>
+      </FeedList>
+      <view className='demo-actions'>
+        <Button
+          className='command-button'
+          onClick={() => {
+            startRefresh()
+          }}
+        >
+          <text className='command-button__text'>Refresh</text>
+        </Button>
+      </view>
+    </view>
+  )
+}
+
+root.render(<App />)
+export default App

--- a/apps/examples/FeedList/lynx.config.mjs
+++ b/apps/examples/FeedList/lynx.config.mjs
@@ -8,6 +8,7 @@ const defaultConfig = exampleConfig({
   FeedListBasic: './Basic/index.tsx',
   FeedListHorizontal: './Horizontal/index.tsx',
   FeedListHorizontalRTL: './HorizontalRTL/index.tsx',
+  FeedListRefresh: './Refresh/index.tsx',
 }, { needWeb: false })
 
 export default defaultConfig


### PR DESCRIPTION
Implement new FeedListCommandRefresh example with refresh functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Add command refresh example for FeedList

Implement new FeedListCommandRefresh example demonstrating pull-to-refresh functionality:

- Add FeedListRefresh route to lynx.config.mjs pointing to the new example
- Create RectangleCard component to display feed items with dynamic heights and gradient letter styling
- Create RefreshHeader component to show refresh indicator with spinner animation
- Add feed data module with initial and refresh item sets
- Add stylesheet for demo layout, action buttons, feed list, refresh header, and card components
- Implement main example component with refresh state management, timeout-based content toggle, and `FeedList` ref integration for imperative refresh control

**Files added:** 6  
**Lines changed:** +299/-0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->