### PR TITLE
docs: import descriptions in zh readmes

### DIFF
--- a/packages/lynx-ui-feed-list/docs/README.zh.mdx
+++ b/packages/lynx-ui-feed-list/docs/README.zh.mdx
@@ -1,4 +1,5 @@
 import { Go, UIApiTable } from '@lynx-ui/index';
+import descriptions from '../../lynx-ui-intros';
 import { PageTabs, PageTab } from '@theme';
 import Introduction from '../../introDocs/lynx-ui-feed-list/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';

--- a/packages/lynx-ui-scroll-view/docs/README.zh.mdx
+++ b/packages/lynx-ui-scroll-view/docs/README.zh.mdx
@@ -1,4 +1,5 @@
 import { PageTabs, PageTab } from '@theme';
+import descriptions from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-scroll-view/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
 import { Go, UIApiTable } from '@lynx-ui/index';


### PR DESCRIPTION
## Summary

- add the missing `descriptions` imports in the zh FeedList and ScrollView READMEs
- keep the generated website docs buildable after the docs switched to `descriptions[...]`

## Test

- `git diff --check`
- validated from `lynx-family/lynx-website` by syncing this source commit and running `pnpm run build`