### PR TITLE
fix(presence): handle interrupted visibility transitions

### DIFF
--- a/.changeset/steady-presence-overlays.md
+++ b/.changeset/steady-presence-overlays.md
@@ -1,0 +1,10 @@
+---
+"@lynx-example/lynx-ui-dialog": patch
+"@lynx-js/lynx-ui-presence": patch
+---
+
+Fix presence edge cases for rapid visibility toggles during enter and exit transitions:
+
+- Recover when an enter interrupts an in-progress exit.
+- Keep open and close callbacks balanced across interrupted transitions.
+- Remove mounted containers when dismissal occurs before entering starts.

--- a/apps/examples/Dialog/TimingRace/index.css
+++ b/apps/examples/Dialog/TimingRace/index.css
@@ -1,0 +1,195 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.lunaris-dark,
+.lunaris-light,
+.luna-dark,
+.luna-light {
+  --ease-out-smooth: cubic-bezier(0.22, 0.61, 0.36, 1);
+  --fade-duration: 220ms;
+  --font-semibold: 600;
+  --text-sm: 12px;
+  --lh-sm: 16px;
+  --text-base: 14px;
+  --lh-base: 18px;
+  --text-lg: 16px;
+  --lh-lg: 21px;
+}
+
+.demo-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 24px;
+  background-color: var(--primary-muted);
+  row-gap: 20px;
+}
+
+.toolbar {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  row-gap: 12px;
+}
+
+.demo-button,
+.probe-button {
+  width: 100%;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background-color: var(--neutral);
+  transition: background-color 150ms ease;
+}
+
+.demo-button.ui-active,
+.probe-button.ui-active {
+  background-color: var(--neutral-2);
+}
+
+.probe-button {
+  background-color: var(--primary);
+}
+
+.probe-button.ui-active {
+  background-color: var(--primary-2);
+}
+
+.demo-button-text,
+.probe-button-text,
+.dialog-action-text {
+  font-size: var(--text-base);
+  line-height: var(--lh-base);
+  font-weight: var(--font-semibold);
+  color: var(--neutral-content);
+}
+
+.probe-button-text {
+  color: var(--primary-content);
+}
+
+.dialog-viewport {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding-left: 24px;
+  padding-right: 24px;
+  overflow: hidden;
+}
+
+.dialog-backdrop {
+  background-color: var(--backdrop);
+  opacity: 0;
+  transition: opacity var(--fade-duration) var(--ease-out-smooth);
+}
+
+.dialog-backdrop.ui-open {
+  opacity: 1;
+}
+
+.dialog-backdrop.ui-closed {
+  opacity: 0;
+}
+
+.dialog-content {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px;
+  border-radius: 24px;
+  border: 1px solid var(--line);
+  background-color: var(--canvas);
+  opacity: 0;
+  transform: translateY(12px) scale(0.98);
+  transition:
+    opacity var(--fade-duration) var(--ease-out-smooth),
+    transform var(--fade-duration) var(--ease-out-smooth);
+}
+
+.dialog-content.ui-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.dialog-content.ui-closed {
+  opacity: 0;
+  transform: translateY(12px) scale(0.98);
+}
+
+.dialog-body {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  row-gap: 8px;
+  padding-bottom: 20px;
+}
+
+.dialog-title {
+  font-size: var(--text-lg);
+  line-height: var(--lh-lg);
+  font-weight: var(--font-semibold);
+  color: var(--content);
+}
+
+.dialog-desc {
+  font-size: var(--text-base);
+  line-height: var(--lh-base);
+  color: var(--content-muted);
+}
+
+.dialog-actions {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  row-gap: 10px;
+}
+
+.dialog-action {
+  width: 100%;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background-color: var(--primary);
+  transition: background-color 150ms ease;
+}
+
+.dialog-action.ui-active {
+  background-color: var(--primary-2);
+}
+
+.dialog-action-muted {
+  background-color: var(--neutral);
+}
+
+.dialog-action-muted.ui-active {
+  background-color: var(--neutral-2);
+}
+
+.event-log {
+  width: 100%;
+  min-height: 156px;
+  display: flex;
+  flex-direction: column;
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background-color: var(--canvas);
+  row-gap: 6px;
+}
+
+.event-text {
+  font-size: var(--text-sm);
+  line-height: var(--lh-sm);
+  color: var(--content-muted);
+}

