### PR TITLE
docs: generate component intros by locale

### DIFF
--- a/packages/lynx-ui-button/docs/README.mdx
+++ b/packages/lynx-ui-button/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-button/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `<Button>`
 
-{descriptions['lynx-ui-button']}
+{lynxUiIntros['lynx-ui-button']}
 
 :::info
 

--- a/packages/lynx-ui-button/docs/README.zh.mdx
+++ b/packages/lynx-ui-button/docs/README.zh.mdx
@@ -1,9 +1,10 @@
 import Introduction from '../../introDocs/lynx-ui-button/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `<Button>`
 
-一个基础的 button 实现，提供高亮和选中状态。
+{lynxUiIntrosZh['lynx-ui-button']}
 
 :::info
 

--- a/packages/lynx-ui-checkbox/docs/README.mdx
+++ b/packages/lynx-ui-checkbox/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-checkbox/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `<Checkbox>`
 
-{descriptions['lynx-ui-checkbox']}
+{lynxUiIntros['lynx-ui-checkbox']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-dialog/docs/README.mdx
+++ b/packages/lynx-ui-dialog/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-dialog/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `Dialog`
 
-{descriptions['lynx-ui-dialog']}
+{lynxUiIntros['lynx-ui-dialog']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-dialog/docs/README.zh.mdx
+++ b/packages/lynx-ui-dialog/docs/README.zh.mdx
@@ -1,9 +1,10 @@
 import Introduction from '../../introDocs/lynx-ui-dialog/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `Dialog`
 
-弹窗组件，用于在当前视图上方展示内容，支持背景遮罩和自定义动画。
+{lynxUiIntrosZh['lynx-ui-dialog']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-draggable/docs/README.mdx
+++ b/packages/lynx-ui-draggable/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-draggable/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `<Draggable>`
 
-{descriptions['lynx-ui-draggable']}
+{lynxUiIntros['lynx-ui-draggable']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-draggable/docs/README.zh.mdx
+++ b/packages/lynx-ui-draggable/docs/README.zh.mdx
@@ -1,9 +1,10 @@
 import Introduction from '../../introDocs/lynx-ui-draggable/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `<Draggable>`
 
-一个基础的可拖拽组件.
+{lynxUiIntrosZh['lynx-ui-draggable']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-feed-list/docs/README.mdx
+++ b/packages/lynx-ui-feed-list/docs/README.mdx
@@ -1,4 +1,4 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import { Go, UIApiTable } from '@lynx-ui/index';
 import { PageTabs, PageTab } from '@theme';
 import Introduction from '../../introDocs/lynx-ui-feed-list/Introduction.mdx';
@@ -7,7 +7,7 @@ import RefreshDocIntroduction from './useRefresh.mdx';
 
 # `<FeedList>`
 
-{descriptions['lynx-ui-feed-list']}
+{lynxUiIntros['lynx-ui-feed-list']}
 
 :::info
 

--- a/packages/lynx-ui-feed-list/docs/README.zh.mdx
+++ b/packages/lynx-ui-feed-list/docs/README.zh.mdx
@@ -3,11 +3,11 @@ import { PageTabs, PageTab } from '@theme';
 import Introduction from '../../introDocs/lynx-ui-feed-list/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
 import RefreshDocIntroduction from './useRefresh.zh.mdx';
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `<FeedList>`
 
-{descriptions['lynx-ui-feed-list']}
+{lynxUiIntrosZh['lynx-ui-feed-list']}
 
 :::info
 

--- a/packages/lynx-ui-form/docs/README.mdx
+++ b/packages/lynx-ui-form/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-form/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `<Form>`
 
-{descriptions['lynx-ui-form']}
+{lynxUiIntros['lynx-ui-form']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-form/docs/README.zh.mdx
+++ b/packages/lynx-ui-form/docs/README.zh.mdx
@@ -1,9 +1,10 @@
 import Introduction from '../../introDocs/lynx-ui-form/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `<Form>`
 
-Form 是一个用于收集和提交数据的表单组件。
+{lynxUiIntrosZh['lynx-ui-form']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-input/docs/README.mdx
+++ b/packages/lynx-ui-input/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-input/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `<Input>`
 
-{descriptions['lynx-ui-input']}
+{lynxUiIntros['lynx-ui-input']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-input/docs/README.zh.mdx
+++ b/packages/lynx-ui-input/docs/README.zh.mdx
@@ -1,9 +1,10 @@
 import Introduction from '../../introDocs/lynx-ui-input/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `<Input>`
 
-输入框组件，支持受控、非受控及键盘避让能力。
+{lynxUiIntrosZh['lynx-ui-input']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-lazy-component/docs/README.mdx
+++ b/packages/lynx-ui-lazy-component/docs/README.mdx
@@ -1,11 +1,11 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import LazyComponentImg from '@assets/LazyComponent/lazy_component.jpeg';
 import Introduction from '../../introDocs/lynx-ui-lazy-component/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `<LazyComponent>`
 
-{descriptions['lynx-ui-lazy-component']}
+{lynxUiIntros['lynx-ui-lazy-component']}
 
 <img src={LazyComponentImg} />
 

--- a/packages/lynx-ui-lazy-component/docs/README.zh.mdx
+++ b/packages/lynx-ui-lazy-component/docs/README.zh.mdx
@@ -1,10 +1,11 @@
 import LazyComponentImg from '@assets/LazyComponent/lazy_component.jpeg';
 import Introduction from '../../introDocs/lynx-ui-lazy-component/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `<LazyComponent>`
 
-A universal lazy-loading component based on global exposure detection. It dynamically renders nodes only when they enter the viewport boundary, significantly improving performance by skipping off-screen elements.
+{lynxUiIntrosZh['lynx-ui-lazy-component']}
 
 <img src={LazyComponentImg} />
 

--- a/packages/lynx-ui-list/docs/README.mdx
+++ b/packages/lynx-ui-list/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-list/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `<List>`
 
-{descriptions['lynx-ui-list']}
+{lynxUiIntros['lynx-ui-list']}
 
 :::info
 

--- a/packages/lynx-ui-list/docs/README.zh.mdx
+++ b/packages/lynx-ui-list/docs/README.zh.mdx
@@ -1,9 +1,10 @@
 import Introduction from '../../introDocs/lynx-ui-list/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `<List>`
 
-一个内置懒加载、回收复用机制的可滚动容器。是对 `<list/>` 底层组件的封装。
+{lynxUiIntrosZh['lynx-ui-list']}
 
 :::info
 

--- a/packages/lynx-ui-overlay/docs/README.mdx
+++ b/packages/lynx-ui-overlay/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-overlay/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `Overlay`
 
-{descriptions['lynx-ui-overlay']}
+{lynxUiIntros['lynx-ui-overlay']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-overlay/docs/README.zh.mdx
+++ b/packages/lynx-ui-overlay/docs/README.zh.mdx
@@ -1,9 +1,10 @@
 import Introduction from '../../introDocs/lynx-ui-overlay/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `Overlay`
 
-x-overlay-ng 的即用替代组件，屏蔽了平台差异。根据是否提供 container 属性，自动渲染为普通 view 或 x-overlay-ng。
+{lynxUiIntrosZh['lynx-ui-overlay']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-popover/docs/README.mdx
+++ b/packages/lynx-ui-popover/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-popover/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `Popover`
 
-{descriptions['lynx-ui-popover']}
+{lynxUiIntros['lynx-ui-popover']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-popover/docs/README.zh.mdx
+++ b/packages/lynx-ui-popover/docs/README.zh.mdx
@@ -1,9 +1,10 @@
 import Introduction from '../../introDocs/lynx-ui-popover/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `Popover`
 
-弹窗组件，可设置不同定位策略和样式，支持自定义内容，支持自定义箭头。
+{lynxUiIntrosZh['lynx-ui-popover']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-radio-group/docs/README.mdx
+++ b/packages/lynx-ui-radio-group/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-radio-group/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `RadioGroup`
 
-{descriptions['lynx-ui-radio-group']}
+{lynxUiIntros['lynx-ui-radio-group']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-radio-group/docs/README.zh.mdx
+++ b/packages/lynx-ui-radio-group/docs/README.zh.mdx
@@ -1,9 +1,10 @@
 import Introduction from '../../introDocs/lynx-ui-radio-group/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `RadioGroup`
 
-单选组是一组可勾选的按钮（即单选按钮），一次只能选择其中一个。
+{lynxUiIntrosZh['lynx-ui-radio-group']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-scroll-view/docs/README.mdx
+++ b/packages/lynx-ui-scroll-view/docs/README.mdx
@@ -3,11 +3,11 @@ import { PageTabs, PageTab } from '@theme';
 import Introduction from '../../introDocs/lynx-ui-scroll-view/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 import BounceDocIntroduction from './useBounce.mdx';
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 
 # `<Scrollview>`
 
-{descriptions['lynx-ui-scroll-view']}
+{lynxUiIntros['lynx-ui-scroll-view']}
 
 - Lazy-loading optimized container powered by LazyComponent, designed to reduce first-screen rendering time
 

--- a/packages/lynx-ui-scroll-view/docs/README.zh.mdx
+++ b/packages/lynx-ui-scroll-view/docs/README.zh.mdx
@@ -3,11 +3,11 @@ import Introduction from '../../introDocs/lynx-ui-scroll-view/Introduction.zh.md
 import APIReference from './APIReference.mdx';
 import { Go, UIApiTable } from '@lynx-ui/index';
 import BounceDocIntroduction from './useBounce.zh.mdx';
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `<Scrollview>`
 
-{descriptions['lynx-ui-scroll-view']}
+{lynxUiIntrosZh['lynx-ui-scroll-view']}
 
 - 利用 [`LazyComponent`](/lynx-ui/components/lazy-component.html)内置懒加载能力的滚动容器，用于优化首屏耗时；
 - 内置双端对齐的 bounces 能力。

--- a/packages/lynx-ui-sheet/docs/README.mdx
+++ b/packages/lynx-ui-sheet/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-sheet/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `<Sheet>`
 
-{descriptions['lynx-ui-sheet']}
+{lynxUiIntros['lynx-ui-sheet']}
 
 - Supports controlled and uncontrolled visibility.
 - Supports snap points, including percentages and content-driven height.

--- a/packages/lynx-ui-sheet/docs/README.zh.mdx
+++ b/packages/lynx-ui-sheet/docs/README.zh.mdx
@@ -1,9 +1,10 @@
 import Introduction from '../../introDocs/lynx-ui-sheet/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `<Sheet>`
 
-一个支持拖拽手势、吸附点、自动高度与遮罩关闭的底部面板组件。
+{lynxUiIntrosZh['lynx-ui-sheet']}
 
 - 支持受控与非受控两种显示方式。
 - 支持吸附点配置，包括百分比高度与内容自适应高度。

--- a/packages/lynx-ui-slider/docs/README.mdx
+++ b/packages/lynx-ui-slider/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-slider/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `<Slider>`
 
-{descriptions['lynx-ui-slider']}
+{lynxUiIntros['lynx-ui-slider']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-slider/docs/README.zh.mdx
+++ b/packages/lynx-ui-slider/docs/README.zh.mdx
@@ -1,9 +1,10 @@
 import Introduction from '../../introDocs/lynx-ui-slider/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `<Slider>`
 
-一个滑块组件，用于选择 `[0, 1]` 范围内的值。
+{lynxUiIntrosZh['lynx-ui-slider']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-sortable/docs/README.mdx
+++ b/packages/lynx-ui-sortable/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-sortable/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `<Sortable>`
 
-{descriptions['lynx-ui-sortable']}
+{lynxUiIntros['lynx-ui-sortable']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-sortable/docs/README.zh.mdx
+++ b/packages/lynx-ui-sortable/docs/README.zh.mdx
@@ -1,9 +1,10 @@
 import Introduction from '../../introDocs/lynx-ui-sortable/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `<Sortable>`
 
-一个排序组件，基于 Draggable 组件实现。目前仅支持等高子项，并且子项之间不可有间距，如 margin。
+{lynxUiIntrosZh['lynx-ui-sortable']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-swipe-action/docs/README.mdx
+++ b/packages/lynx-ui-swipe-action/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-swipe-action/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `<SwipeAction>`
 
-{descriptions['lynx-ui-swipe-action']}
+{lynxUiIntros['lynx-ui-swipe-action']}
 
 - Key Composition:
 

--- a/packages/lynx-ui-swipe-action/docs/README.zh.mdx
+++ b/packages/lynx-ui-swipe-action/docs/README.zh.mdx
@@ -1,9 +1,10 @@
 import Introduction from '../../introDocs/lynx-ui-swipe-action/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `<SwipeAction>`
 
-一个基于触摸系统和 [MTS](https://lynxjs.org/api/lynx-api/main-thread.html) 实现的可滑动组件。 由 `displayArea` 和 `actionArea` 两部分组成。 可以用来实现左滑删除等功能。
+{lynxUiIntrosZh['lynx-ui-swipe-action']}
 
 :::info 环境要求
 LynxSDK 版本 >= 2.16

--- a/packages/lynx-ui-swiper/docs/README.mdx
+++ b/packages/lynx-ui-swiper/docs/README.mdx
@@ -1,4 +1,4 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import { UIApiTable, Columns } from '@lynx-ui/index';
 import { PageTabs, PageTab } from '@theme';
 import Introduction from '../../introDocs/lynx-ui-swiper/Introduction.mdx';
@@ -7,7 +7,7 @@ import APIReference from './APIReference.mdx';
 
 # `<Swiper>`
 
-{descriptions['lynx-ui-swiper']}
+{lynxUiIntros['lynx-ui-swiper']}
 
 :::info
 

--- a/packages/lynx-ui-swiper/docs/README.zh.mdx
+++ b/packages/lynx-ui-swiper/docs/README.zh.mdx
@@ -3,10 +3,11 @@ import { PageTabs, PageTab } from '@theme';
 import Introduction from '../../introDocs/lynx-ui-swiper/Introduction.zh.mdx';
 import Advanced from '../../introDocs/lynx-ui-swiper/advanced.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `<Swiper>`
 
-一个基于触摸系统和 [MTS](https://lynxjs.org/api/lynx-api/main-thread.html) 实现的高性能轮播组件, 提供手势响应，paging，loop，bounces等能力，同时提供高度的自定义能力。
+{lynxUiIntrosZh['lynx-ui-swiper']}
 
 :::info
 

--- a/packages/lynx-ui-switch/docs/README.mdx
+++ b/packages/lynx-ui-switch/docs/README.mdx
@@ -1,10 +1,10 @@
-import descriptions from '../../lynx-ui-intros';
+import { lynxUiIntros } from '../../lynx-ui-intros';
 import Introduction from '../../introDocs/lynx-ui-switch/Introduction.mdx';
 import APIReference from './APIReference.mdx';
 
 # `<Switch>`
 
-{descriptions['lynx-ui-switch']}
+{lynxUiIntros['lynx-ui-switch']}
 
 <Introduction />
 <APIReference />

--- a/packages/lynx-ui-switch/docs/README.zh.mdx
+++ b/packages/lynx-ui-switch/docs/README.zh.mdx
@@ -1,9 +1,10 @@
 import Introduction from '../../introDocs/lynx-ui-switch/Introduction.zh.mdx';
 import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 
 # `<Switch>`
 
-`<Switch>` 开关是一种简单的控件，用于切换设置的开启或关闭。
+{lynxUiIntrosZh['lynx-ui-switch']}
 
 <Introduction />
 <APIReference />


### PR DESCRIPTION
## Summary

- update English component docs to import named `lynxUiIntros`
- update Chinese component docs to import named `lynxUiIntrosZh`
- use the existing root `README_zh.md` files as the zh intro source in lynx-website
- avoid default intro imports so locale mismatches fail clearly

## Test

- `git diff --check`
- checked all component README.mdx imports use named locale maps
- tested from lynx-website by syncing this branch, regenerating intros, and running `pnpm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Update component documentation to import locale-specific intro exports

- Import `lynxUiIntros` named export in all English component README.mdx files instead of default `descriptions` import
- Import `lynxUiIntrosZh` named export in all Chinese component README.zh.mdx files instead of default `descriptions` import
- Update all intro content references to use the imported named exports (e.g., `lynxUiIntros['component-name']` and `lynxUiIntrosZh['component-name']`)
- Remove hardcoded component descriptions from Chinese documentation files in favor of centralized localized intro data
- Support explicit locale-specific imports for lynx-website integration

Affected components: Button, Checkbox, Dialog, Draggable, FeedList, Form, Input, LazyComponent, List, Overlay, Popover, RadioGroup, ScrollView, Sheet, Slider, Sortable, SwipeAction, Swiper, and Switch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->