### PR TITLE
feat(select): add initial headless Select component and example

### DIFF
--- a/apps/examples/select/Basic/index.css
+++ b/apps/examples/select/Basic/index.css
@@ -1,0 +1,82 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.demo-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding-top: 48px;
+  padding-bottom: 24px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.demo-canvas {
+  width: 100%;
+  max-width: 420px;
+  border-radius: 16px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background-color: var(--canvas);
+  border: 1px solid var(--neutral-faint);
+}
+
+.luna-gradient-berry {
+  background: linear-gradient(
+    0deg,
+    var(--gradient-b),
+    var(--gradient-c)
+  );
+}
+
+.eyebrow {
+  font-size: 12px;
+  color: var(--content-subtle);
+}
+
+.title {
+  font-size: 16px;
+  color: var(--content-2);
+}
+
+.desc {
+  margin-bottom: 8px;
+  color: var(--content-subtle);
+  font-size: 13px;
+}
+
+.select-root {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.select-option {
+  display: flex;
+  align-items: center;
+  border-radius: 8px;
+  padding: 12px;
+  color: var(--content);
+  background-color: var(--neutral-faint);
+  border: 1px solid var(--neutral-faint);
+}
+
+.select-option.ui-selected {
+  color: var(--primary-content);
+  background-color: var(--primary-2);
+  border-color: var(--primary);
+}
+
+.select-option.ui-disabled {
+  opacity: 0.45;
+}
+
+.value {
+  margin-top: 8px;
+  color: var(--content-subtle);
+  font-size: 12px;
+}

--- a/apps/examples/select/Basic/index.tsx
+++ b/apps/examples/select/Basic/index.tsx
@@ -1,0 +1,49 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from '@lynx-js/react'
+
+import { Select } from '@lynx-js/lynx-ui'
+
+import './index.css'
+
+const options = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Orange', value: 'orange' },
+  { label: 'Banana', value: 'banana', disabled: true },
+]
+
+function App() {
+  const [value, setValue] = useState('apple')
+
+  return (
+    <view className='demo-container lunaris-dark luna-gradient-berry'>
+      <view className='demo-canvas'>
+        <text className='eyebrow'>
+          Forms
+        </text>
+        <text className='title'>
+          Select example
+        </text>
+        <text className='desc'>
+          Tap an option to switch the value
+        </text>
+        <Select
+          value={value}
+          onValueChange={setValue}
+          options={options}
+          className='select-root'
+          optionClassName='select-option'
+        />
+        <text className='value'>
+          Selected: {value}
+        </text>
+      </view>
+    </view>
+  )
+}
+
+root.render(<App />)
+
+export default App

--- a/apps/examples/select/lynx.config.mjs
+++ b/apps/examples/select/lynx.config.mjs
@@ -1,0 +1,11 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { exampleConfig } from '../../../tools/configs/exampleConfig.mjs'
+
+const defaultConfig = exampleConfig({
+  Basic: './Basic/index.tsx',
+})
+
+export default defaultConfig

--- a/apps/examples/select/package.json
+++ b/apps/examples/select/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@lynx-example/lynx-ui-select",
+  "version": "0.0.0",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-ui.git",
+    "directory": "apps/examples/select"
+  },
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "build:dev": "rspeedy build --mode=development",
+    "dev": "rspeedy dev",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@lynx-js/luna-styles": "workspace:*",
+    "@lynx-js/lynx-ui": "workspace:*",
+    "@lynx-js/react": "catalog:",
+    "clsx": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
+    "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rspeedy": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@types/react": "catalog:"
+  }
+}

--- a/apps/examples/select/tsconfig.json
+++ b/apps/examples/select/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["."],
+  "exclude": ["dist", "node_modules"],
+}

--- a/packages/lynx-ui-select/README.md
+++ b/packages/lynx-ui-select/README.md
@@ -1,0 +1,22 @@
+# @lynx-js/lynx-ui-select
+
+Headless Select component for lynx-ui.
+
+## Installation
+
+```bash
+npm install @lynx-js/lynx-ui-select
+```
+
+## Usage
+
+```tsx
+import { Select } from '@lynx-js/lynx-ui-select'
+
+<Select
+  options={[
+    { label: 'Apple', value: 'apple' },
+    { label: 'Orange', value: 'orange' },
+  ]}
+/>
+```

--- a/packages/lynx-ui-select/SKILL.md
+++ b/packages/lynx-ui-select/SKILL.md
@@ -1,0 +1,3 @@
+# Skill
+
+Description of skills.

--- a/packages/lynx-ui-select/package.json
+++ b/packages/lynx-ui-select/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@lynx-js/lynx-ui-select",
+  "version": "0.0.1",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Lynx Authors"
+  },
+  "sideEffects": false,
+  "type": "module",
+  "main": "./dist/index.jsx",
+  "module": "./dist/index.jsx",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "src/**",
+    "README.md",
+    "CHANGELOG.md",
+    "tsconfig.docs.json",
+    "tsconfig.json",
+    "dist/**"
+  ],
+  "scripts": {
+    "build": "rslib build",
+    "build:watch": "rslib build --watch",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@lynx-js/lynx-ui-common": "workspace:*",
+    "clsx": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/react": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@rslib/core": "catalog:",
+    "@types/react": "catalog:",
+    "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "@lynx-js/react": ">=0.100.0",
+    "@lynx-js/types": "*",
+    "@types/react": "^18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "jsnext:source": "./src/index.tsx"
+}

