### PR TITLE
feat: add onWheel event support for PC

### DIFF
--- a/.changeset/sixty-hounds-shop.md
+++ b/.changeset/sixty-hounds-shop.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/lynx-ui-scroll-view": minor
+"@lynx-js/lynx-ui-list": minor
+---
+
+Support onWheel events on ScrollView and List for PC

--- a/.cspell/lynx.txt
+++ b/.cspell/lynx.txt
@@ -39,6 +39,7 @@ binduiappear
 binduidisappear
 bindupdate
 bindwillchange
+bindwheel
 bounceable
 catchlongpress
 catchtap

--- a/packages/lynx-ui-list/src/index.tsx
+++ b/packages/lynx-ui-list/src/index.tsx
@@ -34,6 +34,7 @@ export const ListEventMapping: Record<string, string> = {
   onLayoutComplete: 'bindlayoutcomplete',
   onScrollStateChange: 'bindscrollstatechange',
   onSnapToItem: 'bindsnap',
+  onWheel: 'bindwheel',
 }
 
 enum DEBUG_LEVEL {

--- a/packages/lynx-ui-list/src/types/index.docs.ts
+++ b/packages/lynx-ui-list/src/types/index.docs.ts
@@ -13,7 +13,11 @@ import type {
   BaseUITouchEvents,
   ComponentBasicProps,
 } from '@lynx-js/lynx-ui-common'
-import type { ListScrollStateChangeEvent, ListSnapEvent } from '@lynx-js/types'
+import type {
+  CommonEvent,
+  ListScrollStateChangeEvent,
+  ListSnapEvent,
+} from '@lynx-js/types'
 
 export type List = (props: ListProps) => ReactElement
 
@@ -559,6 +563,14 @@ export interface ListProps
    * @eventProperty
    */
   onSnapToItem?: (e: ListSnapEvent) => void
+  /**
+   * Send when a wheel event is triggered on the list.
+   * @zh 当列表触发滚轮事件时发送。
+   * @eventProperty
+   * @PC
+   * @Web
+   */
+  onWheel?: (e: CommonEvent) => void
   /**
    * exposure-scene for global exposure
    * @zh 全局曝光的曝光场景

--- a/packages/lynx-ui-scroll-view/src/index.tsx
+++ b/packages/lynx-ui-scroll-view/src/index.tsx
@@ -39,6 +39,7 @@ export const ScrollView = memo(forwardRef(ScrollViewImpl)) as ScrollViewType
 
 const ScrollViewEventMapping: Record<string, string> = {
   onContentSizeChange: 'bindcontentsizechanged',
+  onWheel: 'bindwheel',
 }
 
 /**

--- a/packages/lynx-ui-scroll-view/src/types/index.docs.ts
+++ b/packages/lynx-ui-scroll-view/src/types/index.docs.ts
@@ -14,7 +14,7 @@ import type {
   ComponentBasicProps,
   LazyOptions,
 } from '@lynx-js/lynx-ui-common'
-import type { CSSProperties } from '@lynx-js/types'
+import type { CSSProperties, CommonEvent } from '@lynx-js/types'
 
 export type ScrollView = (props: ScrollViewProps) => ReactElement
 
@@ -286,6 +286,14 @@ export interface ScrollViewProps
   onContentSizeChange?: (res: {
     detail: { scrollWidth: number, scrollHeight: number }
   }) => void
+  /**
+   * Send when a wheel event is triggered on the scroll-view.
+   * @zh 当 scroll-view 触发滚轮事件时发送。
+   * @eventProperty
+   * @PC
+   * @Web
+   */
+  onWheel?: (e: CommonEvent) => void
 }
 
 export interface scrollToBouncesInfo {


### PR DESCRIPTION
Add bindwheel event mapping and type definitions for ScrollView and List components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Add onWheel event support for ScrollView and List components

Add onWheel (wheel) event handling capability to ScrollView and List components on PC platforms by:

- Map `onWheel` to the `bindwheel` binding name in `ListEventMapping` and `ScrollViewEventMapping`
- Add `onWheel?: (e: CommonEvent) => void` event handler prop to `ListProps` type definition
- Add `onWheel?: (e: CommonEvent) => void` event handler prop to `ScrollViewProps` type definition
- Update type imports to include `CommonEvent` from `@lynx-js/types` in both component type definition files
- Include `bindwheel` in spell checker vocabulary (`.cspell/lynx.txt`)
- Bump `@lynx-js/lynx-ui-scroll-view` and `@lynx-js/lynx-ui-list` with minor version updates in changeset metadata

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-ui/pull/184)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->