### PR TITLE
feat(common): add experimental usePreCommit hook

### DIFF
--- a/.changeset/pre-commit-hook.md
+++ b/.changeset/pre-commit-hook.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/lynx-ui-common": minor
+"@lynx-js/lynx-ui": minor
+"@lynx-example/lynx-ui-common": patch
+---
+
+Add an experimental `usePreCommit` hook for running main-thread work before native commit.

--- a/apps/examples/Common/CHANGELOG.md
+++ b/apps/examples/Common/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lynx-example/lynx-ui-common
+
+## 0.0.6
+
+### Patch Changes
+
+- Initial release.

--- a/apps/examples/Common/LICENSE
+++ b/apps/examples/Common/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/examples/Common/PreCommitHook/index.tsx
+++ b/apps/examples/Common/PreCommitHook/index.tsx
@@ -1,0 +1,43 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useMainThreadRef, useState } from '@lynx-js/react'
+import './styles.css'
+
+import { usePreCommit } from '@lynx-js/lynx-ui'
+import type { MainThread } from '@lynx-js/types'
+
+function App() {
+  const nodeMTRef = useMainThreadRef<MainThread.Element>(null)
+  const [boxStyle, setBoxStyle] = useState('')
+
+  /**
+   * When update happens, state will be patched to main thread
+   * This hook will run after the state is patched, but before its result is committed to Native
+   * So it can be used to modify the element before it is committed to Native
+   */
+  usePreCommit(() => {
+    'main thread'
+    nodeMTRef.current?.setStyleProperties({
+      'background-color': '#ff5a7a',
+    })
+  }, [])
+
+  return (
+    <view className='demo-container lunaris-dark'>
+      <view
+        bindtap={() => {
+          setBoxStyle('background-color: var(--primary);')
+        }}
+        main-thread:ref={nodeMTRef}
+        style={boxStyle}
+        className='box'
+      >
+        <text className='box-text'>PreCommit</text>
+      </view>
+    </view>
+  )
+}
+
+root.render(<App />)

--- a/apps/examples/Common/PreCommitHook/styles.css
+++ b/apps/examples/Common/PreCommitHook/styles.css
@@ -1,0 +1,24 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.demo-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background-color: var(--canvas);
+}
+
+.box {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 200px;
+  height: 200px;
+  background-color: var(--primary);
+}
+
+.box-text {
+  color: var(--primary-content);
+  font-size: 24px;
+}

--- a/apps/examples/Common/lynx.config.mjs
+++ b/apps/examples/Common/lynx.config.mjs
@@ -1,0 +1,7 @@
+import { exampleConfig } from '../../../tools/configs/exampleConfig.mjs'
+
+const defaultConfig = exampleConfig({
+  PreCommitHook: './PreCommitHook/index.tsx',
+})
+
+export default defaultConfig

--- a/apps/examples/Common/package.json
+++ b/apps/examples/Common/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@lynx-example/lynx-ui-common",
+  "version": "0.0.6",
+  "description": "Example app demonstrating common utilities in lynx-ui",
+  "homepage": "https://github.com/lynx-family/lynx-ui/tree/main/apps/examples/Common#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-ui.git",
+    "directory": "apps/examples/Common"
+  },
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Lynx Authors"
+  },
+  "type": "module",
+  "files": [
+    "LICENSE",
+    "CHANGELOG.md",
+    "dist/",
+    "**/*.tsx",
+    "**/*.ts",
+    "**/*.css",
+    "lynx.config.mjs"
+  ],
+  "scripts": {
+    "build": "rspeedy build",
+    "build:dev": "rspeedy build --mode=development",
+    "dev": "rspeedy dev",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@lynx-js/luna-styles": "workspace:*",
+    "@lynx-js/lynx-ui": "workspace:*",
+    "@lynx-js/react": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
+    "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rspeedy": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@types/react": "catalog:",
+    "rsbuild-plugin-select-entry": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/apps/examples/Common/tsconfig.json
+++ b/apps/examples/Common/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    ".",
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+  ],
+}

--- a/packages/lynx-ui-common/src/hooks/index.ts
+++ b/packages/lynx-ui-common/src/hooks/index.ts
@@ -11,6 +11,7 @@ export { useRegisteredEvents } from './useRegisteredEvents'
 
 export { useMemoizedFn } from './useMemoizedFn'
 export { usePrevious } from './usePrevious'
