### PR TITLE
chore(luna): bump luna devDeps to 0.5.0

### DIFF
--- a/.changeset/gentle-jeans-vanish.md
+++ b/.changeset/gentle-jeans-vanish.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/luna-core": minor
+---
+
+Export `parseLunaThemeKey` and `inferThemeVariant` helpers.

--- a/.changeset/shy-bananas-post.md
+++ b/.changeset/shy-bananas-post.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/luna-tailwind": minor
+---
+
+Add the `luna-gradient-afterglow` utility class.

--- a/.changeset/slick-turtles-drum.md
+++ b/.changeset/slick-turtles-drum.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/luna-reactlynx": patch
+---
+
+Avoid unnecessary syntax transforms.

--- a/.changeset/sour-terms-smell.md
+++ b/.changeset/sour-terms-smell.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/luna-tokens": patch
+---
+
+Clarify token roles.

--- a/luna/packages/luna-core/README.md
+++ b/luna/packages/luna-core/README.md
@@ -22,13 +22,13 @@ pnpm add @lynx-js/luna-core
 ### Pair With Tokens (Get Concrete Color Values)
 
 ```ts
-import type { LunaThemeTokens } from '@lynx-js/luna-core'
-import { lunarisDarkTokens } from '@lynx-js/luna-tokens'
+import type { LunaThemeTokens } from '@lynx-js/luna-core';
+import { lunarisDarkTokens } from '@lynx-js/luna-tokens';
 
-const theme: LunaThemeTokens = lunarisDarkTokens
+const theme: LunaThemeTokens = lunarisDarkTokens;
 
-const primary = theme.colors['primary']
-const contentMuted = theme.colors['content-muted']
+const primary = theme.colors['primary'];
+const contentMuted = theme.colors['content-muted'];
 ```
 
 ### ColorId / ColorKey
@@ -42,25 +42,25 @@ import {
   colorIdToColorKey,
   colorKeyToColorId,
   createEmptyLunaColors,
-} from '@lynx-js/luna-core'
+} from '@lynx-js/luna-core';
 
-const firstId = LUNA_COLOR_IDS[0]
-const key = colorIdToColorKey('primary-content')
-const id = colorKeyToColorId('primaryContent')
+const firstId = LUNA_COLOR_IDS[0];
+const key = colorIdToColorKey('primary-content');
+const id = colorKeyToColorId('primaryContent');
 
-const emptyColors = createEmptyLunaColors()
-emptyColors.primary = '#ff8ab5'
+const emptyColors = createEmptyLunaColors();
+emptyColors.primary = '#ff8ab5';
 ```
 
 ### Theme Resolver (Pick the Best Match From an Allowlist)
 
 ```ts
-import { resolveThemeKeyFromList } from '@lynx-js/luna-core'
+import { resolveThemeKeyFromList } from '@lynx-js/luna-core';
 
-const allowed = ['luna-light', 'lunaris-dark'] as const
+const allowed = ['luna-light', 'lunaris-dark'] as const;
 
