### PR TITLE
feat(slider): publish slider primitives

### DIFF
--- a/.changeset/public-slider-release.md
+++ b/.changeset/public-slider-release.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/lynx-ui": patch
+"@lynx-js/lynx-ui-slider": patch
+"@lynx-example/lynx-ui-slider": patch
+---
+
+Publish `@lynx-js/lynx-ui-slider` and expose its primitives from the aggregate `@lynx-js/lynx-ui` entry.

--- a/apps/examples/Slider/Basic/index.tsx
+++ b/apps/examples/Slider/Basic/index.tsx
@@ -9,7 +9,7 @@ import {
   SliderRoot,
   SliderThumb,
   SliderTrack,
-} from '@lynx-js/lynx-ui-slider'
+} from '@lynx-js/lynx-ui'
 
 import './index.css'
 

--- a/apps/examples/Slider/CHANGELOG.md
+++ b/apps/examples/Slider/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lynx-example/lynx-ui-slider
+
+## 0.0.6
+
+### Patch Changes
+
+- Initial public release.

--- a/apps/examples/Slider/Controlled/index.tsx
+++ b/apps/examples/Slider/Controlled/index.tsx
@@ -9,7 +9,7 @@ import {
   SliderRoot,
   SliderThumb,
   SliderTrack,
-} from '@lynx-js/lynx-ui-slider'
+} from '@lynx-js/lynx-ui'
 
 import './index.css'
 

--- a/apps/examples/Slider/DynamicWidth/index.tsx
+++ b/apps/examples/Slider/DynamicWidth/index.tsx
@@ -9,7 +9,7 @@ import {
   SliderRoot,
   SliderThumb,
   SliderTrack,
-} from '@lynx-js/lynx-ui-slider'
+} from '@lynx-js/lynx-ui'
 
 import './index.css'
 

--- a/apps/examples/Slider/Facade/index.tsx
+++ b/apps/examples/Slider/Facade/index.tsx
@@ -10,8 +10,8 @@ import {
   SliderRoot,
   SliderThumb,
   SliderTrack,
-} from '@lynx-js/lynx-ui-slider'
-import type { SliderRef, SliderRootProps } from '@lynx-js/lynx-ui-slider'
+} from '@lynx-js/lynx-ui'
+import type { SliderRef, SliderRootProps } from '@lynx-js/lynx-ui'
 
 import './index.css'
 

--- a/apps/examples/Slider/LICENSE
+++ b/apps/examples/Slider/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/examples/Slider/Progress/index.tsx
+++ b/apps/examples/Slider/Progress/index.tsx
@@ -4,11 +4,7 @@
 
 import { root, useEffect, useRef, useState } from '@lynx-js/react'
 
-import {
-  SliderIndicator,
-  SliderRoot,
-  SliderTrack,
-} from '@lynx-js/lynx-ui-slider'
+import { SliderIndicator, SliderRoot, SliderTrack } from '@lynx-js/lynx-ui'
 
 import './index.css'
 

--- a/apps/examples/Slider/Shapes/index.tsx
+++ b/apps/examples/Slider/Shapes/index.tsx
@@ -9,7 +9,7 @@ import {
   SliderRoot,
   SliderThumb,
   SliderTrack,
-} from '@lynx-js/lynx-ui-slider'
+} from '@lynx-js/lynx-ui'
 
 import './index.css'
 

--- a/apps/examples/Slider/WithScrollView/index.tsx
+++ b/apps/examples/Slider/WithScrollView/index.tsx
@@ -9,7 +9,7 @@ import {
   SliderRoot,
   SliderThumb,
   SliderTrack,
-} from '@lynx-js/lynx-ui-slider'
+} from '@lynx-js/lynx-ui'
 
 import './index.css'
 

--- a/apps/examples/Slider/package.json
+++ b/apps/examples/Slider/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@lynx-example/lynx-ui-slider",
-  "version": "0.0.1",
-  "private": true,
+  "version": "0.0.6",
   "description": "Example app demonstrating Slider usage in lynx-ui",
   "homepage": "https://github.com/lynx-family/lynx-ui/tree/main/apps/examples/Slider#readme",
   "repository": {
@@ -14,6 +13,15 @@
     "name": "The Lynx Authors"
   },
   "type": "module",