--- a/packages/lynx-ui-select/rslib.config.ts
+++ b/packages/lynx-ui-select/rslib.config.ts
@@ -1,0 +1,8 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from '@rslib/core'
+import { baseConfig } from '../../tools/configs/rslib.base.js'
+
+export default defineConfig(baseConfig)

--- a/packages/lynx-ui-select/src/Select.tsx
+++ b/packages/lynx-ui-select/src/Select.tsx
@@ -1,0 +1,63 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { useState } from '@lynx-js/react'
+
+import { useMemoizedFn } from '@lynx-js/lynx-ui-common'
+import { clsx } from 'clsx'
+
+import type { SelectProps } from './types'
+
+export const Select = (props: SelectProps) => {
+  const {
+    value,
+    defaultValue,
+    options,
+    onValueChange,
+    className,
+    style,
+    optionClassName,
+    optionStyle,
+    containerProps,
+    optionProps,
+  } = props
+
+  const isControlled = value !== undefined
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue)
+  const actualValue = isControlled ? value : uncontrolledValue
+
+  const handleOptionClick = useMemoizedFn((nextValue: string) => {
+    if (!isControlled) {
+      setUncontrolledValue(nextValue)
+    }
+    onValueChange?.(nextValue)
+  })
+
+  return (
+    <view className={className} style={style} {...containerProps}>
+      {options.map((option) => {
+        const selected = option.value === actualValue
+        const disabled = option.disabled ?? false
+
+        return (
+          <view
+            key={option.value}
+            bindtap={() => {
+              if (disabled) return
+              handleOptionClick(option.value)
+            }}
+            className={clsx(optionClassName, {
+              'ui-selected': selected,
+              'ui-disabled': disabled,
+            })}
+            style={optionStyle}
+            {...optionProps}
+          >
+            <text>{option.label}</text>
+          </view>
+        )
+      })}
+    </view>
+  )
+}

--- a/packages/lynx-ui-select/src/index.tsx
+++ b/packages/lynx-ui-select/src/index.tsx
@@ -1,0 +1,6 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export { Select } from './Select'
+export type { SelectOption, SelectProps } from './types'

--- a/packages/lynx-ui-select/src/types/index.docs.ts
+++ b/packages/lynx-ui-select/src/types/index.docs.ts
@@ -1,0 +1,70 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { CSSProperties, ViewProps } from '@lynx-js/types'
+
+/**
+ * Option config for Select.
+ */
+export interface SelectOption {
+  /**
+   * Option label.
+   */
+  label: string
+  /**
+   * Option value.
+   */
+  value: string
+  /**
+   * Whether this option is disabled.
+   * @defaultValue false
+   */
+  disabled?: boolean
+}
+
+/**
+ * Props for Select.
+ */
+export interface SelectProps {
+  /**
+   * Controlled value.
+   */
+  value?: string
+  /**
+   * Initial value in uncontrolled mode.
+   */
+  defaultValue?: string
+  /**
+   * Option list.
+   */
+  options: SelectOption[]
+  /**
+   * Called when selected value changes.
+   */
+  onValueChange?: (value: string) => void
+  /**
+   * Class name of Select container.
+   */
+  className?: string
+  /**
+   * Style of Select container.
+   */
+  style?: CSSProperties
+  /**
+   * Class name applied to each option.
+   */
+  optionClassName?: string
+  /**
+   * Style applied to each option.
+   */
+  optionStyle?: CSSProperties
+  /**
+   * Additional native props for Select container.
+   */
+  containerProps?: ViewProps
+  /**
+   * Additional native props for each option item.
+   */
+  optionProps?: ViewProps
+}

--- a/packages/lynx-ui-select/src/types/index.ts
+++ b/packages/lynx-ui-select/src/types/index.ts
@@ -1,0 +1,5 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export type * from './index.docs'

--- a/packages/lynx-ui-select/tsconfig.docs.json
+++ b/packages/lynx-ui-select/tsconfig.docs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tools/configs/tsconfig.docs.json",
+  "include": [
+    "src",
+    "dist/types/index.docs.d.ts"
+  ]
+}

--- a/packages/lynx-ui-select/tsconfig.json
+++ b/packages/lynx-ui-select/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tools/configs/tsconfig.lib.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+  },
+  "include": [
+    "src",
+  ],
+}

--- a/packages/lynx-ui/package.json
+++ b/packages/lynx-ui/package.json
@@ -44,6 +44,7 @@
     "@lynx-js/lynx-ui-presence": "workspace:*",
     "@lynx-js/lynx-ui-radio-group": "workspace:*",
     "@lynx-js/lynx-ui-scroll-view": "workspace:*",