+export { supportUsePreCommit, usePreCommit } from './usePreCommit'
 
 export function useFirstRender(cb: () => void): boolean {
   const isFirst = useRef(true)

--- a/packages/lynx-ui-common/src/hooks/usePreCommit.tsx
+++ b/packages/lynx-ui-common/src/hooks/usePreCommit.tsx
@@ -1,0 +1,111 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { runOnMainThread, useRef } from '@lynx-js/react'
+import type { DependencyList } from '@lynx-js/react'
+
+import {
+  runWorkletCtx,
+  setEomShouldFlushElementTree,
+} from '@lynx-js/react/worklet-runtime/bindings'
+import type { Worklet } from '@lynx-js/react/worklet-runtime/bindings'
+
+import { areDepsEqual } from '../utils/areDepsEqual'
+
+declare global {
+  var __setEomShouldFlushElementTree: ((value: boolean) => void) | undefined
+  var __eomFlushHoldCount: number | undefined
+}
+
+const setEomShouldFlush = setEomShouldFlushElementTree as unknown as (
+  value: boolean,
+) => void
+
+let eomFlushHoldCount = 0
+
+function holdEomFlush() {
+  eomFlushHoldCount += 1
+  if (eomFlushHoldCount === 1) {
+    setEomShouldFlush(false)
+  }
+}
+
+function releaseEomFlush() {
+  if (eomFlushHoldCount === 0) {
+    return
+  }
+
+  eomFlushHoldCount -= 1
+  if (eomFlushHoldCount === 0) {
+    setEomShouldFlush(true)
+  }
+}
+
+/**
+ * Use this hack to prevent setEomShouldFlushElementTree being in the MTS closure
+ */
+if (__MAIN_THREAD__) {
+  globalThis.__setEomShouldFlushElementTree = setEomShouldFlush
+}
+
+export function supportUsePreCommit() {
+  return typeof setEomShouldFlushElementTree === 'function'
+}
+
+/**
+ * An experimental hook dedicated to make MTS run on firstScreenPaint
+ * Can be used starting from ReactLynx 0.113.0
+ * @experimental
+ * @param cb A main-thread callback to run on firstScreen
+ * @param deps Dependency array - callback only executes when dependencies change
+ */
+export function usePreCommit(cb: () => void, deps?: DependencyList) {
+  const prevDepsRef = useRef<DependencyList | undefined>(undefined)
+
+  // Check if dependencies have changed
+  const depsChanged = !areDepsEqual(prevDepsRef.current, deps)
+
+  // Update the previous deps for next render
+  prevDepsRef.current = deps
+
+  // Only run if dependencies changed
+  if (!depsChanged) {
+    return
+  }
+
+  // For the Initial Frame Render
+  if (__MAIN_THREAD__) {
+    holdEomFlush()
+    Promise.resolve().then(() => {
+      try {
+        runWorkletCtx(cb as unknown as Worklet, [])
+      } catch (e) {
+        console.error('Error occurred in preCommit hook', e)
+      } finally {
+        releaseEomFlush()
+      }
+    })
+  } else {
+    runOnMainThread(() => {
+      'main thread'
+
+      globalThis.__eomFlushHoldCount = (globalThis.__eomFlushHoldCount ?? 0) + 1
+      if (globalThis.__eomFlushHoldCount === 1) {
+        globalThis.__setEomShouldFlushElementTree?.(false)
+      }
+
+      try {
+        cb()
+      } finally {
+        globalThis.__eomFlushHoldCount = Math.max(
+          (globalThis.__eomFlushHoldCount ?? 1) - 1,
+          0,
+        )
+        if (globalThis.__eomFlushHoldCount === 0) {
+          globalThis.__setEomShouldFlushElementTree?.(true)
+        }
+      }
+    })()
+  }
+}

--- a/packages/lynx-ui-common/src/utils/areDepsEqual.ts
+++ b/packages/lynx-ui-common/src/utils/areDepsEqual.ts
@@ -1,0 +1,26 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { DependencyList } from '@lynx-js/react'
+
+/**
+ * Compares two dependency arrays
+ */
+export function areDepsEqual(
+  prevDeps: DependencyList | undefined,
+  nextDeps: DependencyList | undefined,
+): boolean {
+  if (prevDeps === undefined || nextDeps === undefined) {
+    return false
+  }
+  if (prevDeps.length !== nextDeps.length) {
+    return false
+  }
+  for (let i = 0; i < prevDeps.length; i++) {
+    if (!Object.is(prevDeps[i], nextDeps[i])) {
+      return false
+    }
+  }
+  return true
+}

--- a/packages/lynx-ui/src/index.tsx
+++ b/packages/lynx-ui/src/index.tsx
@@ -14,6 +14,8 @@ export {
   useRegisteredEvents,
   useMemoizedFn,
   usePrevious,
+  supportUsePreCommit,
+  usePreCommit,
   useFirstRender,
   useJSFirstRender,
   useLepusFirstRender,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,37 @@ importers:
         specifier: 'catalog:'
         version: 18.3.27
 
+  apps/examples/Common:
+    dependencies:
+      '@lynx-js/luna-styles':
+        specifier: workspace:*
+        version: link:../../../luna/packages/luna-styles
+      '@lynx-js/lynx-ui':
+        specifier: workspace:*
+        version: link:../../../packages/lynx-ui
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.27)
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.4.6
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.12.4(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.27))(webpack@5.104.1)
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.12.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.3)(webpack@5.104.1)
+      '@lynx-js/types':
+        specifier: 'catalog:'
+        version: 3.6.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.27
+      rsbuild-plugin-select-entry:
+        specifier: workspace:*
+        version: link:../../../tools/rsbuild-plugin-select-entry
+
   apps/examples/Dialog:
     dependencies:
       '@lynx-js/luna-styles':


### PR DESCRIPTION
Adds an experimental pre-commit hook for common main-thread work before native commit.

Exports the hook through the common package and aggregate lynx-ui entry.

Adds a Common example package demonstrating the behavior with OSS package names and LUNA styling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Add experimental usePreCommit hook

Introduce an experimental `usePreCommit` hook in `@lynx-js/lynx-ui-common` to schedule callbacks for running main-thread work before native commits. The hook handles dependency tracking and coordinates with EOM flushing to influence behavior on first screen paint, with separate execution paths for main-thread and background-thread contexts.

- Introduce `usePreCommit` hook with dependency change detection via `areDepsEqual` utility
- Export `supportUsePreCommit` to detect availability of `setEomShouldFlushElementTree`
- Re-export `usePreCommit` and `supportUsePreCommit` from `lynx-ui-common` package
- Aggregate `usePreCommit` and `supportUsePreCommit` exports in `lynx-ui` entry point
- Create `@lynx-example/lynx-ui-common` example package with PreCommitHook demo component
- Include demo component showing hook integration with LUNA styling and OSS package styling
- Add Apache 2.0 license and configuration files for example package

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-ui/pull/188)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->