--- a/apps/examples/Dialog/TimingRace/index.tsx
+++ b/apps/examples/Dialog/TimingRace/index.tsx
@@ -1,0 +1,146 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useEffect, useRef, useState } from '@lynx-js/react'
+
+import './index.css'
+
+import {
+  DialogBackdrop,
+  DialogClose,
+  DialogContent,
+  DialogRoot,
+  DialogTrigger,
+  DialogView,
+} from '@lynx-js/lynx-ui'
+
+const REOPEN_DELAY = 200
+
+function App() {
+  const [show, setShow] = useState(false)
+  const [pageTaps, setPageTaps] = useState(0)
+  const [events, setEvents] = useState<string[]>(['Ready'])
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([])
+  const eventCountRef = useRef(0)
+
+  const pushEvent = (message: string) => {
+    eventCountRef.current += 1
+    setEvents(prev =>
+      [
+        `${eventCountRef.current}. ${message}`,
+        ...prev,
+      ].slice(0, 8)
+    )
+  }
+
+  const clearTimers = () => {
+    timersRef.current.forEach(timer => clearTimeout(timer))
+    timersRef.current = []
+  }
+
+  const schedule = (delay: number, callback: () => void) => {
+    const timer = setTimeout(() => {
+      timersRef.current = timersRef.current.filter(item => item !== timer)
+      callback()
+    }, delay)
+    timersRef.current.push(timer)
+  }
+
+  const requestShow = (nextShow: boolean, source: string) => {
+    pushEvent(`${source}: show=${String(nextShow)}`)
+    setShow(nextShow)
+  }
+
+  const handleShowChange = (nextShow: boolean) => {
+    pushEvent(`onShowChange: show=${String(nextShow)}`)
+    setShow(nextShow)
+  }
+
+  const runCloseReopen = () => {
+    clearTimers()
+    requestShow(false, 'close')
+    schedule(REOPEN_DELAY, () => requestShow(true, 'reopen after 200ms'))
+  }
+
+  const runOverlayProbe = () => {
+    clearTimers()
+    pushEvent('overlay probe started')
+    setPageTaps(0)
+    requestShow(true, 'probe open')
+    schedule(120, () => requestShow(false, 'probe close before enter'))
+    schedule(320, () => requestShow(true, 'probe reopen'))
+    schedule(430, () => requestShow(false, 'probe final close'))
+    schedule(760, () => pushEvent('tap page probe now'))
+  }
+
+  const handlePageProbe = () => {
+    setPageTaps(count => count + 1)
+    pushEvent('page probe tapped')
+  }
+
+  useEffect(() => clearTimers, [])
+
+  return (
+    <view className='demo-container lunaris-dark'>
+      <view className='toolbar'>
+        <DialogRoot
+          onClose={() => pushEvent('onClose')}
+          onOpen={() => pushEvent('onOpen')}
+          show={show}
+          onShowChange={handleShowChange}
+        >
+          <DialogTrigger className='demo-button'>
+            <text className='demo-button-text'>Open</text>
+          </DialogTrigger>
+
+          <DialogView className='dialog-viewport'>
+            <DialogBackdrop className='dialog-backdrop' />
+
+            <DialogContent className='dialog-content'>
+              <view className='dialog-body'>
+                <text className='dialog-title'>Dialog timing probes</text>
+                <text className='dialog-desc'>
+                  Use these actions to interrupt enter and exit transitions.
+                </text>
+              </view>
+
+              <view className='dialog-actions'>
+                <view className='dialog-action' bindtap={runCloseReopen}>
+                  <text className='dialog-action-text'>
+                    Option: reopen 200ms
+                  </text>
+                </view>
+                <DialogClose className='dialog-action dialog-action-muted'>
+                  <text className='dialog-action-text'>Close</text>
+                </DialogClose>
+              </view>
+            </DialogContent>
+          </DialogView>
+        </DialogRoot>
+
+        <view className='demo-button' bindtap={runCloseReopen}>
+          <text className='demo-button-text'>Close/reopen</text>
+        </view>
+
+        <view className='demo-button' bindtap={runOverlayProbe}>
+          <text className='demo-button-text'>Overlay probe</text>
+        </view>
+
+        <view className='probe-button' bindtap={handlePageProbe}>
+          <text className='probe-button-text'>Page taps: {pageTaps}</text>
+        </view>
+      </view>
+
+      <view className='event-log'>
+        {events.map(event => (
+          <text className='event-text' key={event}>{event}</text>
+        ))}
+      </view>
+    </view>
+  )
+}
+
+root.render(<App />)
+
+export default App

--- a/apps/examples/Dialog/lynx.config.mjs
+++ b/apps/examples/Dialog/lynx.config.mjs
@@ -9,6 +9,7 @@ import { exampleConfig } from '../../../tools/configs/exampleConfig.mjs'
 const baseConfig = exampleConfig({
   DialogBasic: './Basic/index.tsx',
   DialogBasicTailwind: './BasicTailwind/index.tsx',
+  DialogTimingRace: './TimingRace/index.tsx',
 })
 
 const defaultConfig = defineConfig({

--- a/packages/lynx-ui-presence/src/usePresence.tsx
+++ b/packages/lynx-ui-presence/src/usePresence.tsx
@@ -40,6 +40,7 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
   const isKFAnimating = useRef<boolean>(false)
   // Track the initial render, to prevent effects from running on mount.
   const isInitialRender = useRef(true)
+  const hasNotifiedOpen = useRef(false)
   const showRef = useRef(show)
   // The core state to control the mounting and unmounting of the component.
   const [mount, setMount] = useState<boolean>(false)
@@ -55,6 +56,10 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
   const MAX_WAIT_FRAMES = 24
 
   showRef.current = show
+
+  const cancelShowTimer = () => {
+    showScheduleIdRef.current += 1
+  }
 
   const notAnimating = () => (isKFAnimating.current === false
     && isTransitionAnimating.current === false)
@@ -82,7 +87,12 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
       }
     }
     if (state === PresenceState.Leaving && notAnimating()) {
-      setPresenceState(PresenceState.Left)
+      cancelShowTimer()
+      if (showRef.current) {
+        setPresenceState(enteringStateWithDelay)
+      } else {
+        setPresenceState(PresenceState.Left)
+      }
     }
   }
 