-const resolved1 = resolveThemeKeyFromList(allowed, 'lunaris-light')
-const resolved2 = resolveThemeKeyFromList(allowed, 'luna-dark')
+const resolved1 = resolveThemeKeyFromList(allowed, 'lunaris-light');
+const resolved2 = resolveThemeKeyFromList(allowed, 'luna-dark');
 ```
 
 ## LUNA Packages

--- a/luna/packages/luna-core/package.json
+++ b/luna/packages/luna-core/package.json
@@ -40,7 +40,7 @@
     "sync:readme": "node ./scripts/sync-readme.mjs"
   },
   "devDependencies": {
-    "@dugyu/luna-core": "0.3.1"
+    "@dugyu/luna-core": "0.5.0"
   },
   "publishConfig": {
     "access": "public"

--- a/luna/packages/luna-reactlynx/README.md
+++ b/luna/packages/luna-reactlynx/README.md
@@ -25,8 +25,8 @@ pnpm add @lynx-js/luna-reactlynx @lynx-js/luna-styles
 
 ## Entry points
 
-| Entry                                          | Contents                                                |
-| ---------------------------------------------- | ------------------------------------------------------- |
+| Entry                                        | Contents                                                |
+| -------------------------------------------- | ------------------------------------------------------- |
 | `@lynx-js/luna-reactlynx`                      | Provider, hooks, `createLunaTheme`, type re-exports     |
 | `@lynx-js/luna-reactlynx/theming`              | Theming-only subpath                                    |
 | `@lynx-js/luna-reactlynx/runtime`              | Runtime shell (`LunaTheme`)                             |
@@ -43,13 +43,13 @@ import {
   LunaThemeProvider,
   createLunaTheme,
   useLunaColors,
-} from '@lynx-js/luna-reactlynx'
-import { lunarisDarkTokens, lunarisLightTokens } from '@lynx-js/luna-tokens'
+} from '@lynx-js/luna-reactlynx';
+import { lunarisDarkTokens, lunarisLightTokens } from '@lynx-js/luna-tokens';
 
 const themes = [
   createLunaTheme(lunarisLightTokens),
   createLunaTheme(lunarisDarkTokens),
-]
+];
 
 export function App() {
   return (
@@ -59,12 +59,12 @@ export function App() {
     >
       <Demo />
     </LunaThemeProvider>
-  )
+  );
 }
 
 function Demo() {
-  const colors = useLunaColors()
-  return <view style={{ backgroundColor: colors.canvas }} />
+  const colors = useLunaColors();
+  return <view style={{ backgroundColor: colors.canvas }} />;
 }
 ```
 
@@ -73,7 +73,7 @@ function Demo() {
 ```tsx
 <LunaThemeProvider theme={createLunaTheme(lunarisLightTokens)}>
   {children}
-</LunaThemeProvider>
+</LunaThemeProvider>;
 ```
 
 ### Color consumption format
@@ -94,15 +94,15 @@ Supported output shapes:
 Example:
 
 ```tsx
-import { useLunaColor } from '@lynx-js/luna-reactlynx'
+import { useLunaColor } from '@lynx-js/luna-reactlynx';
 
-const getValue = useLunaColor({ format: 'value' })
-const getVarRef = useLunaColor({ format: 'var-ref' })
-const getVarName = useLunaColor({ as: 'var-name' })
+const getValue = useLunaColor({ format: 'value' });
+const getVarRef = useLunaColor({ format: 'var-ref' });
+const getVarName = useLunaColor({ as: 'var-name' });
 
-getValue('primary') // '#ff1a6e' (values-backed theme only)
-getVarRef('primary') // 'var(--primary)'
-getVarName('primary') // '--primary'
+getValue('primary'); // '#ff1a6e' (values-backed theme only)
+getVarRef('primary'); // 'var(--primary)'
+getVarName('primary'); // '--primary'
 ```
 
 #### CSS var prefix
@@ -114,24 +114,24 @@ import {
   LunaThemeProvider,
   createLunaTheme,
   useLunaColor,
-} from '@lynx-js/luna-reactlynx'
-import { lunarisLightTokens } from '@lynx-js/luna-tokens'
+} from '@lynx-js/luna-reactlynx';
+import { lunarisLightTokens } from '@lynx-js/luna-tokens';
 
 const theme = createLunaTheme(lunarisLightTokens, {
   consumptionFormat: 'var-ref',
   cssVarPrefix: 'luna',
-})
+});
 
 <LunaThemeProvider theme={theme}>
   <Demo />
-</LunaThemeProvider>
+</LunaThemeProvider>;
 
 function Demo() {
-  const getColor = useLunaColor()
-  getColor('primary') // 'var(--luna-primary)'
+  const getColor = useLunaColor();
+  getColor('primary'); // 'var(--luna-primary)'
 
-  const getUnprefixed = useLunaColor({ cssVarPrefix: '' })
-  getUnprefixed('primary') // 'var(--primary)'
+  const getUnprefixed = useLunaColor({ cssVarPrefix: '' });
+  getUnprefixed('primary'); // 'var(--primary)'
 }
 ```
 
@@ -144,15 +144,15 @@ Import the LUNA stylesheet globally, then apply a theme class (e.g., `lunaris-li
 If you prefer to manage the class yourself, you can skip `LunaTheme` entirely:
 
 ```tsx
-import '@lynx-js/luna-styles/index.css'
-import './app.css'
+import '@lynx-js/luna-styles/index.css';
+import './app.css';
 
 export function App() {
   return (
     <page className='lunaris-light'>
       <view className='app' />
     </page>
-  )
+  );
 }
 ```
 
