### PR TITLE
feat(ui-list): add listProps escape hatch prop

### DIFF
--- a/.changeset/hot-tigers-call.md
+++ b/.changeset/hot-tigers-call.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/lynx-ui-list": patch
+---
+
+add listProps escape hatch prop
+
+add listProps to allow passing raw props to the underlying list element, as an escape hatch for uncovered platform attributes, and update related type definitions

--- a/packages/lynx-ui-list/src/index.tsx
+++ b/packages/lynx-ui-list/src/index.tsx
@@ -124,6 +124,7 @@ function ListImpl(props: ListProps, ref: ForwardedRef<ListRef>) {
     itemSnap,
     preloadBufferCount = 0,
     listMaxSize,
+    listProps,
     temporaryAndroidEnableOverflow = true,
     'main-thread:gesture': gesture,
     // @ts-expect-error Expected
@@ -504,6 +505,7 @@ function ListImpl(props: ListProps, ref: ForwardedRef<ListRef>) {
       }}
       main-thread:gesture={gesture}
       {...(itemSnap ? { 'item-snap': itemSnap } : {})}
+      {...listProps}
     >
       {children}
     </list>

--- a/packages/lynx-ui-list/src/types/index.docs.ts
+++ b/packages/lynx-ui-list/src/types/index.docs.ts
@@ -17,6 +17,7 @@ import type {
   CommonEvent,
   ListScrollStateChangeEvent,
   ListSnapEvent,
+  ListProps as elementListProps,
 } from '@lynx-js/types'
 
 export type List = (props: ListProps) => ReactElement
@@ -293,6 +294,14 @@ export interface ListProps
    * @Harmony
    */
   children?: ReactNode
+  /**
+   * Original list props to spread directly onto the underlying list element.
+   * This is an escape hatch for platform or engine attributes that are not yet covered by ListProps.
+   * @Android
+   * @iOS
+   * @Harmony
+   */
+  listProps?: elementListProps
   /**
    * Enable vertical scroll.
    * @zh 启用垂直滚动。


### PR DESCRIPTION
add listProps to allow passing raw props to the underlying list element, as an escape hatch for uncovered platform attributes, and update related type definitions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add `listProps` escape hatch prop to allow passing raw props to the underlying list element in `ListImpl`
- Update `ListProps` type definition to include optional `listProps` property with proper type aliasing from `@lynx-js/types`
- Add changeset documentation for patch release to `@lynx-js/lynx-ui-list`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-ui/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->