### PR TITLE
chore(ci): unify workflow display names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   get-merge-base:
+    name: Get Merge Base
     permissions:
       contents: read
     runs-on: lynx-ubuntu-24.04-medium
@@ -25,7 +26,7 @@ jobs:
           ref: ${{ env.HEAD_REF }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       # Set up common variables for git operations
-      - name: Setup git refs
+      - name: Setup Git Refs
         id: git-refs
         run: |
           # Strip refs/heads/ prefix if it exists
@@ -54,7 +55,7 @@ jobs:
             echo "Failed to determine merge base after $MAX_ATTEMPTS attempts." >&2
             exit 1
           fi
-      - name: Get merge base
+      - name: Get Merge Base
         id: merge-base
         env:
           CLEAN_BASE_REF: ${{ format('upstream/{0}', steps.git-refs.outputs.base-ref) || github.event.base }}
@@ -83,7 +84,7 @@ jobs:
           node-version: "24"
           package-manager-cache: false
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
-      - name: TurboCache
+      - name: Turbo Cache
         uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
         with:
           path: .turbo
@@ -99,7 +100,7 @@ jobs:
           pnpm turbo build --summarize
         env:
           NODE_OPTIONS: --max-old-space-size=32768
-      - name: Upload turbo summary
+      - name: Upload Turbo Summary
         if: runner.debug == '1'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,10 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
+    name: Build
     uses: ./.github/workflows/build.yml
   code-style-check:
+    name: Code Style Check
     runs-on: lynx-ubuntu-24.04-medium
     timeout-minutes: 10
     steps:
@@ -53,6 +55,7 @@ jobs:
         run: pnpm changeset status --since=origin/main || echo "::warning::Changeset check failed, but continuing execution."
 
   luna-vars:
+    name: LUNA Vars
     needs: build
     uses: ./.github/workflows/common-test.yml
     with:
@@ -60,6 +63,7 @@ jobs:
       run: pnpm check:luna-vars
 
   eslint:
+    name: ESLint
     needs: build
     uses: ./.github/workflows/common-test.yml
     with:
@@ -67,6 +71,7 @@ jobs:
       run: pnpm eslint . --flag v10_config_lookup_from_file
 
   check-exports:
+    name: Check Exports
     needs: build
     uses: ./.github/workflows/common-test.yml
     with:
@@ -74,6 +79,7 @@ jobs:
       run: pnpm check:exports
 
   test-publish:
+    name: Test Publish
     needs: build
     uses: ./.github/workflows/common-test.yml
     secrets: inherit
@@ -113,6 +119,7 @@ jobs:
         echo "Smoke test passed for $PKG_NAME"
 
   test-typos:
+    name: Test Typos
     runs-on: lynx-ubuntu-24.04-medium
     steps:
       - uses: actions/checkout@v4
@@ -120,6 +127,7 @@ jobs:
         with:
           files: .
   test-vitest:
+    name: Vitest (${{ matrix.runs-on.name }})
     needs: build
     uses: ./.github/workflows/common-test.yml
     strategy:
@@ -128,7 +136,6 @@ jobs:
         runs-on:
           - name: Ubuntu
             label: lynx-ubuntu-24.04-medium
-    name: Vitest (${{ matrix.runs-on.name }})
     with:
       runs-on: ${{ matrix.runs-on.label }}
       run: >

--- a/.github/workflows/common-test.yml
+++ b/.github/workflows/common-test.yml
@@ -22,6 +22,7 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   check:
+    name: Check
     timeout-minutes: 30
     runs-on: ${{ inputs.runs-on }}
     permissions:
@@ -38,7 +39,7 @@ jobs:
         with:
           node-version: "24"
           package-manager-cache: false
-      - name: TurboCache
+      - name: Turbo Cache
         uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
         with:
           path: .turbo

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   validate-pr-title:
-    name: Validate PR title
+    name: Validate PR Title
     runs-on: lynx-ubuntu-24.04-medium
     timeout-minutes: 10
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ env:
   NPM_CONFIG_PROVENANCE: true
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: github.repository == 'lynx-family/lynx-ui'
@@ -38,7 +39,7 @@ jobs:
           npm install -g corepack@latest
           corepack enable && corepack prepare
           corepack pnpm install --frozen-lockfile
-      - name: build
+      - name: Build
         run: |
           corepack pnpm turbo build --summarize
       - name: Save Turbo Result
@@ -52,7 +53,8 @@ jobs:
           include-hidden-files: true
   # We make a build here to make sure cache works for pull requests
   # See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
-  changeset-version:
+  release:
+    name: Release
     timeout-minutes: 30
     needs: build
     runs-on: ubuntu-latest
@@ -89,24 +91,24 @@ jobs:
         with:
           name: deploy-${{ github.sha }}
           path: .turbo
-      - name: Print npm and pnpm version
+      - name: Print Package Manager Versions
         run: |
           npm --version
           corepack pnpm --version
-      - name: build
+      - name: Build
         run: |
           corepack pnpm turbo build --summarize
-      - name: Get current date
+      - name: Get Current Date
         id: date
         run: echo "date=$(date -u +'%Y-%m-%d %H:%M:%S')" >> "${GITHUB_OUTPUT}"
-      - name: Check release run is current
+      - name: Check Release Run Is Current
         id: current-main
         shell: bash
         run: |
           set -eu
           read -r latest_main_sha _ < <(git ls-remote --exit-code origin refs/heads/main)
           echo "sha=${latest_main_sha}" >> "${GITHUB_OUTPUT}"
-      - name: publish
+      - name: Create Version PR Or Publish
         if: github.sha == steps.current-main.outputs.sha
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         env:


### PR DESCRIPTION
- rename the publish job id from `changeset-version` to `release`
- add explicit job names where GitHub Actions previously showed raw job ids
- normalize workflow step names to title case across publish, build, ci, common-test, and lint-pr workflows
- keep workflow logic, dependencies, and execution behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Normalize GitHub Actions workflow display names across multiple workflows

- Rename the publish job id from `changeset-version` to `release` and add explicit `name: Release` job metadata in publish.yml
- Add explicit human-readable `name` fields to jobs in ci.yml, build.yml, and other workflows where GitHub Actions previously displayed raw job ids
- Standardize step names to title case across publish, build, ci, common-test, and lint-pr workflows (e.g., "Setup Git Refs", "Get Merge Base", "Turbo Cache", "Upload Turbo Summary", "Print Package Manager Versions", "Check Release Run Is Current", "Validate PR Title")
- Preserve all existing workflow logic, dependencies, commands, and execution behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-ui/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->