+    "@lynx-js/lynx-ui-select": "workspace:*",
     "@lynx-js/lynx-ui-sheet": "workspace:*",
     "@lynx-js/lynx-ui-slider": "workspace:*",
     "@lynx-js/lynx-ui-sortable": "workspace:*",

--- a/packages/lynx-ui/src/index.tsx
+++ b/packages/lynx-ui/src/index.tsx
@@ -278,6 +278,10 @@ export type {
   SliderValueChangeSource,
 } from '@lynx-js/lynx-ui-slider'
 
+// select
+export { Select } from '@lynx-js/lynx-ui-select'
+export type { SelectOption, SelectProps } from '@lynx-js/lynx-ui-select'
+
 // only presence types are exported
 export type {
   PresenceAnimationStatus,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -749,6 +749,37 @@ importers:
         specifier: catalog:tailwind
         version: 3.4.17
 
+  apps/examples/select:
+    dependencies:
+      '@lynx-js/luna-styles':
+        specifier: workspace:*
+        version: link:../../../luna/packages/luna-styles
+      '@lynx-js/lynx-ui':
+        specifier: workspace:*
+        version: link:../../../packages/lynx-ui
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28)
+      clsx:
+        specifier: 'catalog:'
+        version: 2.1.1
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.4.6
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.12.4(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(webpack@5.106.2(postcss@8.5.14))
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.12.2(@rspack/core@1.6.6(@swc/helpers@0.5.21))(typescript@5.9.3)(webpack@5.106.2(postcss@8.5.14))
+      '@lynx-js/types':
+        specifier: 'catalog:'
+        version: 3.6.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.28
+
   luna/packages/luna-core:
     devDependencies:
       '@dugyu/luna-core':
@@ -843,6 +874,9 @@ importers:
       '@lynx-js/lynx-ui-scroll-view':
         specifier: workspace:*
         version: link:../lynx-ui-scroll-view
+      '@lynx-js/lynx-ui-select':
+        specifier: workspace:*
+        version: link:../lynx-ui-select
       '@lynx-js/lynx-ui-sheet':
         specifier: workspace:*
         version: link:../lynx-ui-sheet
@@ -1275,6 +1309,31 @@ importers:
       '@lynx-js/lynx-ui-lazy-component':
         specifier: workspace:*
         version: link:../lynx-ui-lazy-component
+    devDependencies:
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28)
+      '@lynx-js/types':
+        specifier: 'catalog:'
+        version: 3.6.0
+      '@rslib/core':
+        specifier: 'catalog:'
+        version: 0.16.1(typescript@5.9.3)
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.28
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
+  packages/lynx-ui-select:
+    dependencies:
+      '@lynx-js/lynx-ui-common':
+        specifier: workspace:*
+        version: link:../lynx-ui-common
+      clsx:
+        specifier: 'catalog:'
+        version: 2.1.1
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,16 +45,19 @@
       "path": "./packages/lynx-ui-presence"
     },
     {
-      "path": "./packages/lynx-ui-slider"
-    },
-    {
       "path": "./packages/lynx-ui-radio-group"
     },
     {
       "path": "./packages/lynx-ui-scroll-view"
     },
     {
+      "path": "./packages/lynx-ui-select"
+    },
+    {
       "path": "./packages/lynx-ui-sheet"
+    },
+    {
+      "path": "./packages/lynx-ui-slider"
     },
     {
       "path": "./packages/lynx-ui-sortable"


### PR DESCRIPTION
Implemented the initial headless Select component in @lynx-js/lynx-ui-select, providing a simple options-based API with controlled (value) and uncontrolled (defaultValue) modes, disabled option handling, and onValueChange callbacks.
The component is now re-exported through @lynx-js/lynx-ui, with a Basic example added to demonstrate usage and selection states.


<img width="289" height="589" alt="Screenshot 2026-05-28 at 3 14 12 PM" src="https://github.com/user-attachments/assets/4d22c0b0-bf80-4a86-8a3c-96f5a6e66db5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Introduce initial headless Select component in `@lynx-js/lynx-ui-select`

## Changes

- **Introduce headless Select component** with controlled (`value`) and uncontrolled (`defaultValue`) modes, supporting:
  - Array of options with `label`, `value`, and optional `disabled` properties
  - `onValueChange` callback for selection events
  - Disabled option handling that prevents interaction
  - Styling flexibility through `className`, `style`, `optionClassName`, and `optionStyle` props
  - Custom container and option props via `containerProps` and `optionProps`

- **Create Select package** (`@lynx-js/lynx-ui-select`) with complete build and test infrastructure:
  - TypeScript type definitions for `SelectProps` and `SelectOption`
  - RSLib configuration for building ESM and CJS modules
  - Package metadata with proper entry points and npm scripts

- **Export Select from main lynx-ui package** to make it available alongside other UI components in `@lynx-js/lynx-ui`

- **Add Basic example** demonstrating Select usage with three fruit options, visual selection states, and feedback text showing the currently selected value

- **Update workspace configuration** to include project references for the new Select package

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-ui/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->