@@ -161,15 +161,15 @@ export function App() {
 ### Inline style (Lynx SDK >= 3.6)
 
 ```tsx
-import { LunaTheme } from '@lynx-js/luna-reactlynx/runtime'
-import '@lynx-js/luna-styles/index.css'
+import { LunaTheme } from '@lynx-js/luna-reactlynx/runtime';
+import '@lynx-js/luna-styles/index.css';
 
 export function App() {
   return (
     <LunaTheme>
       <view style={{ backgroundColor: 'var(--canvas)' }} />
     </LunaTheme>
-  )
+  );
 }
 ```
 
@@ -182,7 +182,7 @@ export function App() {
 **Optional:** for typed `lynx.__globalProps.lunaTheme`, import the augmentation once at your app entry:
 
 ```ts
-import '@lynx-js/luna-reactlynx/runtime/global-props'
+import '@lynx-js/luna-reactlynx/runtime/global-props';
 ```
 
 ### Tailwind (Lynx SDK < 3.6 friendly)
@@ -190,8 +190,8 @@ import '@lynx-js/luna-reactlynx/runtime/global-props'
 If you use Tailwind, pair `@lynx-js/luna-styles` (variables) with `@lynx-js/luna-tailwind` (utilities). Then you can consume colors via semantic utilities like `bg-canvas` / `text-content` without relying on inline `var(...)`.
 
 ```tsx
-import { LunaTheme } from '@lynx-js/luna-reactlynx/runtime'
-import '@lynx-js/luna-styles/index.css'
+import { LunaTheme } from '@lynx-js/luna-reactlynx/runtime';
+import '@lynx-js/luna-styles/index.css';
 
 export function App() {
   return (
@@ -200,7 +200,7 @@ export function App() {
         <text className='text-content'>Hello</text>
       </view>
     </LunaTheme>
-  )
+  );
 }
 ```
 
@@ -216,16 +216,16 @@ Consume `var(--xxx)` in a stylesheet, then reference it by `className`:
 ```
 
 ```tsx
-import { LunaTheme } from '@lynx-js/luna-reactlynx/runtime'
-import '@lynx-js/luna-styles/index.css'
-import './app.css'
+import { LunaTheme } from '@lynx-js/luna-reactlynx/runtime';
+import '@lynx-js/luna-styles/index.css';
+import './app.css';
 
 export function App() {
   return (
     <LunaTheme>
       <view className='app' />
     </LunaTheme>
-  )
+  );
 }
 ```
 
@@ -243,7 +243,7 @@ In other words, `LunaTheme` is a convenience for applying the theme class; if yo
 |                                                        | JS Tokens        | CSS Variables                     |
 | ------------------------------------------------------ | ---------------- | --------------------------------- |
 | Color consumption                                      | Raw values in JS | `var(--xxx)` / Tailwind utilities |
-| Already using `@lynx-js/luna-styles`                   | —                | ✓                                 |
+| Already using `@lynx-js/luna-styles`                     | —                | ✓                                 |
 | Need theme object in JS (e.g. animation, inline style) | ✓                | —                                 |
 
 ## LUNA Packages

--- a/luna/packages/luna-reactlynx/package.json
+++ b/luna/packages/luna-reactlynx/package.json
@@ -56,7 +56,7 @@
     "@lynx-js/luna-core": "workspace:*"
   },
   "devDependencies": {
-    "@dugyu/luna-reactlynx": "0.3.1",
+    "@dugyu/luna-reactlynx": "0.5.0",
     "@lynx-js/react": "catalog:",
     "@lynx-js/types": "catalog:",
     "@types/react": "catalog:"

--- a/luna/packages/luna-styles/README.md
+++ b/luna/packages/luna-styles/README.md
@@ -62,7 +62,7 @@ function App() {
     <view className='canvas lunaris-dark luna-gradient-rose'>
       {/* Your Demo */}
     </view>
-  )
+  );
 }
 ```
 

--- a/luna/packages/luna-styles/package.json
+++ b/luna/packages/luna-styles/package.json
@@ -54,7 +54,7 @@
     "sync:readme": "node ./scripts/sync-readme.mjs"
   },
   "devDependencies": {
-    "@dugyu/luna-styles": "0.3.1"
+    "@dugyu/luna-styles": "0.5.0"
   },
   "publishConfig": {
     "access": "public"

--- a/luna/packages/luna-tailwind/README.md
+++ b/luna/packages/luna-tailwind/README.md
@@ -22,18 +22,26 @@ pnpm add @lynx-js/luna-styles
 Add the preset to your `tailwind.config.ts`:
 
 ```ts
-import LynxPreset from '@lynx-js/tailwind-preset'
-import type { Config } from 'tailwindcss'
+import type { Config } from 'tailwindcss';
 
-import { LunaPreset } from '@lynx-js/luna-tailwind'
+import LynxPreset from '@lynx-js/tailwind-preset';
+
+import { LunaPreset } from '@lynx-js/luna-tailwind';
 
 const config: Config = {
-  content: [],
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
   presets: [LynxPreset, LunaPreset],
-}
+};
 
-export default config
+export default config;
 ```
+
+Tailwind on Lynx requires `@lynx-js/tailwind-preset` for runtime compatibility.
+
+Some Tailwind integrations can provide source scanning automatically, so the
+`content` field may not be required in every setup. For example, when using
+`rsbuild-plugin-tailwindcss` the plugin replaces Tailwind's `content` config at
+build time.
 
 Import LUNA theme variables once (global stylesheet):
 
@@ -48,7 +56,7 @@ Import LUNA theme variables once (global stylesheet):
 ## Usage
 
 ```tsx
-import { Button } from '@lynx-js/lynx-ui'
+import { Button } from '@lynx-js/lynx-ui';
 
 function App() {
   return (
@@ -57,7 +65,7 @@ function App() {
         <text className='text-primary-content'>Button</text>
       </Button>
     </view>
-  )
+  );
 }
 ```
 
@@ -65,10 +73,11 @@ function App() {
 
 This preset also ships gradient classes that use the LUNA gradient tokens:
 
-- `luna-gradient`
-- `luna-gradient-rose`
-- `luna-gradient-berry`
-- `luna-gradient-ocean`
+- `luna-gradient` — the full signature gradient, spanning the complete LUNA color journey.
+- `luna-gradient-rose` — a warm rose gradient for soft pink surfaces.
+- `luna-gradient-berry` — a richer berry gradient with a warmer, more saturated lower glow.
+- `luna-gradient-afterglow` — an angled pink-to-lavender gradient inspired by the lingering glow after sunset.
+- `luna-gradient-ocean` — a cool lavender-to-aqua gradient inspired by atmospheric haze and moonlit tides.
 
 ## LUNA Packages
 

--- a/luna/packages/luna-tailwind/package.json
+++ b/luna/packages/luna-tailwind/package.json
@@ -43,7 +43,7 @@
     "@lynx-js/luna-core": "workspace:*"
   },
   "devDependencies": {
-    "@dugyu/luna-tailwind": "0.3.1",
+    "@dugyu/luna-tailwind": "0.5.0",
     "tailwindcss": "catalog:tailwind"
   },
   "peerDependencies": {

--- a/luna/packages/luna-tokens/README.md
+++ b/luna/packages/luna-tokens/README.md
@@ -39,12 +39,12 @@ The default foundation. Luna is neutral and intentionally unopinionated — suit
 
 Surfaces form a layered system from background to foreground, defined by how they are perceived rather than by explicit elevation.
 
-| Token            | Role                                                             |
-| ---------------- | ---------------------------------------------------------------- |
-| `canvas-ambient` | Deepest background, diffused, structural, below all content      |
-| `canvas`         | Base surface, where interface begins                             |
-| `paper`          | Primary surface, distinct from the background, used for content  |
-| `paper-clear`    | Nested surface within `paper`, perceptible only through contrast |
+| Token            | Role                                                                   |
+| ---------------- | ---------------------------------------------------------------------- |
+| `canvas-ambient` | Deepest background, diffused, structural, below all content            |
+| `canvas`         | Base surface, where interface begins                                   |
+| `paper`          | Primary content surfaces such as cards and panels                      |
+| `paper-clear`    | Floating surfaces that lift above `paper`, such as popovers and sheets |
 
 Two translucent layers are derived from the canvas(background) direction. They dissolve a surface toward the environment — the surface recedes, blending into the background.
 
@@ -73,13 +73,13 @@ Semi-transparent variants for foreground elements. These describe the element's 
 
 ### Primary
 
-| Token                   | Role                                   |
-| ----------------------- | -------------------------------------- |
-| `primary`               | Brand accent, interactive highlight    |
-| `primary-2`             | Stronger primary variant               |
-| `primary-muted`         | Subdued primary, used for backgrounds  |
-| `primary-content`       | Text/icons on top of primary           |
-| `primary-content-faded` | Reduced-presence text/icons on primary |
+| Token                   | Role                                        |
+| ----------------------- | ------------------------------------------- |
+| `primary`               | Brand accent, interactive highlight         |
+| `primary-2`             | Variant of `primary` used for active states |
+| `primary-muted`         | Subdued primary, used for backgrounds       |
+| `primary-content`       | Text/icons on top of primary                |
+| `primary-content-faded` | Reduced-presence text/icons on primary      |
 
 ### Secondary
 
@@ -88,7 +88,7 @@ Semi-transparent variants for foreground elements. These describe the element's 
 | Token                     | Role                                     |
 | ------------------------- | ---------------------------------------- |
 | `secondary`               | Supporting accent                        |
-| `secondary-2`             | Deeper secondary variant                 |
+| `secondary-2`             | Softened variant of `secondary`          |
 | `secondary-content`       | Text/icons on top of secondary           |
 | `secondary-content-faded` | Reduced-presence text/icons on secondary |
 
@@ -130,10 +130,13 @@ Backdrop tokens are full-screen scrim overlays operating at the spatial layer be
 
 ### Lines
 
-| Token  | Role                             |
-| ------ | -------------------------------- |
-| `line` | Subtle divider, semi-transparent |
-| `rule` | Solid divider                    |
+| Token  | Role                                                                     |
+| ------ | ------------------------------------------------------------------------ |
+| `line` | Thin, airy outlines around components such as buttons, inputs, and cards |
+| `rule` | Dividers that separate regions, such as list items or sections           |
+
+Use `line` to outline a component, and `rule` to separate one region from
+another. The distinction is about role, not weight.
 
 ### Gradient
 
@@ -213,19 +216,19 @@ pnpm add @lynx-js/luna-tokens
 ## Usage
 
 ```typescript
-import { lunarisDarkTokens, lunarisLightTokens } from '@lynx-js/luna-tokens'
-import { lunaDarkTokens, lunaLightTokens } from '@lynx-js/luna-tokens'
+import { lunarisDarkTokens, lunarisLightTokens } from '@lynx-js/luna-tokens';
+import { lunaDarkTokens, lunaLightTokens } from '@lynx-js/luna-tokens';
 
-const theme = lunarisDarkTokens
+const theme = lunarisDarkTokens;
 
-theme.key // "lunaris-dark"
-theme.variant // "lunaris"
-theme.mode // "dark"
+theme.key; // "lunaris-dark"
+theme.variant; // "lunaris"
+theme.mode; // "dark"
 
-const canvas = theme.colors['canvas']
-const paper = theme.colors['paper']
-const primary = theme.colors['primary']
-const contentMuted = theme.colors['content-muted']
+const canvas = theme.colors['canvas'];
+const paper = theme.colors['paper'];
+const primary = theme.colors['primary'];
+const contentMuted = theme.colors['content-muted'];
 ```
 
 This package exports token objects directly. You will not typically need to import from this package unless you are building a custom theme.

--- a/luna/packages/luna-tokens/package.json
+++ b/luna/packages/luna-tokens/package.json
@@ -60,7 +60,7 @@
     "sync:readme": "node ./scripts/sync-readme.mjs"
   },
   "devDependencies": {
-    "@dugyu/luna-tokens": "0.3.1"
+    "@dugyu/luna-tokens": "0.5.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -752,8 +752,8 @@ importers:
   luna/packages/luna-core:
     devDependencies:
       '@dugyu/luna-core':
-        specifier: 0.3.1
-        version: 0.3.1
+        specifier: 0.5.0
+        version: 0.5.0
 
   luna/packages/luna-reactlynx:
     dependencies:
@@ -762,8 +762,8 @@ importers:
         version: link:../luna-core
     devDependencies:
       '@dugyu/luna-reactlynx':
-        specifier: 0.3.1
-        version: 0.3.1(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(@lynx-js/types@3.6.0)(@types/react@18.3.28)
+        specifier: 0.5.0
+        version: 0.5.0(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(@lynx-js/types@3.6.0)(@types/react@18.3.28)
       '@lynx-js/react':
         specifier: 'catalog:'
         version: 0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28)
@@ -777,8 +777,8 @@ importers:
   luna/packages/luna-styles:
     devDependencies:
       '@dugyu/luna-styles':
-        specifier: 0.3.1
-        version: 0.3.1
+        specifier: 0.5.0
+        version: 0.5.0
 
   luna/packages/luna-tailwind:
     dependencies:
@@ -787,8 +787,8 @@ importers:
         version: link:../luna-core
     devDependencies:
       '@dugyu/luna-tailwind':
-        specifier: 0.3.1
-        version: 0.3.1(tailwindcss@3.4.17)
+        specifier: 0.5.0
+        version: 0.5.0(tailwindcss@3.4.17)
       tailwindcss:
         specifier: catalog:tailwind
         version: 3.4.17
@@ -796,8 +796,8 @@ importers:
   luna/packages/luna-tokens:
     devDependencies:
       '@dugyu/luna-tokens':
-        specifier: 0.3.1
-        version: 0.3.1
+        specifier: 0.5.0
+        version: 0.5.0
 
   packages/lynx-ui:
     dependencies:
@@ -2026,26 +2026,26 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@dugyu/luna-core@0.3.1':
-    resolution: {integrity: sha512-rhzP99G0ElhKRtfaa5E8R6OOwdOfwfnrXBAeFQLqj4sCtaQTI9fIPlFUg3juzsaE+RufivkHQHSlXtqii4UMAQ==}
+  '@dugyu/luna-core@0.5.0':
+    resolution: {integrity: sha512-2i/I9YedSrt8U9zMxB3JB2JEsh7/deS4zF7NTtQyinumOqPc9io1xSWzCAkOZEHIElfbqst2BwGKIyEDKx22mg==}
 
-  '@dugyu/luna-reactlynx@0.3.1':
-    resolution: {integrity: sha512-+Scqzz7escKWCPxap15x7OYUmo+15Hn3IKX3AYC0He8y6Bs5ePpKFlqIk1HX2Xu7HSj4uyU4Q1PhCVUojI9Ovg==}
+  '@dugyu/luna-reactlynx@0.5.0':
+    resolution: {integrity: sha512-LhOCPjjJXckPN6i0d5Bk/LF+twB7YDAfR/H3UjKluRzwMFpUVGkMAxu5YoRXHHDwSHFqxDEWluSO3sJrVvNYzA==}
     peerDependencies:
       '@lynx-js/react': '>=0.100.0'
       '@lynx-js/types': '*'
       '@types/react': ^18
 
-  '@dugyu/luna-styles@0.3.1':
-    resolution: {integrity: sha512-uxBPHXtuuW6XAUGUTyp67LC297zagkfuaQxgfi0r6VCT6EA+1oiZkJ4gOltspQx6NSmMBDDNCYPkduy+jQSwOQ==}
+  '@dugyu/luna-styles@0.5.0':
+    resolution: {integrity: sha512-YjBRDutd5KE2rlyXT6S6iYXTBioXz7NEmxIAL8C11Q0+rdjv+o0EoDIkWH0dBI40s/QMrR0gk0TGyfIwK658Tg==}
 
-  '@dugyu/luna-tailwind@0.3.1':
-    resolution: {integrity: sha512-PvHXmOpw+ZhYe5YASsGq8QAZgXChvEU8GH+zkn3TiNdwSCSZxi/BaLsNlsof4Nvf7ISI8NcbkyNKRfLjdJBxyQ==}
+  '@dugyu/luna-tailwind@0.5.0':
+    resolution: {integrity: sha512-FOIFCClFNO4WY84joPjZZLnLTT2IDN8VkNLZsTQOq4Su1WEZ4z64+EGwEdNzADVbsqCYWHx6IQhe460Wg2oMTg==}
     peerDependencies:
       tailwindcss: ^3.4.0
 
-  '@dugyu/luna-tokens@0.3.1':
-    resolution: {integrity: sha512-ZUUiIfJCWJBv0Pye2vB14lurg2urm2ubtyt6Xck/Q05a49ymQmMvVb3cgF2gnoHYJokayFBYsHhmRIG+GyS1jg==}
+  '@dugyu/luna-tokens@0.5.0':
+    resolution: {integrity: sha512-jct1eU7Y99z6ZbYfvuNymhcNNLQqlm2VDfqy4B+p9uXJETokZoXnRcmIzjbM9evk1nZ6ZtlBxCC1t9GyOrFJLA==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -7359,23 +7359,23 @@ snapshots:
   '@dprint/win32-x64@0.48.0':
     optional: true
 
-  '@dugyu/luna-core@0.3.1': {}
+  '@dugyu/luna-core@0.5.0': {}
 
-  '@dugyu/luna-reactlynx@0.3.1(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(@lynx-js/types@3.6.0)(@types/react@18.3.28)':
+  '@dugyu/luna-reactlynx@0.5.0(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(@lynx-js/types@3.6.0)(@types/react@18.3.28)':
     dependencies:
-      '@dugyu/luna-core': 0.3.1
+      '@dugyu/luna-core': 0.5.0
       '@lynx-js/react': 0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28)
       '@lynx-js/types': 3.6.0
       '@types/react': 18.3.28
 
-  '@dugyu/luna-styles@0.3.1': {}
+  '@dugyu/luna-styles@0.5.0': {}
 
-  '@dugyu/luna-tailwind@0.3.1(tailwindcss@3.4.17)':
+  '@dugyu/luna-tailwind@0.5.0(tailwindcss@3.4.17)':
     dependencies:
-      '@dugyu/luna-core': 0.3.1
+      '@dugyu/luna-core': 0.5.0
       tailwindcss: 3.4.17
 
-  '@dugyu/luna-tokens@0.3.1': {}
+  '@dugyu/luna-tokens@0.5.0': {}
 
   '@emnapi/core@1.10.0':
     dependencies:


### PR DESCRIPTION
- export new theme helpers from `@lynx-js/luna-core`
- add `luna-gradient-afterglow` support in `@lynx-js/luna-tailwind`
- reduce unnecessary syntax transforms in `@lynx-js/luna-reactlynx`
- clarify token role definitions in `@lynx-js/luna-tokens`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Bump luna devDependencies to 0.5.0 and update documentation:

- Bump `@lynx-js/luna-core` to 0.5.0 with exports for `parseLunaThemeKey` and `inferThemeVariant` helpers
- Bump `@lynx-js/luna-tailwind` to 0.5.0 and add `luna-gradient-afterglow` support in documentation
- Bump `@lynx-js/luna-reactlynx` to 0.5.0 to reduce unnecessary syntax transforms
- Bump `@lynx-js/luna-tokens` to 0.5.0 and clarify token role definitions in README
- Update package.json devDependencies across `luna-core`, `luna-reactlynx`, `luna-styles`, `luna-tailwind`, and `luna-tokens`
- Standardize code formatting in READMEs (semicolons, consistent punctuation, improved examples)
- Add changeset entries to track version bumps for affected packages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-ui/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->