### PR TITLE
fix(sheet): size content from max snap point

### DIFF
--- a/.changeset/quiet-drawers-drag.md
+++ b/.changeset/quiet-drawers-drag.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-sheet": patch
+---
+
+Fix side drawer positioning with oversized SheetContent surfaces, mixed `fit` snap point sizing on the main thread, and `SheetHandle` drag touch handling.

--- a/.changeset/quiet-drawers-drag.md
+++ b/.changeset/quiet-drawers-drag.md
@@ -2,4 +2,4 @@
 "@lynx-js/lynx-ui-sheet": patch
 ---
 
-Fix side drawer positioning with oversized SheetContent surfaces, mixed `fit` snap point sizing on the main thread, and `SheetHandle` drag touch handling.
+Fix side drawer positioning with oversized SheetContent surfaces, make `enableRTL` set the Sheet viewport direction, fix mixed `fit` snap point sizing on the main thread, and fix `SheetHandle` drag touch handling.

--- a/.changeset/silver-sheets-snap.md
+++ b/.changeset/silver-sheets-snap.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-sheet": patch
+---
+
+Use the highest resolved sheet snap point as the stable inner layout size. Pure `'fit'` snap point sheets continue to preserve content-driven sizing.

--- a/apps/examples/Sheet/AutoHeight/index.tsx
+++ b/apps/examples/Sheet/AutoHeight/index.tsx
@@ -15,7 +15,8 @@ import type { SheetRootRef } from '@lynx-js/lynx-ui'
 import { ActionButton, TriggerButton } from '../shared/index.js'
 import './index.css'
 
-const snapPoints = ['fit']
+const fitSnapPoints = ['fit']
+const fitAndPercentSnapPoints = ['fit', '80%']
 const claimedGestureAngles: [number, number][] = [[-135, -45], [45, 135]]
 
 const longText =
