### PR TITLE
fix: add default z-index: 0 to scroll-view element

### DIFF
--- a/.changeset/green-kings-appear.md
+++ b/.changeset/green-kings-appear.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/lynx-ui-scroll-view': patch
+---
+
+Add a default `z-index: 0` to the underlying `scroll-view` element.

--- a/apps/examples/ScrollView/ZIndex/index.css
+++ b/apps/examples/ScrollView/ZIndex/index.css
@@ -1,0 +1,78 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.demo-container {
+  width: 100%;
+  height: 100%;
+  padding-top: 48px;
+  padding-bottom: 24px;
+  background-color: var(--canvas-ambient);
+}
+
+.scroll-view {
+  width: 100%;
+  height: 520px;
+}
+
+.scroll-view-content {
+  width: 100%;
+  height: 920px;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-bottom: 32px;
+  box-sizing: border-box;
+}
+
+.layer-card {
+  position: relative;
+  width: 100%;
+  height: 196px;
+  margin-top: -28px;
+  padding-top: 56px;
+  padding-left: 20px;
+  padding-right: 20px;
+  border-radius: 20px;
+  background-color: var(--canvas);
+  border-width: 1px;
+  border-color: var(--line);
+}
+
+.layer-card:first-child {
+  margin-top: 0;
+}
+
+.layer-card--raised {
+  z-index: 2;
+}
+
+.layer-card__badge {
+  position: absolute;
+  top: -18px;
+  right: 20px;
+  z-index: 1;
+  padding: 10px 14px;
+  border-radius: 999px;
+  background-color: var(--neutral);
+}
+
+.layer-card__badge--raised {
+  z-index: 3;
+  background-color: var(--fill-primary);
+}
+
+.layer-card__badge-text {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--content-inverse);
+}
+
+.layer-card__title {
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--content);
+}
+
+.layer-card__subtitle {
+  margin-top: 10px;
+  font-size: 14px;
+  color: var(--content-subtle);
+}

--- a/apps/examples/ScrollView/ZIndex/index.tsx
+++ b/apps/examples/ScrollView/ZIndex/index.tsx
@@ -1,0 +1,51 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root } from '@lynx-js/react'
+
+import { ScrollView } from '@lynx-js/lynx-ui'
+
+import './index.css'
+
+const CARDS = [
+  { key: 'card-1', title: 'Base Layer', badge: 'z-index: 1' },
+  { key: 'card-2', title: 'Raised Layer', badge: 'z-index: 3' },
+  { key: 'card-3', title: 'Normal Layer', badge: 'z-index: 1' },
+  { key: 'card-4', title: 'Content Layer', badge: 'z-index: 1' },
+]
+
+function App() {
+  return (
+    <view className='demo-container lunaris-dark'>
+      <ScrollView className='scroll-view'>
+        <view className='scroll-view-content'>
+          {CARDS.map((card, index) => (
+            <view
+              className={`layer-card ${
+                index === 1 ? 'layer-card--raised' : ''
+              }`}
+              key={card.key}
+            >
+              <view
+                className={`layer-card__badge ${
+                  index === 1 ? 'layer-card__badge--raised' : ''
+                }`}
+              >
+                <text className='layer-card__badge-text'>{card.badge}</text>
+              </view>
+              <text className='layer-card__title'>{card.title}</text>
+              <text className='layer-card__subtitle'>
+                Scroll the list and check the overlapping badge.
+              </text>
+            </view>
+          ))}
+        </view>
+      </ScrollView>
+    </view>
+  )
+}
+
+root.render(<App />)
+
+export default App

--- a/apps/examples/ScrollView/lynx.config.mjs
+++ b/apps/examples/ScrollView/lynx.config.mjs
@@ -9,6 +9,7 @@ const defaultConfig = exampleConfig({
   ScrollViewHorizontal: './Horizontal/index.tsx',
   ScrollViewHorizontalRTL: './HorizontalRTL/index.tsx',
   ScrollViewInnerFlex: './InnerFlex/index.tsx',
+  ScrollViewZIndex: './ZIndex/index.tsx',
 }, { needWeb: false })
 
 export default defaultConfig

--- a/packages/lynx-ui-scroll-view/SKILL.md
+++ b/packages/lynx-ui-scroll-view/SKILL.md
@@ -39,6 +39,8 @@ function BasicScrollView() {
 
 When you need `flex` layout, add a wrapper as the first child of `ScrollView`, and apply `flex` styles on that wrapper:
 
+Also make sure the direct child of `ScrollView` is larger than the `ScrollView` viewport on the scrolling axis. Otherwise, the content does not overflow and the `ScrollView` will not scroll.
+
 ```tsx
 import { ScrollView } from '@lynx-js/lynx-ui'
 
@@ -142,7 +144,7 @@ function LoadMoreScrollView() {
 
 **Q: Why can't my `ScrollView` scroll?**
 
-A: `ScrollView` needs a determined boundary. Set a fixed size (e.g., `height: '300px'`) or place it in a flex container and use `flex: 1`.
+A: `ScrollView` needs a determined boundary. Set a fixed size (e.g., `height: '300px'`) or place it in a flex container and use `flex: 1`. Also ensure the direct child of `ScrollView` is larger than the viewport on the scrolling axis. For example, a vertical `ScrollView` with `height: '300px'` needs a direct child taller than `300px`; otherwise it will not scroll.
 
 **Q: `ScrollView` inside `Popup` causes drag conflicts?**
 

--- a/packages/lynx-ui-scroll-view/src/index.tsx
+++ b/packages/lynx-ui-scroll-view/src/index.tsx
@@ -106,6 +106,10 @@ function ScrollViewImpl(
     props,
     scrollViewRegisteredEvents.current,
   )
+  const normalizedStyle: CSSProperties = {
+    zIndex: 0,
+    ...style,
+  }
 
   const isHorizontal = () => {
     return scrollOrientation ? scrollOrientation === 'horizontal' : horizontal
@@ -210,7 +214,7 @@ function ScrollViewImpl(
       : shouldEnableNested(),
     'enable-new-nested': true,
     'className': className,
-    'style': style,
+    'style': normalizedStyle,
     'bounces': platformBounces,
     'enable-scroll': enableScroll,
     ...(androidTouchSlop !== undefined


### PR DESCRIPTION
- add default z-index: 0 to the underlying scroll-view element
- add a new ZIndex demo example to demonstrate stacking context handling
- update SKILL.md to add note about scroll view child size requirement
- add changeset for the scroll-view patch release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Add default z-index: 0 to scroll-view and introduce ZIndex example

- Set `z-index: 0` as default on the underlying `scroll-view` element to establish stacking context
- Add ZIndex example demonstrating scroll-view layering behavior with card components and raised layer variants
- Register new ZIndex example in ScrollView example configuration
- Update SKILL.md documentation to clarify that scroll-view children must exceed viewport size on the scrolling axis
- Add changeset for scroll-view patch release documenting the z-index change

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-ui/pull/179)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->