### PR TITLE
fix(slider): measure bounds with transform props

### DIFF
--- a/.changeset/light-moles-agree.md
+++ b/.changeset/light-moles-agree.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-slider": patch
+---
+
+Fix slider bounds measurement when Android transform props are applied.

--- a/.changeset/purple-knives-sin.md
+++ b/.changeset/purple-knives-sin.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/lynx-ui-common": patch
+---
+
+Enabled transform-aware `boundingClientRect` calculation by default on Android, iOS, and Harmony.

--- a/packages/lynx-ui-common/src/utils/selector.ts
+++ b/packages/lynx-ui-common/src/utils/selector.ts
@@ -121,7 +121,13 @@ export const getRectByRef = (
   new Promise((resolve, reject) => {
     invokeByRef(ref, 'boundingClientRect', {
       relativeTo: relativeToScreen ? 'screen' : relativeTo,
+      // Match the standard getBoundingClientRect behavior: transforms are
+      // included in the returned rect. Keep this enabled by default across
+      // platforms to avoid incorrect bounds for transformed nodes, such as
+      // scaled views. A few animation-related cases may opt out explicitly.
       androidEnableTransformProps: true,
+      iosEnableTransformProps: true,
+      harmonyEnableTransformProps: true,
     })
       .then((res) => {
         resolve(
@@ -152,7 +158,13 @@ export const getRootRect = (
         method: 'boundingClientRect',
         params: {
           relativeTo: relativeToScreen ? 'screen' : relativeTo,
+          // Match the standard getBoundingClientRect behavior: transforms are
+          // included in the returned rect. Keep this enabled by default across
+          // platforms to avoid incorrect bounds for transformed nodes, such as
+          // scaled views. A few animation-related cases may opt out explicitly.
           androidEnableTransformProps: true,
+          iosEnableTransformProps: true,
+          harmonyEnableTransformProps: true,
         },
         success: (res) => {
           resolve(
@@ -181,7 +193,13 @@ export const getRectById = (
   new Promise((resolve, reject) => {
     invokeById(id, 'boundingClientRect', {
       relativeTo: relativeToScreen ? 'screen' : relativeTo,
+      // Match the standard getBoundingClientRect behavior: transforms are
+      // included in the returned rect. Keep this enabled by default across
+      // platforms to avoid incorrect bounds for transformed nodes, such as
+      // scaled views. A few animation-related cases may opt out explicitly.
       androidEnableTransformProps: true,
+      iosEnableTransformProps: true,
+      harmonyEnableTransformProps: true,
     })
       .then((res) => {
         resolve(

--- a/packages/lynx-ui-slider/src/SliderRoot/index.tsx
+++ b/packages/lynx-ui-slider/src/SliderRoot/index.tsx
@@ -13,6 +13,7 @@ import {
 } from '@lynx-js/react'
 import type { ForwardedRef } from '@lynx-js/react'
 
+import { getRectByRef } from '@lynx-js/lynx-ui-common'
 import type { NodesRef } from '@lynx-js/types'
 
 import { SliderContext } from '../context'
@@ -147,25 +148,19 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
   const measureBounds = (): void => {
     if (isMeasuringBounds.current) return
 
-    const trackNode = trackRef.current
-    if (!trackNode?.invoke) return
+    if (!trackRef.current) return
 
     isMeasuringBounds.current = true
 
-    trackNode
-      .invoke({
-        method: 'boundingClientRect',
-        params: { relativeTo: 'screen' },
-        success: (res: unknown) => {
-          isMeasuringBounds.current = false
-          updateBounds(res)
-          flushPendingMoveX()
-        },
-        fail: () => {
-          isMeasuringBounds.current = false
-        },
+    getRectByRef(trackRef)
+      .then((res) => {
+        isMeasuringBounds.current = false
+        updateBounds(res)
+        flushPendingMoveX()
       })
-      ?.exec?.()
+      .catch(() => {
+        isMeasuringBounds.current = false
+      })
   }
 
   const setDragging = (nextDragging: boolean, value: number): void => {


### PR DESCRIPTION
## Summary

- update slider track bounds measurement to request Android transform-prop-aware geometry
- add an empty changeset with context because `@lynx-js/lynx-ui-slider` is private and not versioned by the repo changeset config

## Impact

This keeps slider position calculations aligned when Android transform props affect the measured track node.

## Validation

- `pnpm changeset --empty`
- `pnpm turbo build`
- pre-commit nano-staged checks: eslint, biome, dprint, cspell


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Request Android transform-prop-aware geometry when measuring slider track bounds in lynx-ui-slider
- Add empty changeset documenting slider bounds measurement fix for private `@lynx-js/lynx-ui-slider`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-ui/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->