### PR TITLE
feat(sheet): allow SheetHandle children

### DIFF
--- a/.changeset/sheet-handle-children.md
+++ b/.changeset/sheet-handle-children.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-sheet": patch
+---
+
+Allow `SheetHandle` to render children so consumers can make custom handle visuals the drag target.

--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,5 @@ lynx-examples
 
 apps/examples/scripts/packages/
 apps/examples/scripts/tmp
+
+.codex

--- a/packages/lynx-ui-sheet/SKILL.md
+++ b/packages/lynx-ui-sheet/SKILL.md
@@ -12,7 +12,7 @@ Use it when a UI needs a dismissible panel that slides from an edge of the viewp
 - **`SheetView`**: Renders the sheet subtree in the overlay layer and controls mount/unmount.
 - **`SheetBackdrop`**: Renders the scrim behind the sheet and optionally closes the sheet on tap.
 - **`SheetContent`**: Renders the moving sheet or drawer surface and receives consumer sizing/styling.
-- **`SheetHandle`**: Optional drag handle. Use it for bottom sheets when a visible handle is desired; horizontal drawers usually do not need it.
+- **`SheetHandle`**: Optional drag handle. It renders its `children`, so custom handle visuals can be placed directly inside the draggable target. Use it for bottom sheets when a visible handle is desired; horizontal drawers usually do not need it unless the design intentionally calls for a side grip.
 
 ## Side Rules
 
@@ -20,8 +20,8 @@ Use it when a UI needs a dismissible panel that slides from an edge of the viewp
 - Use `side="top"` for top sheets.
 - Use `side="left"` or `side="right"` for drawer-style panels that should stay on a physical edge.
 - Use `side="start"` or `side="end"` for drawer-style panels that should follow writing direction. These resolve to the physical edge from `enableRTL`.
-- In `top` and `bottom` mode, percentage snap points resolve against viewport height.
-- In horizontal modes (`left`, `right`, `start`, `end`), percentage snap points resolve against viewport width.
+- In `top` and `bottom` mode, percentage snap points resolve against the vertical main-axis basis: `screenHeight` when provided, otherwise viewport height.
+- In horizontal modes (`left`, `right`, `start`, `end`), percentage snap points resolve against the horizontal main-axis basis: `screenWidth` when provided, otherwise viewport width.
 - The `'fit'` snap point resolves to measured content height for `top` / `bottom`, and measured content width for horizontal modes.
 - `screenHeight` can override the height basis for `top` / `bottom`; `screenWidth` can override the width basis for horizontal modes.
 - Rubber-band over-drag defaults to enabled for `top` / `bottom` and disabled for horizontal modes. Use `rubberBand` to override the default.
@@ -41,6 +41,7 @@ Use it when a UI needs a dismissible panel that slides from an edge of the viewp
 - Use `innerClassName` / `innerStyle` for content layout, padding, and panel sizing.
 - For horizontal drawers, set the drawer width with `innerClassName` / `innerStyle` so `'fit'` can resolve from the measured drawer width.
 - Horizontal drawers should usually be full height and use inner padding for safe-area or visual breathing room.
+- Put custom handle visuals inside `SheetHandle` instead of layering a separate invisible hit target over a visual handle.
 - Do not add a bottom-sheet pill handle to horizontal drawer examples unless the design intentionally calls for a side grip.
 
 ## Verification
@@ -61,5 +62,5 @@ Examples:
 
 - "Create a start drawer using `SheetRoot side=\"start\" enableRTL`, controlled by a ref, with `snapPoints={['72%']}` and backdrop tap to close."
 - "Create a left drawer using `SheetRoot side=\"left\"` when the panel should stay on the physical left edge regardless of `enableRTL`."
-- "Create a bottom sheet with `snapPoints={['fit', '80%']}`, a handle, and an inner content layout using L.U.N.A tokens."
+- "Create a bottom sheet with `snapPoints={['fit', '80%']}`, a custom visual inside `SheetHandle`, and an inner content layout using L.U.N.A tokens."
 - "Convert a bottom sheet to an end drawer; keep visual surface styles on `SheetContent` and move drawer width plus inner padding to `innerClassName`."

--- a/packages/lynx-ui-sheet/src/SheetHandle/index.tsx
+++ b/packages/lynx-ui-sheet/src/SheetHandle/index.tsx
@@ -5,7 +5,7 @@ import { useSheetDragContext } from '../context'
 import type { SheetHandleProps } from '../types'
 
 export function SheetHandle(props: SheetHandleProps) {
-  const { className, style, ...rest } = props
+  const { className, style, children, ...rest } = props
   const { dragHandlers } = useSheetDragContext()
 
   return (
@@ -16,6 +16,8 @@ export function SheetHandle(props: SheetHandleProps) {
       main-thread:bindtouchstart={dragHandlers.handleTouchStartMT}
       main-thread:bindtouchmove={dragHandlers.handleTouchMoveMT}
       main-thread:bindtouchend={dragHandlers.handleTouchEndMT}
-    />
+    >
+      {children}
+    </view>
   )
 }

--- a/packages/lynx-ui-sheet/src/types/index.docs.ts
+++ b/packages/lynx-ui-sheet/src/types/index.docs.ts
@@ -327,7 +327,16 @@ export interface SheetRootProps extends ComponentBasicProps {
  * The handle of the Sheet.
  * @zh Sheet 的拖拽手柄。
  */
-export interface SheetHandleProps extends ComponentBasicProps {}
+export interface SheetHandleProps extends ComponentBasicProps {
+  /**
+   * children
+   * @zh 子元素
+   * @Android
+   * @iOS
+   * @Harmony
+   */
+  children?: ReactNode
+}
 
 /**
  * The view container of the Sheet. Can be `x-overlay-ng` or `view`.


### PR DESCRIPTION
Allow SheetHandle to render children so consumers can compose custom handle visuals directly on the draggable target.

Add a patch changeset for @lynx-js/lynx-ui-sheet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Allow SheetHandle to render children for custom handle visuals

Allow `SheetHandle` to accept and render `children` as custom handle visuals within the draggable target. This enables consumers to compose custom handle content directly on the drag-interactive element.

### Changes

- Add optional `children?: ReactNode` property to `SheetHandleProps` type definition in `@lynx-js/lynx-ui-sheet`
- Update `SheetHandle` component to destructure and render `children` inside the root view element
- Document patch version change in changeset for `@lynx-js/lynx-ui-sheet`

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-ui/pull/175)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->