+  "files": [
+    "LICENSE",
+    "CHANGELOG.md",
+    "dist/",
+    "**/*.tsx",
+    "**/*.ts",
+    "**/*.css",
+    "lynx.config.mjs"
+  ],
   "scripts": {
     "build": "rspeedy build",
     "build:dev": "rspeedy build --mode=development",
@@ -22,7 +30,7 @@
   },
   "dependencies": {
     "@lynx-js/luna-styles": "workspace:*",
-    "@lynx-js/lynx-ui-slider": "workspace:*",
+    "@lynx-js/lynx-ui": "workspace:*",
     "@lynx-js/react": "catalog:"
   },
   "devDependencies": {

--- a/packages/lynx-ui-slider/CHANGELOG.md
+++ b/packages/lynx-ui-slider/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @lynx-js/lynx-ui-slider
 
-## 3.130.1
+## 3.132.0
 
 - Introduced primitives-first slider components:
   - `SliderRoot`

--- a/packages/lynx-ui-slider/README.md
+++ b/packages/lynx-ui-slider/README.md
@@ -4,18 +4,24 @@ A primitives-first slider component package for lynx-ui.
 
 ## Installation
 
+We strongly recommend installing and using this component through the main `@lynx-js/lynx-ui` package:
+
 ```bash
 # pnpm (recommended)
-pnpm add @lynx-js/lynx-ui-slider
+pnpm add @lynx-js/lynx-ui
 
 # npm
-npm install @lynx-js/lynx-ui-slider
+npm install @lynx-js/lynx-ui
 
 # yarn
-yarn add @lynx-js/lynx-ui-slider
+yarn add @lynx-js/lynx-ui
 ```
 
+_(If necessary, you can still install the standalone package via `pnpm add @lynx-js/lynx-ui-slider`)_
+
 ## Usage
+
+[View Full Examples](https://github.com/lynx-family/lynx-ui/tree/main/apps/examples/Slider)
 
 ### Primitive Composition
 
@@ -25,7 +31,7 @@ import {
   SliderTrack,
   SliderIndicator,
   SliderThumb,
-} from '@lynx-js/lynx-ui-slider'
+} from '@lynx-js/lynx-ui'
 
 export function SliderPrimitiveDemo() {
   return (
@@ -66,6 +72,10 @@ export function SliderPrimitiveDemo() {
 Styling for track/thumb size and colors is expected to be done through `className` or inline `style`, instead of dedicated style props.
 
 `SliderIndicator` and `SliderThumb` are siblings inside `SliderTrack`, so the filled region stays purely visual while the thumb position is driven directly by value.
+
+## About @lynx-js/lynx-ui
+
+This component is part of `@lynx-js/lynx-ui`, a headless UI library officially maintained by the Lynx team, provided as a reference for building flexible, universal, and high-performance ReactLynx components.
 
 ## License
 

--- a/packages/lynx-ui-slider/README_zh.md
+++ b/packages/lynx-ui-slider/README_zh.md
@@ -4,7 +4,7 @@
 
 ## 安装
 
-强烈建议通过主包 `@lynx-js/lynx-ui` 安装并使用该包：
+建议通过主包 `@lynx-js/lynx-ui` 安装并使用该包：
 
 ```bash
 # pnpm（推荐）
@@ -26,9 +26,14 @@ _（如有需要，也可以通过 `pnpm add @lynx-js/lynx-ui-slider` 单独安�
 ## 组件结构
 
 ```tsx
-<Slider>
-  {/* Your content */}
-</Slider>
+<SliderRoot>
+  <SliderTrack>
+    <SliderIndicator />
+    <SliderThumb>
+      <view />
+    </SliderThumb>
+  </SliderTrack>
+</SliderRoot>
 ```
 
 ## 关于 @lynx-js/lynx-ui

--- a/packages/lynx-ui-slider/SKILL.md
+++ b/packages/lynx-ui-slider/SKILL.md
@@ -11,7 +11,7 @@
 - **RTL Support**: Set `enableRTL` to make the indicator and thumb resolve right-to-left.
 - **Stepping**: Set `step` to snap values to discrete increments.
 - **Disabled Mode**: Set `disabled` to prevent dragging while still displaying the current value.
-- **Interaction Callbacks**: `onDragging(value)` when dragging starts, `onValueChange(value, source)` for slider-driven updates, `onValueCommit(value)` at drag end.
+- **Interaction Callbacks**: `onDragging(value)` when dragging state changes, `onValueChange(value, source)` for slider-driven updates, `onValueCommit(value)` at drag end.
 - **Headless Styling**: Supports styling via `className` and `style` props on every primitive.
 
 ## 2. AI Coding Guide
@@ -24,7 +24,7 @@ import {
   SliderTrack,
   SliderIndicator,
   SliderThumb,
-} from '@lynx-js/lynx-ui-slider'
+} from '@lynx-js/lynx-ui'
 
 function BasicSlider() {
   return (
@@ -52,7 +52,7 @@ import {
   SliderTrack,
   SliderIndicator,
   SliderThumb,
-} from '@lynx-js/lynx-ui-slider'
+} from '@lynx-js/lynx-ui'
 
 function ControlledSlider() {
   const [value, setValue] = useState(0.5)
@@ -109,8 +109,8 @@ function ControlledSlider() {
 | `step`          | `number`                          | —       | Snap interval in `[0, 1]`.                                                          |
 | `disabled`      | `boolean`                         | `false` | Prevent interaction while keeping the slider value visible.                         |
 | `enableRTL`     | `boolean`                         | `false` | Reverse range direction (right-to-left).                                            |
-| `onDragging`    | `(value: number) => void`         | —       | Fires once when the interaction enters dragging state.                              |
-| `onValueChange` | `(value: number, source) => void` | —       | Fires for drag updates and `updateValue` calls. Source is `'drag'` or `'external'`. |
+| `onDragging`    | `(value: number) => void`         | —       | Fires when dragging starts and when dragging ends.                                  |
+| `onValueChange` | `(value: number, source) => void` | —       | Fires after drag updates and `updateValue` calls. Source is `'drag'` or `'external'`. |
 | `onValueCommit` | `(value: number) => void`         | —       | Fires at drag end with final value.                                                 |
 
 ### SliderRef (uncontrolled only)
@@ -128,7 +128,7 @@ A: Use controlled (`value` + `onValueChange`) when you need to sync slider state
 
 **Q: What is the difference between `onDragging`, `onValueChange`, and `onValueCommit`?**
 
-A: `onDragging` fires once when dragging starts. `onValueChange` fires for slider-driven value updates during drag and imperative `updateValue` calls. `onValueCommit` fires once at drag end — useful for persisting the final value.
+A: `onDragging` fires when dragging starts and when dragging ends. `onValueChange` fires after slider-driven value updates during drag and imperative `updateValue` calls. `onValueCommit` fires once at drag end — useful for persisting the final value.
 
 **Q: How do I prevent user interaction while still showing the value?**
 
@@ -136,7 +136,7 @@ A: Set `disabled` on `SliderRoot`. The slider will display the current value but
 
 **Q: What happens if I call `updateValue` / `getValue` in controlled mode?**
 
-A: They will throw an error. In controlled mode, update the `value` prop directly instead.
+A: They will throw an error. In controlled mode, update external state through `onValueChange` so the `value` prop stays in sync with the rendered value.
 
 **Q: Can I set value outside `[0, 1]`?**
 

--- a/packages/lynx-ui-slider/docs/APIReference.mdx
+++ b/packages/lynx-ui-slider/docs/APIReference.mdx
@@ -1,188 +1,11 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
 
-  
-## SliderTrackProps
-    
-  
-<UIApiTable source={[
-  {
-    "name": "children",
-    "type": "ReactNode",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "Usually includes "
-      },
-      {
-        "kind": "code",
-        "text": "`SliderIndicator`"
-      },
-      {
-        "kind": "text",
-        "text": " and optional "
-      },
-      {
-        "kind": "code",
-        "text": "`SliderThumb`"
-      },
-      {
-        "kind": "text",
-        "text": "."
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "通常包含 "
-      },
-      {
-        "kind": "code",
-        "text": "`SliderIndicator`"
-      },
-      {
-        "kind": "text",
-        "text": " 以及可选的 "
-      },
-      {
-        "kind": "code",
-        "text": "`SliderThumb`"
-      },
-      {
-        "kind": "text",
-        "text": "。"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": true,
-    "isSupportIOS": false,
-    "isSupportAndroid": false,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
-  },
-  {
-    "name": "className",
-    "type": "string",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "className"
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "类名"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": true,
-    "isSupportIOS": true,
-    "isSupportAndroid": true,
-    "isSupportHarmony": true,
-    "docTypeFallback": null
-  },
-  {
-    "name": "style",
-    "type": "CSSProperties",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "style"
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "样式"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": true,
-    "isSupportIOS": true,
-    "isSupportAndroid": true,
-    "isSupportHarmony": true,
-    "docTypeFallback": null
-  }
-]}/>
-      
+### SliderRoot
+    Root primitive props.
 
-### SliderThumbProps
-
-
-<UIApiTable source={[
-  {
-    "name": "children",
-    "type": "ReactNode",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "Custom thumb content."
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "自定义拇指内容。"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": true,
-    "isSupportIOS": false,
-    "isSupportAndroid": false,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
-  },
-  {
-    "name": "className",
-    "type": "string",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "className"
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "类名"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": true,
-    "isSupportIOS": true,
-    "isSupportAndroid": true,
-    "isSupportHarmony": true,
-    "docTypeFallback": null
-  },
-  {
-    "name": "style",
-    "type": "CSSProperties",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "style"
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "样式"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": true,
-    "isSupportIOS": true,
-    "isSupportAndroid": true,
-    "isSupportHarmony": true,
-    "docTypeFallback": null
-  }
-]}/>
-    
-      
-
-### SliderRootProps
-
+`SliderRoot` owns interaction logic (dragging and value tracking)
+and provides context for child primitives.
 
 <UIApiTable source={[
   {
@@ -365,13 +188,13 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "summary": [
       {
         "kind": "text",
-        "text": "Triggered once when an interaction enters dragging state, with the current progress value."
+        "text": "Triggered when dragging state changes, with the current progress value. The callback fires when dragging starts and when dragging ends."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "交互进入拖拽态时触发一次，传入当前进度值。"
+        "text": "拖拽状态变化时触发，传入当前进度值。开始拖拽和结束拖拽时都会触发。"
       }
     ],
     "defaultValue": "",
@@ -387,7 +210,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "summary": [
       {
         "kind": "text",
-        "text": "Triggered for slider-driven value updates, including dragging and "
+        "text": "Triggered after slider-driven value updates, including dragging and "
       },
       {
         "kind": "code",
@@ -395,7 +218,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
       },
       {
         "kind": "text",
-        "text": ". In controlled mode, the slider does **not** update its internal value automatically; use this callback to update the controlled "
+        "text": ". In controlled mode, use this callback to keep the external "
       },
       {
         "kind": "code",
@@ -403,13 +226,13 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
       },
       {
         "kind": "text",
-        "text": " prop."
+        "text": " prop in sync with the rendered value."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "由滑块自身驱动的值更新时触发，包括拖拽和 "
+        "text": "由滑块自身驱动的值更新后触发，包括拖拽和 "
       },
       {
         "kind": "code",
@@ -417,7 +240,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
       },
       {
         "kind": "text",
-        "text": "。在受控模式下，滑块不会自动更新内部值，需要通过此回调更新外部的 "
+        "text": "。在受控模式下，请通过此回调让外部 "
       },
       {
         "kind": "code",
@@ -425,7 +248,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
       },
       {
         "kind": "text",
-        "text": " 属性。"
+        "text": " 属性与渲染值保持同步。"
       }
     ],
     "defaultValue": "",
@@ -588,11 +411,119 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "docTypeFallback": null
   }
 ]}/>
-    
-      
 
-### SliderIndicatorProps
 
+### SliderTrack
+    Track primitive props.
+
+`SliderTrack` establishes the measurement/layout coordinate space and renders the base rail.
+
+<UIApiTable source={[
+  {
+    "name": "children",
+    "type": "ReactNode",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Usually includes "
+      },
+      {
+        "kind": "code",
+        "text": "`SliderIndicator`"
+      },
+      {
+        "kind": "text",
+        "text": " and optional "
+      },
+      {
+        "kind": "code",
+        "text": "`SliderThumb`"
+      },
+      {
+        "kind": "text",
+        "text": "."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "通常包含 "
+      },
+      {
+        "kind": "code",
+        "text": "`SliderIndicator`"
+      },
+      {
+        "kind": "text",
+        "text": " 以及可选的 "
+      },
+      {
+        "kind": "code",
+        "text": "`SliderThumb`"
+      },
+      {
+        "kind": "text",
+        "text": "。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "className",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "className"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "类名"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "style",
+    "type": "CSSProperties",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "style"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "样式"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  }
+]}/>
+
+
+### SliderIndicator
+    Indicator primitive props.
+
+`SliderIndicator` is a pure visual layer whose width is controlled by root value.
 
 <UIApiTable source={[
   {
@@ -640,130 +571,27 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "docTypeFallback": null
   }
 ]}/>
-    
-      
 
-### SliderUpdateValueOptions
 
+### SliderThumb
+    Thumb primitive props.
+
+`SliderThumb` is positioned by the current ratio inside `SliderTrack` and does not own interaction logic.
 
 <UIApiTable source={[
   {
-    "name": "force",
-    "type": "boolean",
+    "name": "children",
+    "type": "ReactNode",
     "summary": [
       {
         "kind": "text",
-        "text": "Bypass drag-time guard and force update even while dragging."
+        "text": "Custom thumb content."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "跳过拖拽保护，在拖拽过程中也强制更新。"
-      }
-    ],
-    "defaultValue": "false",
-    "isOption": true,
-    "isSupportIOS": false,
-    "isSupportAndroid": false,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
-  },
-  {
-    "name": "source",
-    "type": "SliderValueChangeSource",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "Mark the update source for analytics/logic branching."
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "标记更新来源，用于分析或逻辑分支。"
-      }
-    ],
-    "defaultValue": "'external'",
-    "isOption": true,
-    "isSupportIOS": false,
-    "isSupportAndroid": false,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
-  }
-]}/>
-    
-      
-
-## SliderRef
-<UIApiTable source={[
-  {
-    "name": "getValue",
-    "type": "() => number",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "Read current slider value in range "
-      },
-      {
-        "kind": "code",
-        "text": "`[0, 1]`"
-      },
-      {
-        "kind": "text",
-        "text": "."
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "读取当前滑块值，取值范围 "
-      },
-      {
-        "kind": "code",
-        "text": "`[0, 1]`"
-      },
-      {
-        "kind": "text",
-        "text": "。"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": false,
-    "isSupportIOS": false,
-    "isSupportAndroid": false,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
-  },
-  {
-    "name": "updateValue",
-    "type": "(value: number, options: {force?: boolean, source?: SliderValueChangeSource}) => void",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "Imperatively set slider value in range "
-      },
-      {
-        "kind": "code",
-        "text": "`[0, 1]`"
-      },
-      {
-        "kind": "text",
-        "text": "."
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "命令式地设置滑块值，取值范围 "
-      },
-      {
-        "kind": "code",
-        "text": "`[0, 1]`"
-      },
-      {
-        "kind": "text",
-        "text": "。"
+        "text": "自定义拇指内容。"
       }
     ],
     "defaultValue": "",
@@ -772,7 +600,49 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "isSupportAndroid": false,
     "isSupportHarmony": false,
     "docTypeFallback": null
+  },
+  {
+    "name": "className",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "className"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "类名"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "style",
+    "type": "CSSProperties",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "style"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "样式"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
   }
 ]}/>
-  
-  

--- a/packages/lynx-ui-slider/package.json
+++ b/packages/lynx-ui-slider/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@lynx-js/lynx-ui-slider",
-  "version": "0.0.1",
-  "private": true,
+  "version": "3.132.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-ui.git",

--- a/packages/lynx-ui-slider/src/types/index.docs.ts
+++ b/packages/lynx-ui-slider/src/types/index.docs.ts
@@ -98,13 +98,13 @@ export interface SliderRootProps extends ComponentBasicProps {
    */
   enableRTL?: boolean
   /**
-   * Triggered once when an interaction enters dragging state, with the current progress value.
-   * @zh 交互进入拖拽态时触发一次，传入当前进度值。
+   * Triggered when dragging state changes, with the current progress value. The callback fires when dragging starts and when dragging ends.
+   * @zh 拖拽状态变化时触发，传入当前进度值。开始拖拽和结束拖拽时都会触发。
    */
   onDragging?: (value: number) => void
   /**
-   * Triggered for slider-driven value updates, including dragging and `SliderRef.updateValue`. In controlled mode, the slider does **not** update its internal value automatically; use this callback to update the controlled `value` prop.
-   * @zh 由滑块自身驱动的值更新时触发，包括拖拽和 `SliderRef.updateValue`。在受控模式下，滑块不会自动更新内部值，需要通过此回调更新外部的 `value` 属性。
+   * Triggered after slider-driven value updates, including dragging and `SliderRef.updateValue`. In controlled mode, use this callback to keep the external `value` prop in sync with the rendered value.
+   * @zh 由滑块自身驱动的值更新后触发，包括拖拽和 `SliderRef.updateValue`。在受控模式下，请通过此回调让外部 `value` 属性与渲染值保持同步。
    */
   onValueChange?: (value: number, source: SliderValueChangeSource) => void
   /**

--- a/packages/lynx-ui/package.json
+++ b/packages/lynx-ui/package.json
@@ -45,6 +45,7 @@
     "@lynx-js/lynx-ui-radio-group": "workspace:*",
     "@lynx-js/lynx-ui-scroll-view": "workspace:*",
     "@lynx-js/lynx-ui-sheet": "workspace:*",
+    "@lynx-js/lynx-ui-slider": "workspace:*",
     "@lynx-js/lynx-ui-sortable": "workspace:*",
     "@lynx-js/lynx-ui-swipe-action": "workspace:*",
     "@lynx-js/lynx-ui-swiper": "workspace:*",

--- a/packages/lynx-ui/src/index.tsx
+++ b/packages/lynx-ui/src/index.tsx
@@ -259,6 +259,23 @@ export type {
   SheetTransition,
 } from '@lynx-js/lynx-ui-sheet'
 
+// slider
+export {
+  SliderRoot,
+  SliderTrack,
+  SliderIndicator,
+  SliderThumb,
+} from '@lynx-js/lynx-ui-slider'
+export type {
+  SliderIndicatorProps,
+  SliderRef,
+  SliderRootProps,
+  SliderThumbProps,
+  SliderTrackProps,
+  SliderUpdateValueOptions,
+  SliderValueChangeSource,
+} from '@lynx-js/lynx-ui-slider'
+
 // only presence types are exported
 export type {
   PresenceAnimationStatus,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,9 +562,9 @@ importers:
       '@lynx-js/luna-styles':
         specifier: workspace:*
         version: link:../../../luna/packages/luna-styles
-      '@lynx-js/lynx-ui-slider':
+      '@lynx-js/lynx-ui':
         specifier: workspace:*
-        version: link:../../../packages/lynx-ui-slider
+        version: link:../../../packages/lynx-ui
       '@lynx-js/react':
         specifier: 'catalog:'
         version: 0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
@@ -809,6 +809,9 @@ importers:
       '@lynx-js/lynx-ui-sheet':
         specifier: workspace:*
         version: link:../lynx-ui-sheet
+      '@lynx-js/lynx-ui-slider':
+        specifier: workspace:*
+        version: link:../lynx-ui-slider
       '@lynx-js/lynx-ui-sortable':
         specifier: workspace:*
         version: link:../lynx-ui-sortable

--- a/tools/typedoc/index.ts
+++ b/tools/typedoc/index.ts
@@ -68,6 +68,12 @@ const primitivesConfig: Record<string, string[]> = {
     'Checkbox',
     'CheckboxIndicator',
   ],
+  'lynx-ui-slider': [
+    'SliderRoot',
+    'SliderTrack',
+    'SliderIndicator',
+    'SliderThumb',
+  ],
 }
 export async function runTypeDocForPackage(
   entryPoints: string | string[],


### PR DESCRIPTION
## Summary

- publish `@lynx-js/lynx-ui-slider` and expose its primitives from `@lynx-js/lynx-ui`
- switch Slider examples to import from the aggregate package and add publish metadata
- regenerate Slider API docs and add the release changeset

## Validation

- `pnpm check:exports`
- `pnpm turbo build`
- `pnpm check:all`
- `pnpm examples:publish -- --dry-run --filter Slider`
- `pnpm changeset status`
- `git diff --check`

## Notes

- Left `tools/typedoc/tpl.ts` uncommitted as requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add `@lynx-js/lynx-ui-slider` to `@lynx-js/lynx-ui` dependencies
- Re-export Slider primitives (`SliderRoot`, `SliderTrack`, `SliderIndicator`, `SliderThumb`) and related types from `@lynx-js/lynx-ui`
- Update Slider example imports to use `@lynx-js/lynx-ui` instead of `@lynx-js/lynx-ui-slider`
- Prepare Slider example package for publication with metadata and licensing
- Regenerate Slider API reference documentation with primitives-first content
- Update Slider documentation (README, SKILL guide, and JSDoc) with new import paths and clarified callback semantics
- Configure TypeDoc to treat `lynx-ui-slider` as a primitive package
- Add release changeset for version bumps across slider and example packages

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-ui/pull/176)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->