@@ -147,11 +157,26 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
 
   // ==== state controller ====
   const handleStateEntered = () => {
+    if (hasNotifiedOpen.current) {
+      return
+    }
+    hasNotifiedOpen.current = true
     onOpen?.()
   }
 
   const handleStateLeft = () => {
-    if (!isInitialRender.current) {
+    if (showRef.current) {
+      log(
+        debugLog,
+        '[lynx-ui-presence][usePresence] skip mount=false because show=true (Left)',
+      )
+      setMount(true)
+      cancelShowTimer()
+      setPresenceState(enteringStateWithDelay)
+      return
+    }
+    if (!isInitialRender.current && hasNotifiedOpen.current) {
+      hasNotifiedOpen.current = false
       onClose?.()
     }
     log(debugLog, '[lynx-ui-presence][usePresence] set mount=false (Left)')
@@ -176,7 +201,12 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
           debugLog,
           `[lynx-ui-presence][usePresence] leaving timeout reached, loopId: ${loopId}, frames: ${leavingWaitFramesRef.current}`,
         )
-        setPresenceState(PresenceState.Left)
+        cancelShowTimer()
+        if (showRef.current) {
+          setPresenceState(enteringStateWithDelay)
+        } else {
+          setPresenceState(PresenceState.Left)
+        }
         return
       }
       leavingWaitFramesRef.current += 1
@@ -269,10 +299,12 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
         '[lynx-ui-presence][usePresence] show=false -> set PresenceState.Leaving',
       )
       setPresenceState(PresenceState.Leaving)
-    } else if (state === PresenceState.Initial && mount) {
+    } else if (
+      (state === PresenceState.Initial || state === PresenceState.Left) && mount
+    ) {
       log(
         debugLog,
-        '[lynx-ui-presence][usePresence] show=false in Initial -> set mount=false',
+        '[lynx-ui-presence][usePresence] show=false before entering -> set mount=false',
       )
       setMount(false)
     }
@@ -283,7 +315,7 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
       debugLog,
       `[lynx-ui-presence][usePresence] show effect show:${show}, enableDelay:${enableDelay}, state:${state}, mount:${mount}`,
     )
-    showScheduleIdRef.current += 1
+    cancelShowTimer()
     const scheduleId = showScheduleIdRef.current
     if (show) {
       handleShow(scheduleId)

--- a/packages/lynx-ui-presence/src/usePresenceGroup.tsx
+++ b/packages/lynx-ui-presence/src/usePresenceGroup.tsx
@@ -118,7 +118,6 @@ export const usePresenceGroup: (
       const count = prev - 1
       if (count === 0) {
         onClose?.()
-        setMountView(false)
       }
       return count
     })
@@ -177,8 +176,10 @@ export const usePresenceGroup: (
   useEffect(() => {
     if (show) {
       setMountView(true)
+    } else if (stateGroup.every(state => state === PresenceState.Left)) {
+      setMountView(false)
     }
-  }, [show])
+  }, [show, stateGroup])
 
   return {
     renderChildren,


### PR DESCRIPTION
Fixes dialogs and other presence-managed overlays becoming visually closed or retaining an invisible interaction-blocking layer when visibility changes rapidly during transitions.

- Recover correctly when an enter interrupts an in-progress exit.
- Balance open and close completion callbacks across interrupted transitions.
- Remove mounted overlay containers when dismissal occurs before entering starts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Handle interrupted visibility transitions in presence state management

- Add changeset entry for `@lynx-js/lynx-ui-presence` patch release documenting overlay cleanup fix
- Track open notifications with hasNotifiedOpen to prevent duplicate onOpen callbacks
- Cancel pending show scheduling via cancelShowTimer to avoid stale enter timers
- Recover to entering/delayed-entering if show reactivates during an in-progress exit (handleAnimationEnd and leaving timeout)
- Re-check show before settling to PresenceState.Left and immediately re-mount and re-enter when needed (handleStateLeft)
- Treat PresenceState.Initial and PresenceState.Left as "before entering" when dismissing with mount enabled to remove mounted containers prior to enter
- Balance onClose emission and mount/unmount sequencing when an enter interrupts a close
- Update usePresenceGroup to keep mountView enabled until all children reach PresenceState.Left and re-run effect on stateGroup changes
- Add Dialog timing-race example (TimingRace) with controls and event logging to reproduce and test rapid visibility toggles
- Include TimingRace stylesheet and register DialogTimingRace in examples config

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-ui/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->