### PR TITLE
fix(ci): run changeset version through package script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
           include-hidden-files: true
   # We make a build here to make sure cache works for pull requests
   # See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
-  publish:
+  changeset-version:
     timeout-minutes: 30
     needs: build
     runs-on: ubuntu-latest
@@ -113,6 +113,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SKILL_LYNX_UI_BASE_REF: ${{ github.event.before }}
         with:
-          version: pnpm ensure:skills-changeset && pnpm changeset version
+          version: pnpm version:packages
           publish: pnpm changeset publish
           title: "chore: Release ${{ steps.date.outputs.date }}"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "make-new-component": "tsx tools/make-new-component/index.ts",
     "prepare": "husky",
     "spell": "cspell lint --config cspell.jsonc --gitignore --no-progress --no-must-find-files --show-suggestions **",
-    "test": "vitest"
+    "test": "vitest",
+    "version:packages": "pnpm ensure:skills-changeset && changeset version"
   },
   "nano-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs,md,json,jsonc}": [

--- a/tools/skill-lynx-ui/check-references.mjs
+++ b/tools/skill-lynx-ui/check-references.mjs
@@ -5,8 +5,15 @@
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { generateReferences } from './generate-references.mjs'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const workspaceRoot = path.resolve(__dirname, '..', '..')
+const packageRoot = path.join(workspaceRoot, 'packages', 'skill-lynx-ui')
+const routingGuidePath = path.join(packageRoot, 'reference.md')
 
 async function listFiles(rootDir) {
   const files = []
@@ -33,7 +40,7 @@ async function main() {
   )
 
   try {
-    await generateReferences(tempRoot)
+    const components = await generateReferences(tempRoot)
 
     const generatedFiles = await listFiles(tempRoot)
     const requiredFiles = ['examples.md', 'references/index.md']
@@ -49,6 +56,24 @@ async function main() {
     )
     if (componentDirs.length === 0) {
       throw new Error('No component references were generated.')
+    }
+
+    const routingGuide = await fs.readFile(routingGuidePath, 'utf8')
+    const missingRoutes = components
+      .map(component => component.slug)
+      .filter(slug =>
+        !routingGuide.includes(`references/components/${slug}/guide.md`)
+      )
+
+    if (missingRoutes.length > 0) {
+      throw new Error(
+        [
+          `${
+            path.relative(workspaceRoot, routingGuidePath)
+          } is missing routing entries for generated component references:`,
+          ...missingRoutes.map(slug => `- ${slug}`),
+        ].join('\n'),
+      )
     }
 
     console.info('Reference generation check passed.')

--- a/tools/skill-lynx-ui/test/skill.test.ts
+++ b/tools/skill-lynx-ui/test/skill.test.ts
@@ -8,6 +8,8 @@ import { fileURLToPath } from 'node:url'
 
 import { describe, expect, it } from 'vitest'
 
+import { collectIncludedComponents } from '../generate-references.mjs'
+
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const packageRoot = path.resolve(
@@ -19,6 +21,7 @@ const packageRoot = path.resolve(
   'skill-lynx-ui',
 )
 const skillPath = path.join(packageRoot, 'SKILL.md')
+const referencePath = path.join(packageRoot, 'reference.md')
 
 describe('skill-lynx-ui SKILL.md', () => {
   it('contains valid frontmatter and progressive-disclosure guidance', async () => {
@@ -34,5 +37,16 @@ describe('skill-lynx-ui SKILL.md', () => {
     expect(skillText).toContain('examples.md')
     expect(skillText).not.toContain('## Examples')
     expect(skillText).not.toContain('## API Definition')
+  })
+
+  it('routes every included component reference', async () => {
+    const referenceText = await fs.readFile(referencePath, 'utf8')
+    const components = await collectIncludedComponents()
+
+    for (const component of components) {
+      expect(referenceText).toContain(
+        `references/components/${component.slug}/guide.md`,
+      )
+    }
   })
 })


### PR DESCRIPTION
Updates the release workflow so changesets/action calls a single package script for versioning.

This keeps the skill changeset guard and changeset versioning chained inside pnpm script execution, preventing the shell operator from being passed through as a plain argument.

Also keeps the publish job naming aligned with its release-versioning role.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Rename `publish` job to `changeset-version` in release workflow to clarify its versioning responsibility
- Invoke changeset versioning through a dedicated `version:packages` package script instead of inline shell commands
- Add `version:packages` script to chain the changeset guard and versioning commands
- Use `import.meta.url` for computing absolute paths in reference-check script instead of relative path assumptions
- Validate that all generated components have corresponding entries in the routing guide and throw descriptive errors for missing references
- Enforce routing coverage by testing that all included components have matching guide.md entries in reference.md

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-ui/pull/186)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->