@@ -23,33 +24,40 @@ const longText =
     .repeat(10)
 
 function App() {
-  const sheetRef = useRef<SheetRootRef>(null)
+  const fitSheetRef = useRef<SheetRootRef>(null)
+  const fitAndPercentSheetRef = useRef<SheetRootRef>(null)
 
   return (
     <view className='demo-container lunaris-dark'>
       <text className='title-text'>Sheet Auto Height</text>
 
-      <TriggerButton
-        onClick={() => sheetRef.current?.open()}
-        text='Open Sheet (via ref)'
-      />
+      <view className='button-group'>
+        <TriggerButton
+          onClick={() => fitSheetRef.current?.open()}
+          text='Open Fit Sheet'
+        />
+        <TriggerButton
+          onClick={() => fitAndPercentSheetRef.current?.open()}
+          text='Open Fit + 80% Sheet'
+        />
+      </view>
 
       <SheetRoot
-        ref={sheetRef}
+        ref={fitSheetRef}
         onShowChange={(show) => {
-          console.log('show change', show)
+          console.log('fit show change', show)
         }}
         onOpen={() => {
-          console.log('open change')
+          console.log('fit open change')
         }}
         onClose={() => {
-          console.log('close change')
+          console.log('fit close change')
         }}
-        snapPoints={snapPoints}
+        snapPoints={fitSnapPoints}
         initialSnap={0}
         claimedGestureAngles={claimedGestureAngles}
         onSnapChange={(snapIndex, snapValue) => {
-          console.log(snapIndex, snapValue)
+          console.log('fit snap change', snapIndex, snapValue)
         }}
       >
         <SheetView className='sheet-viewport'>
@@ -61,11 +69,54 @@ function App() {
             <SheetHandle className='sheet-handle' />
             <view className='control-panel'>
               <text className='header-text'>
-                Sheet with Long Content
+                Fit Sheet with Long Content
               </text>
+              <text className='info-text'>snapPoints=["fit"]</text>
               <text className='info-text'>{longText}</text>
               <ActionButton
-                onClick={() => sheetRef.current?.close()}
+                onClick={() => fitSheetRef.current?.close()}
+                text='Close via Ref'
+              />
+            </view>
+          </SheetContent>
+        </SheetView>
+      </SheetRoot>
+
+      <SheetRoot
+        ref={fitAndPercentSheetRef}
+        snapPoints={fitAndPercentSnapPoints}
+        initialSnap={0}
+        claimedGestureAngles={claimedGestureAngles}
+        onSnapChange={(snapIndex, snapValue) => {
+          console.log('fit + 80% snap change', snapIndex, snapValue)
+        }}
+      >
+        <SheetView className='sheet-viewport'>
+          <SheetBackdrop className='sheet-overlay' />
+          <SheetContent
+            className='sheet-content'
+            innerClassName='sheet-inner-content'
+          >
+            <SheetHandle className='sheet-handle' />
+            <view className='control-panel'>
+              <text className='header-text'>
+                Fit Sheet with Percent Snap
+              </text>
+              <text className='info-text'>snapPoints=["fit", "80%"]</text>
+              <text className='info-text'>
+                The fit snap uses measured content height, while 80% resolves
+                against the viewport height.
+              </text>
+              <ActionButton
+                onClick={() => fitAndPercentSheetRef.current?.snapTo(0)}
+                text='Snap to fit'
+              />
+              <ActionButton
+                onClick={() => fitAndPercentSheetRef.current?.snapTo(1)}
+                text='Snap to 80%'
+              />
+              <ActionButton
+                onClick={() => fitAndPercentSheetRef.current?.close()}
                 text='Close via Ref'
               />
             </view>

--- a/apps/examples/Sheet/Directional/index.tsx
+++ b/apps/examples/Sheet/Directional/index.tsx
@@ -55,6 +55,8 @@ function App() {
   const rightDrawerRef = useRef<SheetRootRef>(null)
   const startDrawerRef = useRef<SheetRootRef>(null)
   const endDrawerRef = useRef<SheetRootRef>(null)
+  const rtlLeftDrawerRef = useRef<SheetRootRef>(null)
+  const rtlRightDrawerRef = useRef<SheetRootRef>(null)
   const topSheetRef = useRef<SheetRootRef>(null)
   const bottomSheetRef = useRef<SheetRootRef>(null)
 
@@ -81,6 +83,14 @@ function App() {
         <TriggerButton
           onClick={() => endDrawerRef.current?.open()}
           text='Open End Drawer'
+        />
+        <TriggerButton
+          onClick={() => rtlLeftDrawerRef.current?.open()}
+          text='Open RTL Left Drawer'
+        />
+        <TriggerButton
+          onClick={() => rtlRightDrawerRef.current?.open()}
+          text='Open RTL Right Drawer'
         />
         <TriggerButton
           onClick={() => topSheetRef.current?.open()}
@@ -164,6 +174,44 @@ function App() {
             description='This drawer uses side="end" with a percentage snap point.'
             note='Without enableRTL, end resolves to right. Turn enableRTL on to make end resolve to left.'
             close={() => endDrawerRef.current?.close()}
+            surfaceClassName='drawer-content drawer-content-right'
+            innerClassName='drawer-inner-content drawer-inner-content-percent'
+          />
+        </SheetView>
+      </SheetRoot>
+
+      <SheetRoot
+        ref={rtlLeftDrawerRef}
+        side='left'
+        snapPoints={['fit']}
+        initialSnap={0}
+      >
+        <SheetView className='sheet-viewport' style={{ direction: 'rtl' }}>
+          <SheetBackdrop className='sheet-overlay' clickToClose={true} />
+          <DrawerSection
+            title='RTL Left Drawer'
+            description='This drawer uses side="left" while the container direction is RTL.'
+            note='Physical left should stay left even when text and inline layout run right-to-left.'
+            close={() => rtlLeftDrawerRef.current?.close()}
+            surfaceClassName='drawer-content drawer-content-left'
+            innerClassName='drawer-inner-content drawer-inner-content-fit'
+          />
+        </SheetView>
+      </SheetRoot>
+
+      <SheetRoot
+        ref={rtlRightDrawerRef}
+        side='right'
+        snapPoints={['72%']}
+        initialSnap={0}
+      >
+        <SheetView className='sheet-viewport' style={{ direction: 'rtl' }}>
+          <SheetBackdrop className='sheet-overlay' clickToClose={true} />
+          <DrawerSection
+            title='RTL Right Drawer'
+            description='This drawer uses side="right" while the container direction is RTL.'
+            note='Physical right should stay right even when text and inline layout run right-to-left.'
+            close={() => rtlRightDrawerRef.current?.close()}
             surfaceClassName='drawer-content drawer-content-right'
             innerClassName='drawer-inner-content drawer-inner-content-percent'
           />

--- a/apps/examples/Sheet/Directional/index.tsx
+++ b/apps/examples/Sheet/Directional/index.tsx
@@ -183,15 +183,16 @@ function App() {
       <SheetRoot
         ref={rtlLeftDrawerRef}
         side='left'
+        enableRTL={true}
         snapPoints={['fit']}
         initialSnap={0}
       >
-        <SheetView className='sheet-viewport' style={{ direction: 'rtl' }}>
+        <SheetView className='sheet-viewport'>
           <SheetBackdrop className='sheet-overlay' clickToClose={true} />
           <DrawerSection
             title='RTL Left Drawer'
-            description='This drawer uses side="left" while the container direction is RTL.'
-            note='Physical left should stay left even when text and inline layout run right-to-left.'
+            description='This drawer uses side="left" with enableRTL.'
+            note='Physical left stays left, while the Sheet viewport direction becomes RTL.'
             close={() => rtlLeftDrawerRef.current?.close()}
             surfaceClassName='drawer-content drawer-content-left'
             innerClassName='drawer-inner-content drawer-inner-content-fit'
@@ -202,15 +203,16 @@ function App() {
       <SheetRoot
         ref={rtlRightDrawerRef}
         side='right'
+        enableRTL={true}
         snapPoints={['72%']}
         initialSnap={0}
       >
-        <SheetView className='sheet-viewport' style={{ direction: 'rtl' }}>
+        <SheetView className='sheet-viewport'>
           <SheetBackdrop className='sheet-overlay' clickToClose={true} />
           <DrawerSection
             title='RTL Right Drawer'
-            description='This drawer uses side="right" while the container direction is RTL.'
-            note='Physical right should stay right even when text and inline layout run right-to-left.'
+            description='This drawer uses side="right" with enableRTL.'
+            note='Physical right stays right, while the Sheet viewport direction becomes RTL.'
             close={() => rtlRightDrawerRef.current?.close()}
             surfaceClassName='drawer-content drawer-content-right'
             innerClassName='drawer-inner-content drawer-inner-content-percent'

--- a/packages/lynx-ui-sheet/SKILL.md
+++ b/packages/lynx-ui-sheet/SKILL.md
@@ -23,6 +23,7 @@ Use it when a UI needs a dismissible panel that slides from an edge of the viewp
 - In `top` and `bottom` mode, percentage snap points resolve against the vertical main-axis basis: `screenHeight` when provided, otherwise viewport height.
 - In horizontal modes (`left`, `right`, `start`, `end`), percentage snap points resolve against the horizontal main-axis basis: `screenWidth` when provided, otherwise viewport width.
 - The `'fit'` snap point resolves to measured content height for `top` / `bottom`, and measured content width for horizontal modes.
+- The inner layout uses `maxSnapSize`, the highest resolved `snapPoints` value, as its stable main-axis size so `flex: 1` children have a snap-related height/width basis. Pure `'fit'` snap point sheets stay content-driven.
 - `screenHeight` can override the height basis for `top` / `bottom`; `screenWidth` can override the width basis for horizontal modes.
 - Rubber-band over-drag defaults to enabled for `top` / `bottom` and disabled for horizontal modes. Use `rubberBand` to override the default.
 

--- a/packages/lynx-ui-sheet/src/SheetContent/index.tsx
+++ b/packages/lynx-ui-sheet/src/SheetContent/index.tsx
@@ -232,13 +232,13 @@ export function SheetContent(props: SheetContentProps) {
         style={{
           position: 'absolute',
           top: 0,
-          left: 0,
-          width: '100vw',
+          ...(resolvedSide === 'left'
+            ? { right: '100%' }
+            : { left: '100%' }),
+          width: '150vw',
           height: '100vh',
           overflow: 'hidden',
-          transform: resolvedSide === 'left'
-            ? `translate(${-viewportSize}px, 0px)`
-            : `translate(${viewportSize}px, 0px)`,
+          transform: 'translate(0px, 0px)',
           display: 'flex',
           flexDirection: 'row',
           justifyContent: resolvedSide === 'left'
@@ -259,6 +259,8 @@ export function SheetContent(props: SheetContentProps) {
     <view
       className={className}
       style={{
+        position: 'absolute',
+        left: 0,
         ...(isTop
           ? {
             bottom: '100%',
@@ -269,8 +271,10 @@ export function SheetContent(props: SheetContentProps) {
           : {
             top: '100%',
           }),
-        height: '100vh',
+        width: '100vw',
+        height: '150vh',
         overflow: 'hidden',
+        transform: 'translate(0px, 0px)',
         ...style,
       }}
       main-thread:ref={setSheetMTRef}

--- a/packages/lynx-ui-sheet/src/SheetContent/index.tsx
+++ b/packages/lynx-ui-sheet/src/SheetContent/index.tsx
@@ -99,6 +99,8 @@ export function SheetContent(props: SheetContentProps) {
     getResolvedSnapOffsets,
     getResolvedSnapPointValues,
     handleSheetLayoutChangeMT,
+    setContentMTRef,
+    maxSnapSize,
     // Controller exports
     onDragStartMT,
     onDragEndSnapMT,
@@ -199,6 +201,7 @@ export function SheetContent(props: SheetContentProps) {
     }),
     [handleTouchStartMT, handleTouchMoveMT, handleTouchEndMT],
   )
+  const hasFitSnapPoint = snapPoints.some(p => String(p).trim() === 'fit')
 
   const horizontalContent = (
     <view
@@ -207,8 +210,10 @@ export function SheetContent(props: SheetContentProps) {
       style={{
         height: '100%',
         ...innerStyle,
+        ...(hasFitSnapPoint ? {} : { width: `${maxSnapSize}px` }),
       }}
       event-through={false}
+      main-thread:ref={setContentMTRef}
       main-thread:bindtouchstart={handleOnly ? undefined : handleTouchStartMT}
       main-thread:bindtouchmove={handleOnly ? undefined : handleTouchMoveMT}
       main-thread:bindtouchend={handleOnly ? undefined : handleTouchEndMT}
@@ -281,7 +286,9 @@ export function SheetContent(props: SheetContentProps) {
         style={{
           width: '100%',
           ...innerStyle,
+          ...(hasFitSnapPoint ? {} : { height: `${maxSnapSize}px` }),
         }}
+        main-thread:ref={setContentMTRef}
         main-thread:bindlayoutchange={handleSheetLayoutChangeMT}
       >
         <SheetDragContext.Provider value={contextValue}>

--- a/packages/lynx-ui-sheet/src/SheetContent/index.tsx
+++ b/packages/lynx-ui-sheet/src/SheetContent/index.tsx
@@ -208,6 +208,10 @@ export function SheetContent(props: SheetContentProps) {
       {...rest}
       className={innerClassName}
       style={{
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        ...(resolvedSide === 'left' ? { right: 0 } : { left: 0 }),
         height: '100%',
         ...innerStyle,
         ...(hasFitSnapPoint ? {} : { width: `${maxSnapSize}px` }),
@@ -239,11 +243,6 @@ export function SheetContent(props: SheetContentProps) {
           height: '100vh',
           overflow: 'hidden',
           transform: 'translate(0px, 0px)',
-          display: 'flex',
-          flexDirection: 'row',
-          justifyContent: resolvedSide === 'left'
-            ? 'flex-end'
-            : 'flex-start',
           ...style,
         }}
         main-thread:ref={setSheetMTRef}

--- a/packages/lynx-ui-sheet/src/SheetHandle/index.tsx
+++ b/packages/lynx-ui-sheet/src/SheetHandle/index.tsx
@@ -13,6 +13,7 @@ export function SheetHandle(props: SheetHandleProps) {
       className={className}
       style={style}
       {...rest}
+      event-through={false}
       main-thread:bindtouchstart={dragHandlers.handleTouchStartMT}
       main-thread:bindtouchmove={dragHandlers.handleTouchMoveMT}
       main-thread:bindtouchend={dragHandlers.handleTouchEndMT}

--- a/packages/lynx-ui-sheet/src/SheetView/index.tsx
+++ b/packages/lynx-ui-sheet/src/SheetView/index.tsx
@@ -16,7 +16,7 @@ export const SheetView = (props: SheetViewProps) => {
     nativeProps,
   } = props
 
-  const { mounted, forceMount } = useSheetContext()
+  const { mounted, forceMount, enableRTL } = useSheetContext()
 
   if (!mounted && !forceMount) {
     return null
@@ -27,6 +27,7 @@ export const SheetView = (props: SheetViewProps) => {
       container={container}
       className={className}
       style={{
+        direction: enableRTL ? 'rtl' : 'ltr',
         ...style,
         position: container ? 'relative' : 'fixed',
       }}

--- a/packages/lynx-ui-sheet/src/hooks/useSnap.ts
+++ b/packages/lynx-ui-sheet/src/hooks/useSnap.ts
@@ -167,6 +167,18 @@ export function useSnap({
     return clamp(targetY, Math.max(sheetSizeMTRef.current, maxSnap))
   }
 
+  function getMaxSnapSizeMT(points: number[], fitSize = 0) {
+    'main thread'
+    let max = fitSize
+    for (const point of points) {
+      const value = point === -1 ? fitSize : point
+      if (value > max) {
+        max = value
+      }
+    }
+    return max
+  }
+
   function setSheetMTRef(el: MainThread.Element) {
     'main thread'
     sheetMTRef.current = el
@@ -204,11 +216,7 @@ export function useSnap({
         ? Math.min(v, opened)
         : v
       el.setStyleProperties({
-        transform: getSheetTransform(
-          resolvedSide,
-          transformValue,
-          viewportSize,
-        ),
+        transform: getSheetTransform(resolvedSide, transformValue),
         transition: 'none',
       })
       if (sheetProgress?.current) {
@@ -382,7 +390,7 @@ export function useSnap({
         o === -1 ? fitSize : o
       )
       if (!hasOnlyFitSnapPoints) {
-        updateContentSizeMT(getMaxSnapSize(innerSnapPointValues, fitSize))
+        updateContentSizeMT(getMaxSnapSizeMT(innerSnapPointValues, fitSize))
       }
 
       // Resolve any pending snap operation

--- a/packages/lynx-ui-sheet/src/hooks/useSnap.ts
+++ b/packages/lynx-ui-sheet/src/hooks/useSnap.ts
@@ -124,11 +124,6 @@ export function useSnap({
     () => snapPoints.some(p => String(p).trim() === 'fit'),
     [snapPoints],
   )
-  const hasOnlyFitSnapPoints = useMemo(
-    () => snapPoints.every(p => String(p).trim() === 'fit'),
-    [snapPoints],
-  )
-
   // Keep snap points order stable: indices should match `snapPoints` order.
   const { snapPointValues, snapOffsets } = useMemo(() => {
     const values = snapPoints.map(p => toPxJS(p, viewportSize))
@@ -165,18 +160,6 @@ export function useSnap({
     const maxSnap = offsets.length > 0 ? Math.max(...offsets) : 0
     // Allow snapping up to the max snap point, even if content is shorter
     return clamp(targetY, Math.max(sheetSizeMTRef.current, maxSnap))
-  }
-
-  function getMaxSnapSizeMT(points: number[], fitSize = 0) {
-    'main thread'
-    let max = fitSize
-    for (const point of points) {
-      const value = point === -1 ? fitSize : point
-      if (value > max) {
-        max = value
-      }
-    }
-    return max
   }
 
   function setSheetMTRef(el: MainThread.Element) {
@@ -389,10 +372,6 @@ export function useSnap({
       resolvedSnapOffsetsMTRef.current = innerSnapOffsets.map(o =>
         o === -1 ? fitSize : o
       )
-      if (!hasOnlyFitSnapPoints) {
-        updateContentSizeMT(getMaxSnapSizeMT(innerSnapPointValues, fitSize))
-      }
-
       // Resolve any pending snap operation
       controller.resolvePendingSnapMT()
     } else if (contentSizeMTRef.current !== maxSnapSize) {

--- a/packages/lynx-ui-sheet/src/hooks/useSnap.ts
+++ b/packages/lynx-ui-sheet/src/hooks/useSnap.ts
@@ -27,6 +27,7 @@ import {
   getDefaultRubberBand,
   getMainAxisLayoutSize,
   getMainAxisSize,
+  getMaxSnapSize,
   getSheetTransform,
   isHorizontalSide,
   resolveSheetSide,
@@ -94,8 +95,11 @@ export function useSnap({
   const effectiveRubberBand = rubberBand ?? getDefaultRubberBand(resolvedSide)
   const allowOverDrag = effectiveRubberBand !== false
   const sheetMTRef = useMainThreadRef<MainThread.Element | null>(null)
+  const contentMTRef = useMainThreadRef<MainThread.Element | null>(null)
   const yRef = useMotionValueRef<number>(0)
   const sheetSizeMTRef = useMainThreadRef<number>(0)
+  const contentSizeMTRef = useMainThreadRef<number>(0)
+  const fitSizeMTRef = useMainThreadRef<number>(0)
   const currentSnapIndex = useMainThreadRef<number>(initialSnap)
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -120,6 +124,10 @@ export function useSnap({
     () => snapPoints.some(p => String(p).trim() === 'fit'),
     [snapPoints],
   )
+  const hasOnlyFitSnapPoints = useMemo(
+    () => snapPoints.every(p => String(p).trim() === 'fit'),
+    [snapPoints],
+  )
 
   // Keep snap points order stable: indices should match `snapPoints` order.
   const { snapPointValues, snapOffsets } = useMemo(() => {
@@ -135,6 +143,7 @@ export function useSnap({
   const maxOffset = validOffsets.length > 0
     ? Math.max(...validOffsets)
     : 0
+  const maxSnapSize = getMaxSnapSize(snapPointValues)
 
   function getResolvedSnapOffsets() {
     'main thread'
@@ -161,6 +170,27 @@ export function useSnap({
   function setSheetMTRef(el: MainThread.Element) {
     'main thread'
     sheetMTRef.current = el
+  }
+
+  function setContentMTRef(el: MainThread.Element) {
+    'main thread'
+    contentMTRef.current = el
+  }
+
+  function updateContentSizeMT(size: number) {
+    'main thread'
+    contentSizeMTRef.current = size
+    const el = contentMTRef.current
+    if (!el) return
+    if (isHorizontalSide(resolvedSide)) {
+      el.setStyleProperties({
+        width: `${size}px`,
+      })
+    } else {
+      el.setStyleProperties({
+        height: `${size}px`,
+      })
+    }
   }
 
   useMotionValueRefEvent(yRef, 'change', v => {
@@ -342,20 +372,29 @@ export function useSnap({
     const innerSnapOffsets = snapOffsets
 
     if (hasFitSnapPoint) {
+      if (fitSizeMTRef.current === 0 && layoutSize <= 0) return
+      const fitSize = layoutSize > 0 ? layoutSize : fitSizeMTRef.current
+      fitSizeMTRef.current = fitSize
       resolvedSnapPointMTRef.current = innerSnapPointValues.map(v =>
-        v === -1 ? layoutSize : v
+        v === -1 ? fitSize : v
       )
       resolvedSnapOffsetsMTRef.current = innerSnapOffsets.map(o =>
-        o === -1 ? layoutSize : o
+        o === -1 ? fitSize : o
       )
+      if (!hasOnlyFitSnapPoints) {
+        updateContentSizeMT(getMaxSnapSize(innerSnapPointValues, fitSize))
+      }
 
       // Resolve any pending snap operation
       controller.resolvePendingSnapMT()
+    } else if (contentSizeMTRef.current !== maxSnapSize) {
+      updateContentSizeMT(maxSnapSize)
     }
   }
 
   return {
     setSheetMTRef,
+    setContentMTRef,
     snapTo,
     expand,
     collapse,
@@ -378,6 +417,7 @@ export function useSnap({
     snapPointValues,
     minOffset,
     maxOffset,
+    maxSnapSize,
     getClampedValueMT,
     animateToMT,
     nearestSnapMT,

--- a/packages/lynx-ui-sheet/src/types/index.docs.ts
+++ b/packages/lynx-ui-sheet/src/types/index.docs.ts
@@ -150,12 +150,14 @@ export interface SheetRootProps extends ComponentBasicProps {
    */
   side?: SheetSide
   /**
-   * Whether logical drawer sides should resolve in RTL mode.
+   * Whether the Sheet should use RTL direction.
+   * This sets the Sheet viewport direction to `rtl` by default and resolves
+   * logical drawer sides in RTL mode.
    * When false, `start` means left and `end` means right.
    * When true, `start` means right and `end` means left.
    * Physical `left` and `right` sides are not affected by `enableRTL`.
    * @defaultValue false
-   * @zh 是否以 RTL 模式解析逻辑抽屉方向。为 false 时，`start` 为左侧、`end` 为右侧；为 true 时，`start` 为右侧、`end` 为左侧。物理 `left` 和 `right` 不受 `enableRTL` 影响。
+   * @zh Sheet 是否使用 RTL 方向。默认会将 Sheet 视口方向设置为 `rtl`，并以 RTL 模式解析逻辑抽屉方向。为 false 时，`start` 为左侧、`end` 为右侧；为 true 时，`start` 为右侧、`end` 为左侧。物理 `left` 和 `right` 不受 `enableRTL` 影响。
    */
   enableRTL?: boolean
   /**

--- a/packages/lynx-ui-sheet/src/utils/direction.ts
+++ b/packages/lynx-ui-sheet/src/utils/direction.ts
@@ -125,7 +125,6 @@ export function getNextMainAxisOffset(
 export function getSheetTransform(
   side: SheetResolvedSide,
   value: number,
-  viewportSize: number,
 ) {
   'main thread'
   if (side === 'bottom') {
@@ -135,7 +134,7 @@ export function getSheetTransform(
     return `translate(0px, ${value}px)`
   }
   if (side === 'left') {
-    return `translate(${value - viewportSize}px, 0px)`
+    return `translate(${value}px, 0px)`
   }
-  return `translate(${viewportSize - value}px, 0px)`
+  return `translate(${-value}px, 0px)`
 }

--- a/packages/lynx-ui-sheet/src/utils/direction.ts
+++ b/packages/lynx-ui-sheet/src/utils/direction.ts
@@ -88,6 +88,20 @@ export function getMainAxisLayoutSize(
     : event.detail?.height ?? event.params?.height ?? 0
 }
 
+export function getMaxSnapSize(
+  snapPoints: number[],
+  fitSize = 0,
+) {
+  let max = fitSize
+  for (const snapPoint of snapPoints) {
+    const value = snapPoint === -1 ? fitSize : snapPoint
+    if (value > max) {
+      max = value
+    }
+  }
+  return max
+}
+
 export function getMainAxisTouchCoordinate(
   side: SheetResolvedSide,
   detail: Pick<MainThread.TouchEvent['detail'], 'x' | 'y'>,

--- a/packages/lynx-ui-sheet/src/utils/index.test.ts
+++ b/packages/lynx-ui-sheet/src/utils/index.test.ts
@@ -111,17 +111,17 @@ describe('sheet side utils', () => {
   })
 
   it('computes the expected transforms for each resolved side', () => {
-    expect(getSheetTransform('top', 120, 360)).toBe(
+    expect(getSheetTransform('top', 120)).toBe(
       'translate(0px, 120px)',
     )
-    expect(getSheetTransform('bottom', 120, 360)).toBe(
+    expect(getSheetTransform('bottom', 120)).toBe(
       'translate(0px, -120px)',
     )
-    expect(getSheetTransform('left', 120, 360)).toBe(
-      'translate(-240px, 0px)',
+    expect(getSheetTransform('left', 120)).toBe(
+      'translate(120px, 0px)',
     )
-    expect(getSheetTransform('right', 120, 360)).toBe(
-      'translate(240px, 0px)',
+    expect(getSheetTransform('right', 120)).toBe(
+      'translate(-120px, 0px)',
     )
   })
 })

--- a/packages/lynx-ui-sheet/src/utils/index.test.ts
+++ b/packages/lynx-ui-sheet/src/utils/index.test.ts
@@ -9,6 +9,7 @@ import {
   getDefaultRubberBand,
   getMainAxisLayoutSize,
   getMainAxisSize,
+  getMaxSnapSize,
   getNextMainAxisOffset,
   getSheetTransform,
   resolveSheetSide,
@@ -69,6 +70,12 @@ describe('sheet side utils', () => {
         detail: { height: 420, width: 260 },
       }),
     ).toBe(260)
+  })
+
+  it('uses the highest resolved snap point as the stable layout size', () => {
+    expect(getMaxSnapSize([400, 800])).toBe(800)
+    expect(getMaxSnapSize([400, -1, 800], 520)).toBe(800)
+    expect(getMaxSnapSize([400, -1, 800], 920)).toBe(920)
   })
 
   it('uses vertical gesture angles for vertical sheets', () => {

--- a/packages/lynx-ui-sheet/src/utils/index.ts
+++ b/packages/lynx-ui-sheet/src/utils/index.ts
@@ -8,6 +8,7 @@ export {
   getDefaultRubberBand,
   getMainAxisLayoutSize,
   getMainAxisSize,
+  getMaxSnapSize,
   getMainAxisTouchCoordinate,
   getNextMainAxisOffset,
   getSheetTransform,


### PR DESCRIPTION
Updates Sheet sizing so percentage and pixel snap points provide a stable inner layout size based on the highest resolved snap point. This gives flexible children a predictable height or width basis while keeping `fit` content-driven for auto-height sheets.

Adds focused utility coverage and a changeset for the sheet package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Use the highest resolved snap point as the stable inner layout size so flexible children receive a predictable main-axis basis while preserving content-driven sizing for sheets that use only `fit` snap points.

- Add getMaxSnapSize(snapPoints, fitSize?) utility to compute the highest resolved snap size and treat `-1` as the `fit` placeholder
- Re-export getMaxSnapSize from packages/lynx-ui-sheet utilities
- Update useSnap to derive maxSnapSize, expose setContentMTRef and maxSnapSize, track content/fit measurements, and conditionally update inner content sizing based on resolved max and fit behavior
- Update SheetContent to bind main-thread ref, apply width/height constraints to the inner content container using maxSnapSize when the sheet is not solely `fit`, and adjust outer container layout/transforms for horizontal and vertical sides
- Adjust getSheetTransform signature and horizontal translation logic to use side-sign translations
- Add unit tests for getMaxSnapSize and update transform expectations to match new translation behavior
- Document stable inner layout sizing behavior in packages/lynx-ui-sheet/SKILL.md
- Add changesets to bump `@lynx-js/lynx-ui-sheet` with patch notes about stable inner layout sizing and related fixes
- Update examples (AutoHeight and Directional) to include separate demos for pure `fit`, mixed `fit + 80%`, and RTL drawer behaviors
- Prevent pointer/touch passthrough on SheetHandle by setting event-through={false}

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-ui/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->