### PR TITLE
fix(example): make Checkbox example text styling explicit on web

### DIFF
--- a/.changeset/frank-chefs-type.md
+++ b/.changeset/frank-chefs-type.md
@@ -1,0 +1,8 @@
+---
+"@lynx-example/lynx-ui-checkbox": patch
+---
+
+Apply explicit text classes in Checkbox examples so text styling no longer relies
+on inherited container styles, which can be overridden by higher-priority host
+site text rules in lynx for web environments such as lynx-website.
+

--- a/.cspell/misc.txt
+++ b/.cspell/misc.txt
@@ -75,3 +75,6 @@ worklet
 xlarge
 yoavbls
 zizmor
+n'BDX
+overscroll
+Rects

--- a/apps/examples/Checkbox/Basic/index.css
+++ b/apps/examples/Checkbox/Basic/index.css
@@ -25,7 +25,6 @@
   padding-right: 48px;
   border-radius: 16px;
   overflow: hidden;
-  color: var(--content);
   background-color: var(--canvas);
 }
 

--- a/apps/examples/Checkbox/Basic/index.tsx
+++ b/apps/examples/Checkbox/Basic/index.tsx
@@ -30,7 +30,7 @@ function App() {
                 <CheckMark />
               </CheckboxIndicator>
             </Checkbox>
-            <text>Uncontrolled Checkbox</text>
+            <text className='label'>Uncontrolled Checkbox</text>
           </view>
         </view>
 
@@ -51,7 +51,7 @@ function App() {
                 <CheckMark />
               </CheckboxIndicator>
             </Checkbox>
-            <text>{checked ? 'Checked' : 'Unchecked'}</text>
+            <text className='label'>{checked ? 'Checked' : 'Unchecked'}</text>
           </view>
         </view>
 

--- a/apps/examples/Checkbox/Indeterminate/index.css
+++ b/apps/examples/Checkbox/Indeterminate/index.css
@@ -3,6 +3,7 @@
 /* =========================
  * Container
  * ========================= */
+
 .demo-container {
   display: flex;
   flex-direction: column;
@@ -13,7 +14,6 @@
   padding-left: 48px;
   padding-right: 48px;
   background-color: var(--canvas);
-  color: var(--content);
 }
 
 .demo-canvas {
@@ -46,7 +46,7 @@
   row-gap: 10px;
 }
 
-.title {
+.title, .label {
   font-size: 16px;
   color: var(--content-2);
 }

--- a/apps/examples/Checkbox/Indeterminate/index.tsx
+++ b/apps/examples/Checkbox/Indeterminate/index.tsx
@@ -54,7 +54,7 @@ function App() {
                 {indeterminate ? <IndeterminateMark /> : <CheckMark />}
               </CheckboxIndicator>
             </Checkbox>
-            <text>Select All</text>
+            <text className='label'>Select All</text>
           </view>
 
           <view className='fruits'>
@@ -70,7 +70,7 @@ function App() {
                     <CheckMark />
                   </CheckboxIndicator>
                 </Checkbox>
-                <text>{fruit}</text>
+                <text className='label'>{fruit}</text>
               </view>
             ))}
           </view>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -89,6 +89,7 @@ export default tseslint.config(
             'Android',
             'iOS',
             'Harmony',
+            'PC',
             'experimental',
             'zh',
             'docTypeFallback',


### PR DESCRIPTION
- Add explicit text classes to Checkbox examples instead of relying on inherited container text styles. This prevents host website text rules from overriding demo text styles in lynx for web environments such as lynx-website.

- Update spelling allowlists for generated typedoc output and allow the custom JSDoc tag @PC in the ESLint config so the remaining warnings are cleared.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add changelog entry for `@lynx-example/lynx-ui-checkbox` patch release
- Make Checkbox example text styling explicit by applying label class to text elements
- Update demo container styling to use background instead of inherited text color
- Expand CSS selectors to apply consistent text styling to both titles and labels
- Update spell-check wordlist with additional entries
- Allow custom `@PC` JSDoc tag in ESLint configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-ui/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->