### PR TITLE
feat: improve sortable scroll support

### DIFF
--- a/.changeset/sortable-drag-experience.md
+++ b/.changeset/sortable-drag-experience.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/lynx-ui-sortable': minor
+---
+
+Support dragging items inside a scrollable boundary, with auto-scroll and a sticky drag overlay. `SortableRoot` now supports `as?: 'ScrollView'` to enable setting the scrollView as the scrollable boundary.

--- a/apps/examples/ScrollView/ScrollBy/index.css
+++ b/apps/examples/ScrollView/ScrollBy/index.css
@@ -22,7 +22,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--surface);
+  background-color: var(--canvas-ambient);
 }
 
 .button--primary {
@@ -43,7 +43,7 @@
   width: 100%;
   height: 640px;
   border-radius: 18px;
-  background-color: var(--surface);
+  background-color: var(--canvas-ambient);
 }
 
 .scroll-view-content {

--- a/apps/examples/ScrollView/ScrollBy/index.css
+++ b/apps/examples/ScrollView/ScrollBy/index.css
@@ -1,0 +1,78 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.demo-container {
+  width: 100%;
+  height: 100%;
+  padding: 32px 20px;
+  background-color: var(--canvas);
+}
+
+.toolbar {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.button {
+  flex: 1;
+  height: 48px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--surface);
+}
+
+.button--primary {
+  background-color: var(--primary);
+}
+
+.button-text {
+  color: var(--content);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.button--primary .button-text {
+  color: var(--canvas);
+}
+
+.scroll-view {
+  width: 100%;
+  height: 640px;
+  border-radius: 18px;
+  background-color: var(--surface);
+}
+
+.scroll-view-content {
+  width: 100%;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card {
+  width: 100%;
+  height: 96px;
+  border-radius: 14px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--gradient-a), var(--gradient-b));
+}
+
+.card-title {
+  color: var(--content);
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.card-subtitle {
+  margin-top: 6px;
+  color: var(--content-subtle);
+  font-size: 13px;
+}

--- a/apps/examples/ScrollView/ScrollBy/index.tsx
+++ b/apps/examples/ScrollView/ScrollBy/index.tsx
@@ -1,0 +1,63 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root } from '@lynx-js/react'
+
+import './index.css'
+
+const ITEMS = Array.from({ length: 24 }, (_, index) => index + 1)
+
+function scrollByOffset(offset: number) {
+  'main thread'
+  lynx.querySelector('#scrollByDemoView')?.invoke('scrollBy', {
+    offset,
+  })
+}
+
+function App() {
+  return (
+    <view className='demo-container lunaris-dark'>
+      <view className='toolbar'>
+        <view
+          className='button'
+          main-thread:bindtap={() => {
+            'main thread'
+            scrollByOffset(-160)
+          }}
+        >
+          <text className='button-text'>Scroll Up</text>
+        </view>
+        <view
+          className='button button--primary'
+          main-thread:bindtap={() => {
+            'main thread'
+            scrollByOffset(160)
+          }}
+        >
+          <text className='button-text'>Scroll Down</text>
+        </view>
+      </view>
+
+      <scroll-view
+        id='scrollByDemoView'
+        className='scroll-view'
+        scroll-orientation='vertical'
+        enable-scroll={false}
+      >
+        <view className='scroll-view-content'>
+          {ITEMS.map(item => (
+            <view className='card' key={`scroll-by-card-${item}`}>
+              <text className='card-title'>{`Item ${item}`}</text>
+              <text className='card-subtitle'>scrollBy target content</text>
+            </view>
+          ))}
+        </view>
+      </scroll-view>
+    </view>
+  )
+}
+
+root.render(<App />)
+
+export default App

--- a/apps/examples/ScrollView/lynx.config.mjs
+++ b/apps/examples/ScrollView/lynx.config.mjs
@@ -9,6 +9,7 @@ const defaultConfig = exampleConfig({
   ScrollViewHorizontal: './Horizontal/index.tsx',
   ScrollViewHorizontalRTL: './HorizontalRTL/index.tsx',
   ScrollViewInnerFlex: './InnerFlex/index.tsx',
+  ScrollViewScrollBy: './ScrollBy/index.tsx',
   ScrollViewZIndex: './ZIndex/index.tsx',
 }, { needWeb: false })
 

--- a/apps/examples/Sortable/ScrollableBoundary/index.css
+++ b/apps/examples/Sortable/ScrollableBoundary/index.css
@@ -1,0 +1,125 @@
+@import "@lynx-js/luna-styles/index.css";
+
+@import "../shared/base.css";
+@import "../shared/palette.css";
+
+.demo-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding-top: 48px;
+  padding-bottom: 48px;
+  padding-right: 16px;
+  padding-left: 16px;
+  z-index: 0;
+}
+
+.scroll-view {
+  width: 100%;
+  flex: 1;
+  z-index: 0;
+}
+
+.scrollable-boundary-root {
+  justify-content: flex-start;
+  min-height: 100%;
+  padding-top: 24px;
+  padding-bottom: 32px;
+  border-radius: 16px;
+  height: max-content;
+}
+
+.demo-header {
+  width: 100%;
+  padding: 20px 24px;
+  border-radius: 16px;
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.demo-title {
+  font-size: 22px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.demo-description {
+  margin-top: 8px;
+  font-size: 14px;
+  line-height: 20px;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.scroll-by-actions {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 16px;
+}
+
+.scroll-by-button {
+  flex: 1;
+  height: 44px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.16);
+}
+
+.scroll-by-button--primary {
+  background-color: #ffffff;
+}
+
+.scroll-by-button-text {
+  font-size: 14px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.scroll-by-button--primary .scroll-by-button-text {
+  color: #1f2937;
+}
+
+.sortable-item {
+  display: flex;
+  flex-direction: column;
+  height: 100px;
+  padding-bottom: 12px;
+  flex-shrink: 0;
+  background-color: transparent;
+}
+
+.sortable-item-surface {
+  display: flex;
+  flex-direction: row;
+  justify-content: end;
+  align-items: center;
+  width: 100%;
+  height: 88px;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.sortable-item-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  padding-left: 20px;
+}
+
+.sortable-item-title {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.sortable-item-subtitle {
+  margin-top: 6px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.sortable-item-area {
+  width: 88px;
+}

--- a/apps/examples/Sortable/ScrollableBoundary/index.tsx
+++ b/apps/examples/Sortable/ScrollableBoundary/index.tsx
@@ -1,0 +1,117 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useCallback, useState } from '@lynx-js/react'
+
+import './index.css'
+
+import { SortableItem, SortableItemArea, SortableRoot } from '@lynx-js/lynx-ui'
+import type { SortableData } from '@lynx-js/lynx-ui'
+
+import type { SortableDemoItem } from '../shared/data'
+import { createDemoData } from '../shared/data'
+
+function scrollBoundaryBy(offset: number) {
+  'main thread'
+  lynx.querySelector('#sortableScrollableBoundary')?.invoke('scrollBy', {
+    offset,
+  })
+}
+
+export function App() {
+  const [data, setData] = useState<SortableData<SortableDemoItem>[]>(
+    () => createDemoData(16),
+  )
+  const [enableScroll, setEnableScroll] = useState(true)
+
+  const handleSortStart = useCallback(() => {
+    setEnableScroll(false)
+  }, [])
+
+  const handleSortEnd = useCallback(
+    (sortedData: SortableData<SortableDemoItem>[]) => {
+      setEnableScroll(true)
+      setData(sortedData)
+    },
+    [],
+  )
+
+  const renderSortableItem = useCallback(
+    (item: SortableData<SortableDemoItem>) => {
+      const { id, tone } = item.dataItem
+      const numericId = Number(id)
+      const paletteIndex = numericId % 6
+
+      return (
+        <SortableItem
+          key={item.getSortingKey()}
+          as='DraggableRoot'
+          className='sortable-item'
+          sortingKey={item.getSortingKey()}
+        >
+          <view
+            className={`sortable-item-surface sortable-item--${paletteIndex}`}
+          >
+            <view className='sortable-item-content'>
+              <text className={`sortable-item-title drag-here-text--${tone}`}>
+                {`Option ${numericId + 1}`}
+              </text>
+              <text className='sortable-item-subtitle'>
+                Drag near the edge
+              </text>
+            </view>
+            <SortableItemArea className='sortable-item-area'>
+              <text className={`drag-here-text drag-here-text--${tone}`}>
+                Drag Here
+              </text>
+            </SortableItemArea>
+          </view>
+        </SortableItem>
+      )
+    },
+    [],
+  )
+
+  return (
+    <view className='demo-container lunaris-dark luna-gradient-berry'>
+      <view className='scroll-by-actions'>
+        <view
+          className='scroll-by-button'
+          main-thread:bindtap={() => {
+            'main thread'
+            scrollBoundaryBy(-160)
+          }}
+        >
+          <text className='scroll-by-button-text'>Scroll Up</text>
+        </view>
+        <view
+          className='scroll-by-button scroll-by-button--primary'
+          main-thread:bindtap={() => {
+            'main thread'
+            scrollBoundaryBy(160)
+          }}
+        >
+          <text className='scroll-by-button-text'>Scroll Down</text>
+        </view>
+      </view>
+      <SortableRoot
+        data={data}
+        onSortStart={handleSortStart}
+        onSortEnd={handleSortEnd}
+        boundaryId='sortableRoot'
+        scrollable
+        scrollableBoundaryId='sortableScrollableBoundary'
+        scrollableClassName='scroll-view'
+        scrollableContentClassName='sortable-root scrollable-boundary-root'
+        scrollableEnableScroll={enableScroll}
+        scrollableStickyUpperOffset={12}
+        scrollableStickyLowerOffset={12}
+      >
+        {renderSortableItem}
+      </SortableRoot>
+    </view>
+  )
+}
+
+root.render(<App />)

--- a/apps/examples/Sortable/ScrollableBoundary/index.tsx
+++ b/apps/examples/Sortable/ScrollableBoundary/index.tsx
@@ -23,15 +23,9 @@ export function App() {
   const [data, setData] = useState<SortableData<SortableDemoItem>[]>(
     () => createDemoData(16),
   )
-  const [enableScroll, setEnableScroll] = useState(true)
-
-  const handleSortStart = useCallback(() => {
-    setEnableScroll(false)
-  }, [])
 
   const handleSortEnd = useCallback(
     (sortedData: SortableData<SortableDemoItem>[]) => {
-      setEnableScroll(true)
       setData(sortedData)
     },
     [],
@@ -97,14 +91,12 @@ export function App() {
       </view>
       <SortableRoot
         data={data}
-        onSortStart={handleSortStart}
         onSortEnd={handleSortEnd}
         boundaryId='sortableRoot'
-        scrollable
+        as='ScrollView'
         scrollableBoundaryId='sortableScrollableBoundary'
         scrollableClassName='scroll-view'
         scrollableContentClassName='sortable-root scrollable-boundary-root'
-        scrollableEnableScroll={enableScroll}
         scrollableStickyUpperOffset={12}
         scrollableStickyLowerOffset={12}
       >

--- a/apps/examples/Sortable/ShortScrollView/index.css
+++ b/apps/examples/Sortable/ShortScrollView/index.css
@@ -1,5 +1,3 @@
-@import "@lynx-js/luna-styles/index.css";
-
 @import "../shared/base.css";
 @import "../shared/palette.css";
 

--- a/apps/examples/Sortable/ShortScrollView/index.css
+++ b/apps/examples/Sortable/ShortScrollView/index.css
@@ -1,0 +1,135 @@
+@import "@lynx-js/luna-styles/index.css";
+
+@import "../shared/base.css";
+@import "../shared/palette.css";
+
+.demo-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 24px 16px;
+  z-index: 0;
+}
+
+.outside-panel {
+  width: 100%;
+  height: 112px;
+  flex-shrink: 0;
+  border-radius: 16px;
+  padding: 18px 20px;
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.outside-panel--top {
+  margin-bottom: 12px;
+}
+
+.outside-panel--bottom {
+  margin-top: 12px;
+}
+
+.outside-panel-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.outside-panel-copy {
+  margin-top: 8px;
+  font-size: 13px;
+  line-height: 18px;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.scroll-by-actions {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 12px;
+}
+
+.scroll-by-button {
+  flex: 1;
+  height: 40px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.16);
+}
+
+.scroll-by-button--primary {
+  background-color: #ffffff;
+}
+
+.scroll-by-button-text {
+  font-size: 14px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.scroll-by-button--primary .scroll-by-button-text {
+  color: #1f2937;
+}
+
+.short-scroll-view {
+  width: 100%;
+  height: 360px;
+  flex-shrink: 0;
+  border-radius: 18px;
+  border-width: 1px;
+  border-color: rgba(255, 255, 255, 0.22);
+  background-color: rgba(0, 0, 0, 0.16);
+  z-index: 0;
+}
+
+.short-sortable-root {
+  justify-content: flex-start;
+  min-height: 100%;
+  padding: 16px 12px;
+  height: max-content;
+}
+
+.sortable-item {
+  display: flex;
+  flex-direction: column;
+  height: 92px;
+  padding-bottom: 10px;
+  flex-shrink: 0;
+  background-color: transparent;
+}
+
+.sortable-item-surface {
+  display: flex;
+  flex-direction: row;
+  justify-content: end;
+  align-items: center;
+  width: 100%;
+  height: 82px;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.sortable-item-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  padding-left: 18px;
+}
+
+.sortable-item-title {
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.sortable-item-subtitle {
+  margin-top: 5px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.sortable-item-area {
+  width: 76px;
+}

--- a/apps/examples/Sortable/ShortScrollView/index.tsx
+++ b/apps/examples/Sortable/ShortScrollView/index.tsx
@@ -23,15 +23,9 @@ export function App() {
   const [data, setData] = useState<SortableData<SortableDemoItem>[]>(
     () => createDemoData(18),
   )
-  const [enableScroll, setEnableScroll] = useState(true)
-
-  const handleSortStart = useCallback(() => {
-    setEnableScroll(false)
-  }, [])
 
   const handleSortEnd = useCallback(
     (sortedData: SortableData<SortableDemoItem>[]) => {
-      setEnableScroll(true)
       setData(sortedData)
     },
     [],
@@ -73,6 +67,16 @@ export function App() {
     [],
   )
 
+  const handleScrollUpTap = useCallback(() => {
+    'main thread'
+    scrollShortBoundaryBy(-160)
+  }, [])
+
+  const handleScrollDownTap = useCallback(() => {
+    'main thread'
+    scrollShortBoundaryBy(160)
+  }, [])
+
   return (
     <view className='demo-container lunaris-dark luna-gradient-berry'>
       <view className='outside-panel outside-panel--top'>
@@ -86,19 +90,13 @@ export function App() {
       <view className='scroll-by-actions'>
         <view
           className='scroll-by-button'
-          main-thread:bindtap={() => {
-            'main thread'
-            scrollShortBoundaryBy(-160)
-          }}
+          main-thread:bindtap={handleScrollUpTap}
         >
           <text className='scroll-by-button-text'>Scroll Up</text>
         </view>
         <view
           className='scroll-by-button scroll-by-button--primary'
-          main-thread:bindtap={() => {
-            'main thread'
-            scrollShortBoundaryBy(160)
-          }}
+          main-thread:bindtap={handleScrollDownTap}
         >
           <text className='scroll-by-button-text'>Scroll Down</text>
         </view>
@@ -106,14 +104,12 @@ export function App() {
 
       <SortableRoot
         data={data}
-        onSortStart={handleSortStart}
         onSortEnd={handleSortEnd}
         boundaryId='shortSortableRoot'
-        scrollable
+        as='ScrollView'
         scrollableBoundaryId='shortSortableScrollView'
         scrollableClassName='short-scroll-view'
         scrollableContentClassName='sortable-root short-sortable-root'
-        scrollableEnableScroll={enableScroll}
         scrollableStickyUpperOffset={12}
         scrollableStickyLowerOffset={12}
       >

--- a/apps/examples/Sortable/ShortScrollView/index.tsx
+++ b/apps/examples/Sortable/ShortScrollView/index.tsx
@@ -1,0 +1,133 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useCallback, useState } from '@lynx-js/react'
+
+import './index.css'
+
+import { SortableItem, SortableItemArea, SortableRoot } from '@lynx-js/lynx-ui'
+import type { SortableData } from '@lynx-js/lynx-ui'
+
+import type { SortableDemoItem } from '../shared/data'
+import { createDemoData } from '../shared/data'
+
+function scrollShortBoundaryBy(offset: number) {
+  'main thread'
+  lynx.querySelector('#shortSortableScrollView')?.invoke('scrollBy', {
+    offset,
+  })
+}
+
+export function App() {
+  const [data, setData] = useState<SortableData<SortableDemoItem>[]>(
+    () => createDemoData(18),
+  )
+  const [enableScroll, setEnableScroll] = useState(true)
+
+  const handleSortStart = useCallback(() => {
+    setEnableScroll(false)
+  }, [])
+
+  const handleSortEnd = useCallback(
+    (sortedData: SortableData<SortableDemoItem>[]) => {
+      setEnableScroll(true)
+      setData(sortedData)
+    },
+    [],
+  )
+
+  const renderSortableItem = useCallback(
+    (item: SortableData<SortableDemoItem>) => {
+      const { id, tone } = item.dataItem
+      const numericId = Number(id)
+      const paletteIndex = numericId % 6
+
+      return (
+        <SortableItem
+          key={item.getSortingKey()}
+          as='DraggableRoot'
+          className='sortable-item'
+          sortingKey={item.getSortingKey()}
+        >
+          <view
+            className={`sortable-item-surface sortable-item--${paletteIndex}`}
+          >
+            <view className='sortable-item-content'>
+              <text className={`sortable-item-title drag-here-text--${tone}`}>
+                {`Row ${numericId + 1}`}
+              </text>
+              <text className='sortable-item-subtitle'>
+                Middle scroll-view boundary
+              </text>
+            </view>
+            <SortableItemArea className='sortable-item-area'>
+              <text className={`drag-here-text drag-here-text--${tone}`}>
+                Drag
+              </text>
+            </SortableItemArea>
+          </view>
+        </SortableItem>
+      )
+    },
+    [],
+  )
+
+  return (
+    <view className='demo-container lunaris-dark luna-gradient-berry'>
+      <view className='outside-panel outside-panel--top'>
+        <text className='outside-panel-title'>Content Above</text>
+        <text className='outside-panel-copy'>
+          The sortable scroll-view below is intentionally shorter than the
+          screen.
+        </text>
+      </view>
+
+      <view className='scroll-by-actions'>
+        <view
+          className='scroll-by-button'
+          main-thread:bindtap={() => {
+            'main thread'
+            scrollShortBoundaryBy(-160)
+          }}
+        >
+          <text className='scroll-by-button-text'>Scroll Up</text>
+        </view>
+        <view
+          className='scroll-by-button scroll-by-button--primary'
+          main-thread:bindtap={() => {
+            'main thread'
+            scrollShortBoundaryBy(160)
+          }}
+        >
+          <text className='scroll-by-button-text'>Scroll Down</text>
+        </view>
+      </view>
+
+      <SortableRoot
+        data={data}
+        onSortStart={handleSortStart}
+        onSortEnd={handleSortEnd}
+        boundaryId='shortSortableRoot'
+        scrollable
+        scrollableBoundaryId='shortSortableScrollView'
+        scrollableClassName='short-scroll-view'
+        scrollableContentClassName='sortable-root short-sortable-root'
+        scrollableEnableScroll={enableScroll}
+        scrollableStickyUpperOffset={12}
+        scrollableStickyLowerOffset={12}
+      >
+        {renderSortableItem}
+      </SortableRoot>
+
+      <view className='outside-panel outside-panel--bottom'>
+        <text className='outside-panel-title'>Content Below</text>
+        <text className='outside-panel-copy'>
+          Dragging near the panel edge should not react to this outside area.
+        </text>
+      </view>
+    </view>
+  )
+}
+
+root.render(<App />)

--- a/apps/examples/Sortable/WithScrollView/index.tsx
+++ b/apps/examples/Sortable/WithScrollView/index.tsx
@@ -54,6 +54,7 @@ export function App() {
 
   return (
     <scroll-view
+      id='sortableScrollView'
       className='scroll-view lunaris-dark luna-gradient-berry'
       enable-scroll={enableScroll}
       scroll-orientation='vertical'
@@ -69,6 +70,7 @@ export function App() {
           onSortStart={handleSortStart}
           onSortEnd={handleSortEnd}
           boundaryId='sortableRoot'
+          scrollableBoundaryId='sortableScrollView'
         >
           {renderSortableItem}
         </SortableRoot>

--- a/apps/examples/Sortable/lynx.config.mjs
+++ b/apps/examples/Sortable/lynx.config.mjs
@@ -7,6 +7,8 @@ import { exampleConfig } from '../../../tools/configs/exampleConfig.mjs'
 const defaultConfig = exampleConfig({
   SortableBasic: './Basic/index.tsx',
   SortableWithScrollView: './WithScrollView/index.tsx',
+  SortableScrollableBoundary: './ScrollableBoundary/index.tsx',
+  SortableShortScrollView: './ShortScrollView/index.tsx',
   SortableNoBoundary: './NoBoundary/index.tsx',
   SortableDisableSorting: './DisableSorting/index.tsx',
 }, { needWeb: false })

--- a/packages/lynx-ui-sortable/src/Sortable.tsx
+++ b/packages/lynx-ui-sortable/src/Sortable.tsx
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import {
+  runOnBackground,
   runOnMainThread,
   useCallback,
   useContext,
@@ -10,7 +11,6 @@ import {
   useMainThreadRef,
   useMemo,
   useRef,
-  useState,
 } from '@lynx-js/react'
 import type { RefObject } from '@lynx-js/react'
 
@@ -21,7 +21,7 @@ import {
   DraggableRoot,
 } from '@lynx-js/lynx-ui-draggable'
 import type { DraggableRef } from '@lynx-js/lynx-ui-draggable'
-import type { MainThread, NodesRef } from '@lynx-js/types'
+import type { MainThread, ScrollEvent } from '@lynx-js/types'
 
 import { SortableContext } from './SortableContext'
 import type { SortableItemProps, SortableRootProps } from './types'
@@ -29,16 +29,132 @@ import { useSortable } from './useSortable'
 
 export { DraggableArea as SortableItemArea }
 
+type RectTarget = 'item' | 'boundary' | 'scrollableBoundary'
+interface ScrollByResult {
+  scrollTop?: number
+  detail?: { scrollTop?: number }
+}
+interface ScrollTranslateDelta {
+  dragDeltaY: number
+  measuredRectDeltaY: number
+}
+interface VerticalBounds {
+  top: number
+  bottom: number
+}
+interface EdgeDistance {
+  distanceToTop: number
+  distanceToBottom: number
+}
+interface ClippedOverflowResult {
+  clippedStickyDirection: number
+  overflow: number
+}
+
+const AUTO_SCROLL_QUANTUM = 8 / 11
+const AUTO_SCROLL_MAX_STEP = 18
+const AUTO_SCROLL_VELOCITY_FACTOR = 0.35
+
+function getNormalizedElementKey(sortingKey: string) {
+  return String(sortingKey).replace(/[^\w-]/g, '-')
+}
+
+function getSortableItemElementId(sortingKey: string) {
+  return `sortable-item-${getNormalizedElementKey(sortingKey)}`
+}
+
+function getSortableDragOverlayElementId(sortingKey: string) {
+  return `sortable-drag-overlay-${getNormalizedElementKey(sortingKey)}`
+}
+
+function getEdgeDistance(
+  itemBounds: VerticalBounds,
+  boundaryRect: VerticalBounds,
+): EdgeDistance {
+  'main thread'
+  return {
+    distanceToTop: itemBounds.top - boundaryRect.top,
+    distanceToBottom: boundaryRect.bottom - itemBounds.bottom,
+  }
+}
+
+function getClippedStickyDirection(edgeDistance: EdgeDistance) {
+  'main thread'
+  if (edgeDistance.distanceToTop < 0) {
+    return -1
+  }
+  if (edgeDistance.distanceToBottom < 0) {
+    return 1
+  }
+  return 0
+}
+
+function getStickyOverflow(
+  edgeDistance: EdgeDistance,
+  stickyUpperOffset: number,
+  stickyLowerOffset: number,
+) {
+  'main thread'
+  if (edgeDistance.distanceToTop < stickyUpperOffset) {
+    return edgeDistance.distanceToTop - stickyUpperOffset
+  }
+  if (edgeDistance.distanceToBottom < stickyLowerOffset) {
+    return stickyLowerOffset - edgeDistance.distanceToBottom
+  }
+  return 0
+}
+
+function getClippedAutoScrollOverflow(
+  clippedStickyDirection: number,
+  overflow: number,
+  edgeDistance: EdgeDistance,
+  stickyUpperOffset: number,
+  stickyLowerOffset: number,
+): ClippedOverflowResult {
+  'main thread'
+  if (clippedStickyDirection < 0) {
+    if (edgeDistance.distanceToTop >= stickyUpperOffset) {
+      return { clippedStickyDirection: 0, overflow }
+    }
+    if (overflow < 0) {
+      return { clippedStickyDirection, overflow: 0 }
+    }
+  } else if (clippedStickyDirection > 0) {
+    if (edgeDistance.distanceToBottom >= stickyLowerOffset) {
+      return { clippedStickyDirection: 0, overflow }
+    }
+    if (overflow > 0) {
+      return { clippedStickyDirection, overflow: 0 }
+    }
+  }
+  return { clippedStickyDirection, overflow }
+}
+
 export function SortableRoot<T>(props: SortableRootProps<T>) {
   const {
     children,
     data,
     debugLog = false,
     boundaryId,
+    scrollableBoundaryId,
+    scrollable = false,
+    scrollableClassName,
+    scrollableContentClassName,
+    scrollableEnableScroll = true,
+    scrollableStickyUpperOffset = 0,
+    scrollableStickyLowerOffset = 0,
     onSortEnd,
     onSortStart,
     enableSorting = true,
   } = props
+  const scrollableElementId = useMemo(
+    () => scrollableBoundaryId ?? 'sortable-scrollable-boundary',
+    [scrollableBoundaryId],
+  )
+  const scrollableContentId = useMemo(
+    () => boundaryId ?? 'sortable-scrollable-content',
+    [boundaryId],
+  )
   const sizeMap = useMainThreadRef<Record<string, number>>({})
   const childrenRefMap = useMainThreadRef<
     Record<string, DraggableRef | null>
@@ -50,10 +166,43 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
   >(
     {},
   )
+  const dragOverlayRefMap = useMainThreadRef<
+    Record<string, MainThread.Element | null>
+  >(
+    {},
+  )
+  const scrollableBoundaryUpperEdgeRef = useMainThreadRef(false)
+  const scrollableBoundaryLowerEdgeRef = useMainThreadRef(false)
+  const scrollableScrollTopRef = useMainThreadRef(0)
   const updateItemSize = useCallback((sortingKey: string, size: number) => {
     'main thread'
     sizeMap.current[sortingKey] = size
   }, [])
+
+  const handleScrollableBoundaryScroll = useCallback((event: ScrollEvent) => {
+    'main thread'
+    scrollableScrollTopRef.current = event.detail.scrollTop
+  }, [scrollableScrollTopRef])
+
+  const handleScrollableBoundaryUpperExposure = useCallback(() => {
+    'main thread'
+    scrollableBoundaryUpperEdgeRef.current = true
+  }, [scrollableBoundaryUpperEdgeRef])
+
+  const handleScrollableBoundaryUpperDisexposure = useCallback(() => {
+    'main thread'
+    scrollableBoundaryUpperEdgeRef.current = false
+  }, [scrollableBoundaryUpperEdgeRef])
+
+  const handleScrollableBoundaryLowerExposure = useCallback(() => {
+    'main thread'
+    scrollableBoundaryLowerEdgeRef.current = true
+  }, [scrollableBoundaryLowerEdgeRef])
+
+  const handleScrollableBoundaryLowerDisexposure = useCallback(() => {
+    'main thread'
+    scrollableBoundaryLowerEdgeRef.current = false
+  }, [scrollableBoundaryLowerEdgeRef])
 
   const setChildrenRef = useCallback(
     (refI: RefObject<DraggableRef>, key: string) => {
@@ -71,8 +220,16 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     childrenMTSRefMap.current[key] = refI.current
   }, [])
 
-  const { handleDragEnd, handleDragMove, handleDragStart } = useSortable<T>({
-    data,
+  const setDragOverlayRef = useCallback((
+    refI: RefObject<MainThread.Element | null>,
+    key: string,
+  ) => {
+    'main thread'
+    dragOverlayRefMap.current[key] = refI.current
+  }, [dragOverlayRefMap])
+
+  const { handleDragEnd, handleDragMove, handleDragStart } = useSortable({
+    data: data as SortableData<unknown>[],
     sizeMap: sizeMap,
     itemRefMap: childrenRefMap,
     itemMTSRefMap: childrenMTSRefMap,
@@ -82,30 +239,117 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
   })
   const sortableContextValue = useMemo(() => ({
     data,
+    isDragOverlay: false,
+    debugLog,
     enableSorting,
-    boundaryId,
+    boundaryId: scrollable ? scrollableContentId : boundaryId,
+    scrollableBoundaryId: scrollable
+      ? scrollableElementId
+      : scrollableBoundaryId,
+    scrollableBoundaryUpperEdgeRef: scrollable
+      ? scrollableBoundaryUpperEdgeRef
+      : undefined,
+    scrollableBoundaryLowerEdgeRef: scrollable
+      ? scrollableBoundaryLowerEdgeRef
+      : undefined,
+    scrollableScrollTopRef: scrollable
+      ? scrollableScrollTopRef
+      : undefined,
+    dragOverlayRefMap: scrollable ? dragOverlayRefMap : undefined,
+    scrollableStickyUpperOffset,
+    scrollableStickyLowerOffset,
     updateItemSize,
     setChildrenRef,
     setChildrenMTSRef,
+    setDragOverlayRef,
     handleDragEnd,
     handleDragMove,
     handleDragStart,
   }), [
     data,
+    debugLog,
     enableSorting,
     boundaryId,
+    scrollable,
+    scrollableContentId,
+    scrollableElementId,
+    scrollableBoundaryId,
+    scrollableBoundaryLowerEdgeRef,
+    scrollableBoundaryUpperEdgeRef,
+    scrollableScrollTopRef,
+    dragOverlayRefMap,
+    scrollableStickyLowerOffset,
+    scrollableStickyUpperOffset,
     updateItemSize,
     setChildrenRef,
     setChildrenMTSRef,
+    setDragOverlayRef,
     handleDragEnd,
     handleDragMove,
     handleDragStart,
   ])
 
+  const sortableDragOverlayContextValue = useMemo(() => ({
+    ...sortableContextValue,
+    isDragOverlay: true,
+  }), [sortableContextValue])
+
   const renderedChildren = useMemo(
     () => data?.map(item => children(item)),
     [data, children],
   )
+
+  const renderedDragOverlayChildren = useMemo(
+    () => data?.map(item => children(item)),
+    [data, children],
+  )
+
+  if (scrollable) {
+    return (
+      <>
+        <scroll-view
+          id={scrollableElementId}
+          className={scrollableClassName}
+          enable-scroll={scrollableEnableScroll}
+          scroll-orientation='vertical'
+          main-thread:bindscroll={handleScrollableBoundaryScroll}
+        >
+          <view
+            id={scrollableContentId}
+            className={scrollableContentClassName}
+            style={{ zIndex: '0' }}
+          >
+            <view
+              style='display: flex; flex-direction: column; overflow:hidden; height: 1ppx; width: 100%;'
+              exposure-scene={scrollableElementId}
+              exposure-id='upperExposureView'
+              id={`${scrollableElementId}-upperExposureView`}
+              main-thread:binduiappear={handleScrollableBoundaryUpperExposure}
+              main-thread:binduidisappear={handleScrollableBoundaryUpperDisexposure}
+            />
+            <SortableContext.Provider
+              value={sortableContextValue}
+            >
+              {renderedChildren}
+            </SortableContext.Provider>
+            <view
+              style='display: flex; flex-direction: column; overflow:hidden; height: 1ppx; width: 100%;'
+              exposure-scene={scrollableElementId}
+              exposure-id='lowerExposureView'
+              id={`${scrollableElementId}-lowerExposureView`}
+              main-thread:binduiappear={handleScrollableBoundaryLowerExposure}
+              main-thread:binduidisappear={handleScrollableBoundaryLowerDisexposure}
+            />
+          </view>
+        </scroll-view>
+        <SortableContext.Provider
+          value={sortableDragOverlayContextValue}
+        >
+          {renderedDragOverlayChildren}
+        </SortableContext.Provider>
+      </>
+    )
+  }
 
   return (
     <SortableContext.Provider
@@ -126,11 +370,64 @@ interface boundingClientRectRes {
 }
 
 export function SortableItem(props: SortableItemProps) {
+  const { isDragOverlay } = useContext(SortableContext)
+  if (isDragOverlay) {
+    return <SortableDragOverlayItem {...props} />
+  }
+
+  return <SortableInteractiveItem {...props} />
+}
+
+function SortableDragOverlayItem(props: SortableItemProps) {
+  const { className, children, sortingKey } = props
+  const { setDragOverlayRef } = useContext(SortableContext)
+  const overlayRef = useMainThreadRef<MainThread.Element | null>(null)
+  const overlayElementId = useMemo(
+    () => getSortableDragOverlayElementId(sortingKey),
+    [sortingKey],
+  )
+  const overlayStyle = useMemo(() => ({
+    position: 'fixed',
+    top: '0px',
+    left: '0px',
+    width: '0px',
+    height: '0px',
+    opacity: 0,
+    visibility: 'hidden',
+    // zIndex: '10000',
+    transform: 'translate(0px, 0px)',
+  } as const), [])
+
+  useEffect(() => {
+    runOnMainThread(setDragOverlayRef)(overlayRef, sortingKey)
+  }, [overlayRef, setDragOverlayRef, sortingKey])
+
+  return (
+    <view
+      id={overlayElementId}
+      className={className}
+      main-thread:ref={overlayRef}
+      style={overlayStyle}
+      user-interaction-enabled={false}
+    >
+      {children}
+    </view>
+  )
+}
+
+function SortableInteractiveItem(props: SortableItemProps) {
   const { className, children, sortingKey, as = 'Draggable' } = props
   const {
     data,
     enableSorting,
     boundaryId,
+    scrollableBoundaryId,
+    scrollableBoundaryUpperEdgeRef,
+    scrollableBoundaryLowerEdgeRef,
+    scrollableScrollTopRef,
+    dragOverlayRefMap,
+    scrollableStickyUpperOffset,
+    scrollableStickyLowerOffset,
     updateItemSize,
     setChildrenRef,
     setChildrenMTSRef,
@@ -140,8 +437,7 @@ export function SortableItem(props: SortableItemProps) {
   } = useContext(SortableContext)
 
   const MTSRef = useMainThreadRef<DraggableRef>(null)
-  const ref = useRef<NodesRef>(null)
-  const [itemRect, setItemRect] = useState<boundingClientRectRes>({
+  const itemRect = useMainThreadRef<boundingClientRectRes>({
     height: 0,
     width: 0,
     top: 0,
@@ -149,7 +445,7 @@ export function SortableItem(props: SortableItemProps) {
     bottom: 0,
     right: 0,
   })
-  const [boundaryRect, setBoundaryRect] = useState<boundingClientRectRes>({
+  const boundaryRect = useMainThreadRef<boundingClientRectRes>({
     height: 0,
     width: 0,
     top: 0,
@@ -157,39 +453,775 @@ export function SortableItem(props: SortableItemProps) {
     bottom: 0,
     right: 0,
   })
+  const scrollableBoundaryRect = useMainThreadRef<
+    boundingClientRectRes
+  >({
+    height: 0,
+    width: 0,
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+  })
+  const itemRectCopy = useRef<boundingClientRectRes>({
+    height: 0,
+    width: 0,
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+  })
+  const boundaryRectCopy = useRef<boundingClientRectRes>({
+    height: 0,
+    width: 0,
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+  })
+  const scrollableBoundaryRectCopy = useRef<boundingClientRectRes>({
+    height: 0,
+    width: 0,
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+  })
+  const autoScrollingRef = useMainThreadRef(false)
+  const lastAutoScrollTranslateY = useMainThreadRef(0)
+  const autoScrollDistanceSum = useMainThreadRef(0)
+  const pendingAutoScrollDistance = useMainThreadRef(0)
+  const autoScrollCompensationY = useMainThreadRef(0)
+  const autoScrollStartScrollTop = useMainThreadRef(0)
+  const itemMeasuredScrollTop = useMainThreadRef(0)
+  const dragStartScrollDeltaFromMeasuredRect = useMainThreadRef(0)
+  const autoScrollOverflow = useMainThreadRef(0)
+  const autoScrollDirection = useMainThreadRef(0)
+  const autoScrollStickyDirection = useMainThreadRef(0)
+  const dragStartClippedStickyDirection = useMainThreadRef(0)
+  const dragOverlayActive = useMainThreadRef(false)
+  const dragSourceHidden = useMainThreadRef(false)
+  const latestDragTranslate = useMainThreadRef<Point>({ x: 0, y: 0 })
+  const latestDragEvent = useMainThreadRef<
+    MainThread.MouseEvent | MainThread.TouchEvent | null
+  >(null)
+  const autoScrollFrameRef = useMainThreadRef<(() => void) | null>(null)
+  const syncScrollDeltaForItemTranslateY = useCallback((
+    scrollByResult?: ScrollByResult,
+    fallbackScrollByOffset = 0,
+  ): ScrollTranslateDelta => {
+    'main thread'
+    if (scrollableScrollTopRef) {
+      const previousScrollTop = scrollableScrollTopRef.current
+      const scrollTop = scrollByResult?.scrollTop
+        ?? scrollByResult?.detail?.scrollTop
+      if (typeof scrollTop === 'number') {
+        scrollableScrollTopRef.current = scrollTop
+      } else if (scrollByResult || fallbackScrollByOffset !== 0) {
+        scrollableScrollTopRef.current += fallbackScrollByOffset
+      }
+
+      if (scrollByResult || fallbackScrollByOffset !== 0) {
+        autoScrollDistanceSum.current += scrollableScrollTopRef.current
+          - previousScrollTop
+      }
+      autoScrollCompensationY.current = scrollableScrollTopRef.current
+        - autoScrollStartScrollTop.current
+      return {
+        dragDeltaY: autoScrollCompensationY.current,
+        measuredRectDeltaY: scrollableScrollTopRef.current
+          - itemMeasuredScrollTop.current,
+      }
+    }
+
+    if (fallbackScrollByOffset !== 0) {
+      autoScrollDistanceSum.current += fallbackScrollByOffset
+      autoScrollCompensationY.current += fallbackScrollByOffset
+    }
+    return {
+      dragDeltaY: autoScrollCompensationY.current,
+      measuredRectDeltaY: dragStartScrollDeltaFromMeasuredRect.current
+        + autoScrollDistanceSum.current,
+    }
+  }, [
+    autoScrollDistanceSum,
+    autoScrollCompensationY,
+    autoScrollStartScrollTop,
+    dragStartScrollDeltaFromMeasuredRect,
+    itemMeasuredScrollTop,
+    scrollableScrollTopRef,
+  ])
+
+  const itemElementId = useMemo(
+    () => getSortableItemElementId(sortingKey),
+    [sortingKey],
+  )
+  const setAutoScrolling = useCallback((isAutoScrolling: boolean) => {
+    'main thread'
+    autoScrollingRef.current = isAutoScrolling
+  }, [autoScrollingRef])
+  const setItemRectOnMainThread = useCallback((rect: boundingClientRectRes) => {
+    'main thread'
+    itemRect.current = rect
+    itemMeasuredScrollTop.current = scrollableScrollTopRef?.current ?? 0
+  }, [itemMeasuredScrollTop, itemRect, scrollableScrollTopRef])
+  const setBoundaryRectOnMainThread = useCallback(
+    (rect: boundingClientRectRes) => {
+      'main thread'
+      boundaryRect.current = rect
+    },
+    [boundaryRect],
+  )
+  const setScrollableBoundaryRectOnMainThread = useCallback(
+    (rect: boundingClientRectRes) => {
+      'main thread'
+      scrollableBoundaryRect.current = rect
+    },
+    [scrollableBoundaryRect],
+  )
+  const syncItemRectCopy = useCallback((rect: boundingClientRectRes) => {
+    itemRectCopy.current = rect
+  }, [])
+  const syncBoundaryRectCopy = useCallback((rect: boundingClientRectRes) => {
+    boundaryRectCopy.current = rect
+  }, [])
+  const syncScrollableBoundaryRectCopy = useCallback(
+    (rect: boundingClientRectRes) => {
+      scrollableBoundaryRectCopy.current = rect
+    },
+    [],
+  )
+
+  const measureRectById = useCallback((
+    id: string | undefined,
+    target: RectTarget,
+  ) => {
+    'main thread'
+    if (!id) {
+      return
+    }
+
+    const element = lynx.querySelector(`#${id}`)
+    element?.invoke('boundingClientRect', {})
+      .then((res) => {
+        const rect = res as boundingClientRectRes
+        if (target === 'item') {
+          setItemRectOnMainThread(rect)
+          runOnBackground(syncItemRectCopy)(rect)
+          return
+        }
+        if (target === 'boundary') {
+          setBoundaryRectOnMainThread(rect)
+          runOnBackground(syncBoundaryRectCopy)(rect)
+          return
+        }
+
+        setScrollableBoundaryRectOnMainThread(rect)
+        runOnBackground(syncScrollableBoundaryRectCopy)(rect)
+      })
+  }, [
+    setBoundaryRectOnMainThread,
+    setItemRectOnMainThread,
+    setScrollableBoundaryRectOnMainThread,
+    syncBoundaryRectCopy,
+    syncItemRectCopy,
+    syncScrollableBoundaryRectCopy,
+  ])
+
+  const refreshDraggingRects = useCallback(() => {
+    'main thread'
+    measureRectById(itemElementId, 'item')
+    measureRectById(boundaryId, 'boundary')
+    measureRectById(scrollableBoundaryId, 'scrollableBoundary')
+  }, [
+    boundaryId,
+    itemElementId,
+    measureRectById,
+    scrollableBoundaryId,
+  ])
+
+  const scrollScrollableBoundaryBy = useCallback((
+    offset: number,
+    onScrolled?: () => void,
+  ) => {
+    'main thread'
+    if (
+      !scrollableBoundaryId
+      || offset === 0
+    ) {
+      onScrolled?.()
+      return
+    }
+
+    const element = lynx.querySelector(`#${scrollableBoundaryId}`)
+    if (!element) {
+      onScrolled?.()
+      return
+    }
+
+    element.invoke('scrollBy', {
+      offset,
+    }).then((res) => {
+      'main thread'
+      syncScrollDeltaForItemTranslateY(res as ScrollByResult, offset)
+      onScrolled?.()
+    })
+  }, [
+    autoScrollingRef,
+    scrollableBoundaryId,
+    sortingKey,
+    syncScrollDeltaForItemTranslateY,
+  ])
+
+  const isAutoScrollBlocked = useCallback((offset: number) => {
+    'main thread'
+    if (offset > 0) { // block autoScroll down when at lower edge
+      return scrollableBoundaryLowerEdgeRef?.current === true
+    }
+    if (offset < 0) { // block autoScroll up when at upper edge
+      return scrollableBoundaryUpperEdgeRef?.current === true
+    }
+    return false
+  }, [scrollableBoundaryLowerEdgeRef, scrollableBoundaryUpperEdgeRef])
+
+  const consumeQuantizedAutoScroll = useCallback((offset: number) => {
+    'main thread'
+    if (isAutoScrollBlocked(offset)) {
+      pendingAutoScrollDistance.current = 0
+      return 0
+    }
+
+    // if (offset > 0) {
+    //   if (scrollableBoundaryUpperEdgeRef) {
+    //     scrollableBoundaryUpperEdgeRef.current = false
+    //   }
+    // } else if (offset < 0 && scrollableBoundaryLowerEdgeRef) {
+    //   scrollableBoundaryLowerEdgeRef.current = false
+    // }
+
+    pendingAutoScrollDistance.current += offset
+    const quantumCount = Math.trunc(
+      pendingAutoScrollDistance.current / AUTO_SCROLL_QUANTUM,
+    )
+    if (quantumCount === 0) {
+      return 0
+    }
+
+    const quantizedOffset = quantumCount * AUTO_SCROLL_QUANTUM
+    if (isAutoScrollBlocked(quantizedOffset)) {
+      pendingAutoScrollDistance.current = 0
+      return 0
+    }
+
+    pendingAutoScrollDistance.current -= quantizedOffset
+    return quantizedOffset
+  }, [
+    isAutoScrollBlocked,
+    pendingAutoScrollDistance,
+    scrollableBoundaryLowerEdgeRef,
+    scrollableBoundaryUpperEdgeRef,
+  ])
+
+  const getDragStartItemBounds = useCallback((translateY: number) => {
+    'main thread'
+    const measuredTopAtDragStart = itemRect.current.top
+      - dragStartScrollDeltaFromMeasuredRect.current
+    const measuredBottomAtDragStart = itemRect.current.bottom
+      - dragStartScrollDeltaFromMeasuredRect.current
+
+    return {
+      top: measuredTopAtDragStart + translateY,
+      bottom: measuredBottomAtDragStart + translateY,
+    }
+  }, [dragStartScrollDeltaFromMeasuredRect, itemRect])
+
+  const getAutoScrollOverflow = useCallback((
+    distanceToTop: number,
+    distanceToBottom: number,
+  ) => {
+    'main thread'
+    return getStickyOverflow(
+      { distanceToTop, distanceToBottom },
+      scrollableStickyUpperOffset,
+      scrollableStickyLowerOffset,
+    )
+  }, [scrollableStickyLowerOffset, scrollableStickyUpperOffset])
+
+  const getDragStartClippedStickyDirection = useCallback(() => {
+    'main thread'
+    if (!scrollableBoundaryId || scrollableBoundaryRect.current.height <= 0) {
+      return 0
+    }
+
+    const draggedItem = getDragStartItemBounds(0)
+    return getClippedStickyDirection(
+      getEdgeDistance(draggedItem, scrollableBoundaryRect.current),
+    )
+  }, [
+    getDragStartItemBounds,
+    scrollableBoundaryId,
+    scrollableBoundaryRect,
+  ])
+
+  const getDragStartClippedAutoScrollOverflow = useCallback((
+    overflow: number,
+    distanceToTop: number,
+    distanceToBottom: number,
+  ) => {
+    'main thread'
+    const result = getClippedAutoScrollOverflow(
+      dragStartClippedStickyDirection.current,
+      overflow,
+      { distanceToTop, distanceToBottom },
+      scrollableStickyUpperOffset,
+      scrollableStickyLowerOffset,
+    )
+    dragStartClippedStickyDirection.current = result.clippedStickyDirection
+    return result.overflow
+  }, [
+    dragStartClippedStickyDirection,
+    scrollableStickyLowerOffset,
+    scrollableStickyUpperOffset,
+  ])
+
+  const getAutoScrollDirection = useCallback((
+    stickyDirection: number,
+    translateDeltaY: number,
+  ) => {
+    'main thread'
+    if (translateDeltaY === 0) {
+      return autoScrollDirection.current || stickyDirection
+    }
+
+    const dragDirection = translateDeltaY > 0 ? 1 : -1
+    return dragDirection === stickyDirection ? stickyDirection : 0
+  }, [autoScrollDirection])
+
+  const getVisualTranslateY = useCallback(() => {
+    'main thread'
+    const scrollDelta = syncScrollDeltaForItemTranslateY()
+    if (autoScrollStickyDirection.current > 0) {
+      return scrollableBoundaryRect.current.bottom
+        - itemRect.current.bottom
+        - scrollableStickyLowerOffset
+        + scrollDelta.measuredRectDeltaY
+    }
+    if (autoScrollStickyDirection.current < 0) {
+      return scrollableBoundaryRect.current.top
+        - itemRect.current.top
+        + scrollableStickyUpperOffset
+        + scrollDelta.measuredRectDeltaY
+    }
+    return latestDragTranslate.current.y + scrollDelta.dragDeltaY
+  }, [
+    autoScrollStickyDirection,
+    itemRect,
+    latestDragTranslate,
+    scrollableBoundaryRect,
+    scrollableStickyLowerOffset,
+    scrollableStickyUpperOffset,
+    syncScrollDeltaForItemTranslateY,
+  ])
+
+  const getStickyTranslateY = useCallback((stickyDirection: number) => {
+    'main thread'
+    const scrollDelta = syncScrollDeltaForItemTranslateY()
+    if (stickyDirection > 0) {
+      return scrollableBoundaryRect.current.bottom
+        - itemRect.current.bottom
+        - scrollableStickyLowerOffset
+        + scrollDelta.measuredRectDeltaY
+    }
+    if (stickyDirection < 0) {
+      return scrollableBoundaryRect.current.top
+        - itemRect.current.top
+        + scrollableStickyUpperOffset
+        + scrollDelta.measuredRectDeltaY
+    }
+    return latestDragTranslate.current.y + scrollDelta.dragDeltaY
+  }, [
+    itemRect,
+    latestDragTranslate,
+    scrollableBoundaryRect,
+    scrollableStickyLowerOffset,
+    scrollableStickyUpperOffset,
+    syncScrollDeltaForItemTranslateY,
+  ])
+
+  const getVisualBounds = useCallback((visualTranslateY: number) => {
+    'main thread'
+    const scrollDelta = syncScrollDeltaForItemTranslateY()
+    return {
+      top: itemRect.current.top
+        - scrollDelta.measuredRectDeltaY
+        + visualTranslateY,
+      bottom: itemRect.current.bottom
+        - scrollDelta.measuredRectDeltaY
+        + visualTranslateY,
+      left: itemRect.current.left + latestDragTranslate.current.x,
+      right: itemRect.current.right + latestDragTranslate.current.x,
+      width: itemRect.current.width,
+      height: itemRect.current.height,
+    }
+  }, [
+    itemRect,
+    latestDragTranslate,
+    syncScrollDeltaForItemTranslateY,
+  ])
+
+  const getVisualEdgeDistance = useCallback((visualTranslateY: number) => {
+    'main thread'
+    return getEdgeDistance(
+      getVisualBounds(visualTranslateY),
+      scrollableBoundaryRect.current,
+    )
+  }, [getVisualBounds, scrollableBoundaryRect])
+
+  const logStickyPosition = useCallback((
+    visualTranslateY: number,
+    rawStickyDirection: number,
+    overflow: number,
+    rawOverflow: number,
+    scrollDirection: number,
+    blockedByScrollableEdge: boolean,
+    distanceToTop: number,
+    distanceToBottom: number,
+    translateY: number,
+  ) => {
+    'main thread'
+    if (
+      rawStickyDirection === 0 && dragStartClippedStickyDirection.current === 0
+    ) {
+      return
+    }
+
+    const stickyTranslateY = getStickyTranslateY(rawStickyDirection)
+    const visualEdgeDistance = getVisualEdgeDistance(visualTranslateY)
+    console.info(
+      `[lynx-ui-sortable][SortableItem] stickyPosition, sortableKey: ${sortingKey}, translateY: ${translateY}, visualTranslateY: ${visualTranslateY}, stickyTranslateY: ${stickyTranslateY}, stickyDeltaY: ${
+        visualTranslateY - stickyTranslateY
+      }, rawStickyDirection: ${rawStickyDirection}, overflow: ${overflow}, rawOverflow: ${rawOverflow}, scrollDirection: ${scrollDirection}, blockedByScrollableEdge: ${blockedByScrollableEdge}, dragStartClippedStickyDirection: ${dragStartClippedStickyDirection.current}, distanceToTop: ${distanceToTop}, distanceToBottom: ${distanceToBottom}, visualDistanceToTop: ${visualEdgeDistance.distanceToTop}, visualDistanceToBottom: ${visualEdgeDistance.distanceToBottom}`,
+    )
+  }, [
+    dragStartClippedStickyDirection,
+    getVisualEdgeDistance,
+    getStickyTranslateY,
+    sortingKey,
+  ])
+
+  const getDragOverlayElement = useCallback(() => {
+    'main thread'
+    return dragOverlayRefMap?.current?.[sortingKey] ?? null
+  }, [dragOverlayRefMap, sortingKey])
+
+  const hideDragSourceItem = useCallback(() => {
+    'main thread'
+    if (!scrollableBoundaryId || dragSourceHidden.current) {
+      return
+    }
+
+    MTSRef.current?.MTSSetOtherStyles({
+      visibility: 'hidden',
+      opacity: '0',
+    })
+    dragSourceHidden.current = true
+  }, [
+    MTSRef,
+    dragSourceHidden,
+    scrollableBoundaryId,
+  ])
+
+  const showDragSourceItem = useCallback(() => {
+    'main thread'
+    if (!dragSourceHidden.current) {
+      return
+    }
+
+    MTSRef.current?.MTSSetOtherStyles({
+      visibility: 'visible',
+      opacity: '1',
+    })
+    dragSourceHidden.current = false
+  }, [
+    MTSRef,
+    dragSourceHidden,
+  ])
+
+  const updateDragOverlayTransform = useCallback((visualTranslateY: number) => {
+    'main thread'
+    if (!dragOverlayActive.current) {
+      return
+    }
+
+    const overlay = getDragOverlayElement()
+    if (!overlay) {
+      return
+    }
+
+    const bounds = getVisualBounds(visualTranslateY)
+    overlay.setStyleProperty(
+      'transform',
+      `translate(${bounds.left}px, ${bounds.top}px)`,
+    )
+  }, [
+    dragOverlayActive,
+    getDragOverlayElement,
+    getVisualBounds,
+  ])
+
+  const activateDragOverlay = useCallback(() => {
+    'main thread'
+    if (!scrollableBoundaryId) {
+      return
+    }
+
+    hideDragSourceItem()
+
+    const overlay = getDragOverlayElement()
+    if (!overlay) {
+      return
+    }
+
+    dragOverlayActive.current = true
+
+    const visualTranslateY = getVisualTranslateY()
+    const bounds = getVisualBounds(visualTranslateY)
+    overlay.setStyleProperties({
+      position: 'fixed',
+      top: '0px',
+      left: '0px',
+      width: `${bounds.width}px`,
+      height: `${bounds.height}px`,
+      opacity: '1',
+      visibility: 'visible',
+      // 'z-index': '10000',
+      transform: `translate(${bounds.left}px, ${bounds.top}px)`,
+    })
+  }, [
+    dragOverlayActive,
+    getDragOverlayElement,
+    getVisualBounds,
+    getVisualTranslateY,
+    hideDragSourceItem,
+    scrollableBoundaryId,
+  ])
+
+  const deactivateDragOverlay = useCallback(() => {
+    'main thread'
+    showDragSourceItem()
+
+    if (!dragOverlayActive.current) {
+      return
+    }
+
+    const overlay = getDragOverlayElement()
+    if (overlay) {
+      overlay.setStyleProperties({
+        opacity: '0',
+        visibility: 'hidden',
+        transform: 'translate(0px, 0px)',
+      })
+    }
+    dragOverlayActive.current = false
+  }, [
+    dragOverlayActive,
+    getDragOverlayElement,
+    showDragSourceItem,
+  ])
+
+  const applyVisualTranslate = useCallback(() => {
+    'main thread'
+    const visualTranslateY = getVisualTranslateY()
+    if (dragOverlayActive.current) {
+      MTSRef.current?.MTSSetTransform(0, 0)
+      updateDragOverlayTransform(visualTranslateY)
+    } else {
+      MTSRef.current?.MTSSetTransform(
+        latestDragTranslate.current.x,
+        visualTranslateY,
+      )
+    }
+    return visualTranslateY
+  }, [
+    MTSRef,
+    dragOverlayActive,
+    getVisualTranslateY,
+    latestDragTranslate,
+    updateDragOverlayTransform,
+  ])
+
+  const emitSortableDragMove = useCallback((
+    visualTranslateY: number,
+    event: MainThread.MouseEvent | MainThread.TouchEvent | null,
+  ) => {
+    'main thread'
+    if (!event) {
+      return
+    }
+
+    handleDragMove?.(
+      { x: latestDragTranslate.current.x, y: visualTranslateY },
+      sortingKey,
+      event,
+    )
+  }, [handleDragMove, latestDragTranslate, sortingKey])
+
+  const scheduleNextAutoScrollFrame = useCallback(() => {
+    'main thread'
+    const nextFrame = autoScrollFrameRef.current
+    if (nextFrame) {
+      setTimeout(nextFrame, 8)
+    }
+  }, [autoScrollFrameRef])
+
+  const finishAutoScrollFrame = useCallback(() => {
+    'main thread'
+    const visualTranslateY = applyVisualTranslate()
+
+    emitSortableDragMove(visualTranslateY, latestDragEvent.current)
+    scheduleNextAutoScrollFrame()
+  }, [
+    applyVisualTranslate,
+    emitSortableDragMove,
+    latestDragEvent,
+    scheduleNextAutoScrollFrame,
+  ])
+
+  const runAutoScrollFrame = useCallback(() => {
+    'main thread'
+    if (!autoScrollingRef.current) {
+      return
+    }
+
+    const overflow = autoScrollOverflow.current
+    if (overflow === 0) {
+      setAutoScrolling(false)
+      return
+    }
+
+    const direction = autoScrollDirection.current || (overflow > 0 ? 1 : -1)
+    if (isAutoScrollBlocked(direction)) {
+      pendingAutoScrollDistance.current = 0
+      const visualTranslateY = applyVisualTranslate()
+      emitSortableDragMove(visualTranslateY, latestDragEvent.current)
+      setAutoScrolling(false)
+      return
+    }
+
+    const step = direction * Math.min(
+      AUTO_SCROLL_MAX_STEP,
+      Math.max(
+        AUTO_SCROLL_QUANTUM,
+        Math.abs(overflow) * AUTO_SCROLL_VELOCITY_FACTOR,
+      ),
+    )
+    const emittedOffset = consumeQuantizedAutoScroll(step)
+    const finishScrolledFrame = () => {
+      'main thread'
+      finishAutoScrollFrame()
+    }
+
+    if (emittedOffset === 0) {
+      finishScrolledFrame()
+    } else {
+      scrollScrollableBoundaryBy(emittedOffset, finishScrolledFrame)
+    }
+  }, [
+    applyVisualTranslate,
+    autoScrollDirection,
+    autoScrollOverflow,
+    autoScrollingRef,
+    consumeQuantizedAutoScroll,
+    emitSortableDragMove,
+    finishAutoScrollFrame,
+    isAutoScrollBlocked,
+    latestDragEvent,
+    pendingAutoScrollDistance,
+    scrollScrollableBoundaryBy,
+    setAutoScrolling,
+  ])
+
+  const startAutoScrollLoop = useCallback(() => {
+    'main thread'
+    if (autoScrollingRef.current) {
+      return
+    }
+    autoScrollFrameRef.current = runAutoScrollFrame
+    setAutoScrolling(true)
+    scheduleNextAutoScrollFrame()
+  }, [
+    autoScrollingRef,
+    runAutoScrollFrame,
+    scheduleNextAutoScrollFrame,
+    setAutoScrolling,
+  ])
+
+  const stopAutoScrollLoop = useCallback(() => {
+    'main thread'
+    autoScrollOverflow.current = 0
+    autoScrollDirection.current = 0
+    autoScrollStickyDirection.current = 0
+    setAutoScrolling(false)
+  }, [
+    autoScrollDirection,
+    autoScrollOverflow,
+    autoScrollStickyDirection,
+    setAutoScrolling,
+  ])
+
   useEffect(() => {
     runOnMainThread(setChildrenMTSRef)(MTSRef, sortingKey)
-    if (boundaryId) {
-      ref?.current
-        ?.invoke({
-          method: 'boundingClientRect',
-          params: {},
-          success: (res) => {
-            setItemRect(res as boundingClientRectRes)
-          },
-        })
-        .exec()
-      lynx.createSelectorQuery().select(`#${boundaryId}`)?.invoke({
-        method: 'boundingClientRect',
-        params: {},
-        success: (res) => {
-          setBoundaryRect(res as boundingClientRectRes)
-        },
-      })
-        .exec()
-    }
-  }, [setChildrenRef, setChildrenMTSRef, sortingKey, data, boundaryId])
+    runOnMainThread(refreshDraggingRects)()
+  }, [
+    data,
+    refreshDraggingRects,
+    setChildrenRef,
+    setChildrenMTSRef,
+    sortingKey,
+  ])
 
   const handleMTSLayoutChange = (e: MainThread.LayoutChangeEvent) => {
     'main thread'
     updateItemSize(sortingKey, e.detail.height)
   }
 
+  const resetAutoScrollDragState = useCallback(() => {
+    'main thread'
+    lastAutoScrollTranslateY.current = 0
+    autoScrollDistanceSum.current = 0
+    pendingAutoScrollDistance.current = 0
+    autoScrollCompensationY.current = 0
+    autoScrollOverflow.current = 0
+    autoScrollDirection.current = 0
+    autoScrollStickyDirection.current = 0
+    dragStartClippedStickyDirection.current = 0
+    latestDragTranslate.current = { x: 0, y: 0 }
+  }, [
+    autoScrollCompensationY,
+    autoScrollDirection,
+    autoScrollDistanceSum,
+    autoScrollOverflow,
+    autoScrollStickyDirection,
+    dragStartClippedStickyDirection,
+    lastAutoScrollTranslateY,
+    latestDragTranslate,
+    pendingAutoScrollDistance,
+  ])
+
   const itemDragStart = (
     pagePoint: Point,
     event: MainThread.MouseEvent | MainThread.TouchEvent,
   ) => {
     'main thread'
+    resetAutoScrollDragState()
+    const scrollTop = scrollableScrollTopRef?.current ?? 0
+    autoScrollStartScrollTop.current = scrollTop
+    dragStartScrollDeltaFromMeasuredRect.current = scrollTop
+      - itemMeasuredScrollTop.current
+    dragStartClippedStickyDirection.current =
+      getDragStartClippedStickyDirection()
+    latestDragEvent.current = event
+    activateDragOverlay()
     handleDragStart?.(pagePoint, sortingKey, event)
   }
 
@@ -198,6 +1230,84 @@ export function SortableItem(props: SortableItemProps) {
     event: MainThread.MouseEvent | MainThread.TouchEvent,
   ) => {
     'main thread'
+    latestDragTranslate.current = translate
+    latestDragEvent.current = event
+    if (scrollableBoundaryId && scrollableBoundaryRect.current.height > 0) {
+      const draggedItem = getDragStartItemBounds(translate.y)
+      const { distanceToTop, distanceToBottom } = getEdgeDistance(
+        draggedItem,
+        scrollableBoundaryRect.current,
+      )
+      const translateDeltaY = translate.y - lastAutoScrollTranslateY.current
+      const rawOverflow = getAutoScrollOverflow(distanceToTop, distanceToBottom)
+      const overflow = getDragStartClippedAutoScrollOverflow(
+        rawOverflow,
+        distanceToTop,
+        distanceToBottom,
+      )
+
+      lastAutoScrollTranslateY.current = translate.y
+
+      if (overflow === 0) {
+        stopAutoScrollLoop()
+        const visualTranslateY = applyVisualTranslate()
+        logStickyPosition(
+          visualTranslateY,
+          rawOverflow > 0 ? 1 : (rawOverflow < 0 ? -1 : 0),
+          overflow,
+          rawOverflow,
+          0,
+          false,
+          distanceToTop,
+          distanceToBottom,
+          translate.y,
+        )
+        emitSortableDragMove(visualTranslateY, event)
+      } else {
+        const stickyDirection = overflow > 0 ? 1 : -1
+        const rawStickyDirection = rawOverflow > 0 ? 1 : -1
+        const scrollDirection = getAutoScrollDirection(
+          stickyDirection,
+          translateDeltaY,
+        )
+        const previousScrollDirection = autoScrollDirection.current
+        if (
+          previousScrollDirection !== 0
+          && previousScrollDirection !== scrollDirection
+        ) {
+          pendingAutoScrollDistance.current = 0
+        }
+        autoScrollOverflow.current = overflow
+        autoScrollStickyDirection.current = stickyDirection
+        autoScrollDirection.current = scrollDirection
+        const visualTranslateY = applyVisualTranslate()
+        const blockedByScrollableEdge = scrollDirection !== 0
+          && isAutoScrollBlocked(scrollDirection)
+        if (scrollDirection === 0) {
+          pendingAutoScrollDistance.current = 0
+          setAutoScrolling(false)
+        } else if (blockedByScrollableEdge) {
+          pendingAutoScrollDistance.current = 0
+          setAutoScrolling(false)
+        } else {
+          startAutoScrollLoop()
+        }
+        logStickyPosition(
+          visualTranslateY,
+          rawStickyDirection,
+          overflow,
+          rawOverflow,
+          scrollDirection,
+          blockedByScrollableEdge,
+          distanceToTop,
+          distanceToBottom,
+          translate.y,
+        )
+        emitSortableDragMove(visualTranslateY, event)
+      }
+      return
+    }
+
     handleDragMove?.(translate, sortingKey, event)
   }
 
@@ -206,19 +1316,25 @@ export function SortableItem(props: SortableItemProps) {
     event: MainThread.MouseEvent | MainThread.TouchEvent,
   ) => {
     'main thread'
+    deactivateDragOverlay()
+    resetAutoScrollDragState()
+    autoScrollStartScrollTop.current = 0
+    dragStartScrollDeltaFromMeasuredRect.current = 0
+    latestDragEvent.current = null
+    stopAutoScrollLoop()
     handleDragEnd?.(sortingKey, event)
   }
 
   const resetStyle = useMemo(
-    () => ({ transform: 'translate(0, 0)', zIndex: '0' }),
+    () => ({ transform: 'translate(0, 0)' }),
     [data],
   )
 
   if (as === 'Draggable') {
     return (
       <Draggable
+        id={itemElementId}
         MTSRef={MTSRef}
-        ref={ref}
         trigger='immediate'
         style={resetStyle}
         className={className}
@@ -230,10 +1346,12 @@ export function SortableItem(props: SortableItemProps) {
         onMTSDragEnd={itemDragEnd}
         onMTSDragging={itemDragging}
         allowedDirection={['up', 'down']}
-        {...(boundaryId
+        {...(!scrollableBoundaryId && boundaryId
           && {
-            minTranslateY: -(itemRect?.top - boundaryRect?.top),
-            maxTranslateY: boundaryRect?.bottom - itemRect?.bottom,
+            minTranslateY:
+              -(itemRectCopy.current.top - boundaryRectCopy.current.top),
+            maxTranslateY: boundaryRectCopy.current.bottom
+              - itemRectCopy.current.bottom,
           })}
       >
         {children}
@@ -242,8 +1360,8 @@ export function SortableItem(props: SortableItemProps) {
   } else {
     return (
       <DraggableRoot
+        id={itemElementId}
         MTSRef={MTSRef}
-        ref={ref}
         trigger='immediate'
         style={resetStyle}
         className={className}
@@ -254,10 +1372,12 @@ export function SortableItem(props: SortableItemProps) {
         onMTSDragEnd={itemDragEnd}
         onMTSDragging={itemDragging}
         enableDragging={enableSorting}
-        {...(boundaryId
+        {...(!scrollableBoundaryId && boundaryId
           && {
-            minTranslateY: -(itemRect?.top - boundaryRect?.top),
-            maxTranslateY: boundaryRect?.bottom - itemRect?.bottom,
+            minTranslateY:
+              -(itemRectCopy.current.top - boundaryRectCopy.current.top),
+            maxTranslateY: boundaryRectCopy.current.bottom
+              - itemRectCopy.current.bottom,
           })}
         allowedDirection={['up', 'down']}
       >

--- a/packages/lynx-ui-sortable/src/Sortable.tsx
+++ b/packages/lynx-ui-sortable/src/Sortable.tsx
@@ -3,14 +3,13 @@
 // LICENSE file in the root directory of this source tree.
 
 import {
-  runOnBackground,
   runOnMainThread,
   useCallback,
   useContext,
   useEffect,
   useMainThreadRef,
   useMemo,
-  useRef,
+  useState,
 } from '@lynx-js/react'
 import type { RefObject } from '@lynx-js/react'
 
@@ -25,7 +24,11 @@ import type { DraggableRef } from '@lynx-js/lynx-ui-draggable'
 import type { MainThread, ScrollEvent } from '@lynx-js/types'
 
 import { SortableContext } from './SortableContext'
-import type { SortableItemProps, SortableRootProps } from './types'
+import type {
+  SortableData,
+  SortableItemProps,
+  SortableRootProps,
+} from './types'
 import { useSortable } from './useSortable'
 
 export { DraggableArea as SortableItemArea }
@@ -96,7 +99,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     debugLog = false,
     boundaryId,
     scrollableBoundaryId,
-    scrollable = false,
+    as,
     scrollableClassName,
     scrollableContentClassName,
     scrollableEnableScroll = true,
@@ -106,6 +109,19 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     onSortStart,
     enableSorting = true,
   } = props
+  const scrollable = as === 'ScrollView'
+  const [isDragging, setIsDragging] = useState(false)
+  const handleInternalSortStart = useCallback(() => {
+    setIsDragging(true)
+    onSortStart?.()
+  }, [onSortStart])
+  const handleInternalSortEnd = useCallback(
+    (sortedData: SortableData<T>[]) => {
+      setIsDragging(false)
+      onSortEnd(sortedData)
+    },
+    [onSortEnd],
+  )
   const scrollableElementId = useMemo(
     () => scrollableBoundaryId ?? 'sortable-scrollable-boundary',
     [scrollableBoundaryId],
@@ -130,6 +146,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
   >(
     {},
   )
+  const dirtyKeysRef = useMainThreadRef<Record<string, boolean>>({})
   const scrollableBoundaryUpperEdgeRef = useMainThreadRef(false)
   const scrollableBoundaryLowerEdgeRef = useMainThreadRef(false)
   const scrollableScrollTopRef = useMainThreadRef(0)
@@ -192,8 +209,9 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     sizeMap: sizeMap,
     itemRefMap: childrenRefMap,
     itemMTSRefMap: childrenMTSRefMap,
-    onDragEnd: onSortEnd,
-    onDragStart: onSortStart,
+    dirtyKeysRef,
+    onDragEnd: handleInternalSortEnd,
+    onDragStart: handleInternalSortStart,
     debugLog,
   })
   const sortableContextValue = useMemo(() => ({
@@ -215,6 +233,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
       ? scrollableScrollTopRef
       : undefined,
     dragOverlayRefMap: scrollable ? dragOverlayRefMap : undefined,
+    dirtyKeysRef,
     scrollableStickyUpperOffset,
     scrollableStickyLowerOffset,
     updateItemSize,
@@ -237,6 +256,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     scrollableBoundaryUpperEdgeRef,
     scrollableScrollTopRef,
     dragOverlayRefMap,
+    dirtyKeysRef,
     scrollableStickyLowerOffset,
     scrollableStickyUpperOffset,
     updateItemSize,
@@ -269,7 +289,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
         <scroll-view
           id={scrollableElementId}
           className={scrollableClassName}
-          enable-scroll={scrollableEnableScroll}
+          enable-scroll={scrollableEnableScroll && !isDragging}
           scroll-orientation='vertical'
           main-thread:bindscroll={handleScrollableBoundaryScroll}
         >
@@ -385,6 +405,7 @@ function SortableInteractiveItem(props: SortableItemProps) {
     scrollableBoundaryLowerEdgeRef,
     scrollableScrollTopRef,
     dragOverlayRefMap,
+    dirtyKeysRef,
     scrollableStickyUpperOffset,
     scrollableStickyLowerOffset,
     updateItemSize,
@@ -396,7 +417,7 @@ function SortableInteractiveItem(props: SortableItemProps) {
   } = useContext(SortableContext)
 
   const MTSRef = useMainThreadRef<DraggableRef>(null)
-  const itemRect = useMainThreadRef<boundingClientRectRes>({
+  const [itemRect, setItemRect] = useState<boundingClientRectRes>({
     height: 0,
     width: 0,
     top: 0,
@@ -404,7 +425,7 @@ function SortableInteractiveItem(props: SortableItemProps) {
     bottom: 0,
     right: 0,
   })
-  const boundaryRect = useMainThreadRef<boundingClientRectRes>({
+  const [boundaryRect, setBoundaryRect] = useState<boundingClientRectRes>({
     height: 0,
     width: 0,
     top: 0,
@@ -412,33 +433,9 @@ function SortableInteractiveItem(props: SortableItemProps) {
     bottom: 0,
     right: 0,
   })
-  const scrollableBoundaryRect = useMainThreadRef<
+  const [scrollableBoundaryRect, setScrollableBoundaryRect] = useState<
     boundingClientRectRes
   >({
-    height: 0,
-    width: 0,
-    top: 0,
-    left: 0,
-    bottom: 0,
-    right: 0,
-  })
-  const itemRectCopy = useRef<boundingClientRectRes>({
-    height: 0,
-    width: 0,
-    top: 0,
-    left: 0,
-    bottom: 0,
-    right: 0,
-  })
-  const boundaryRectCopy = useRef<boundingClientRectRes>({
-    height: 0,
-    width: 0,
-    top: 0,
-    left: 0,
-    bottom: 0,
-    right: 0,
-  })
-  const scrollableBoundaryRectCopy = useRef<boundingClientRectRes>({
     height: 0,
     width: 0,
     top: 0,
@@ -516,76 +513,40 @@ function SortableInteractiveItem(props: SortableItemProps) {
     'main thread'
     autoScrollingRef.current = isAutoScrolling
   }, [autoScrollingRef])
-  const setItemRectOnMainThread = useCallback((rect: boundingClientRectRes) => {
+  const captureItemMeasuredScrollTop = useCallback(() => {
     'main thread'
-    itemRect.current = rect
     itemMeasuredScrollTop.current = scrollableScrollTopRef?.current ?? 0
-  }, [itemMeasuredScrollTop, itemRect, scrollableScrollTopRef])
-  const setBoundaryRectOnMainThread = useCallback(
-    (rect: boundingClientRectRes) => {
-      'main thread'
-      boundaryRect.current = rect
-    },
-    [boundaryRect],
-  )
-  const setScrollableBoundaryRectOnMainThread = useCallback(
-    (rect: boundingClientRectRes) => {
-      'main thread'
-      scrollableBoundaryRect.current = rect
-    },
-    [scrollableBoundaryRect],
-  )
-  const syncItemRectCopy = useCallback((rect: boundingClientRectRes) => {
-    itemRectCopy.current = rect
-  }, [])
-  const syncBoundaryRectCopy = useCallback((rect: boundingClientRectRes) => {
-    boundaryRectCopy.current = rect
-  }, [])
-  const syncScrollableBoundaryRectCopy = useCallback(
-    (rect: boundingClientRectRes) => {
-      scrollableBoundaryRectCopy.current = rect
-    },
-    [],
-  )
+  }, [itemMeasuredScrollTop, scrollableScrollTopRef])
 
   const measureRectById = useCallback((
     id: string | undefined,
     target: RectTarget,
   ) => {
-    'main thread'
     if (!id) {
       return
     }
 
-    const element = lynx.querySelector(`#${id}`)
-    element?.invoke('boundingClientRect', {})
-      .then((res) => {
+    lynx.createSelectorQuery().select(`#${id}`)?.invoke({
+      method: 'boundingClientRect',
+      params: {},
+      success: (res: unknown) => {
         const rect = res as boundingClientRectRes
         if (target === 'item') {
-          setItemRectOnMainThread(rect)
-          runOnBackground(syncItemRectCopy)(rect)
+          setItemRect(rect)
+          runOnMainThread(captureItemMeasuredScrollTop)()
           return
         }
         if (target === 'boundary') {
-          setBoundaryRectOnMainThread(rect)
-          runOnBackground(syncBoundaryRectCopy)(rect)
+          setBoundaryRect(rect)
           return
         }
 
-        setScrollableBoundaryRectOnMainThread(rect)
-        runOnBackground(syncScrollableBoundaryRectCopy)(rect)
-      })
-  }, [
-    setBoundaryRectOnMainThread,
-    setItemRectOnMainThread,
-    setScrollableBoundaryRectOnMainThread,
-    syncBoundaryRectCopy,
-    syncItemRectCopy,
-    syncScrollableBoundaryRectCopy,
-  ])
+        setScrollableBoundaryRect(rect)
+      },
+    }).exec()
+  }, [captureItemMeasuredScrollTop])
 
   const refreshDraggingRects = useCallback(() => {
-    'main thread'
     measureRectById(itemElementId, 'item')
     measureRectById(boundaryId, 'boundary')
     measureRectById(scrollableBoundaryId, 'scrollableBoundary')
@@ -642,9 +603,9 @@ function SortableInteractiveItem(props: SortableItemProps) {
 
   const getDragStartItemBounds = useCallback((translateY: number) => {
     'main thread'
-    const measuredTopAtDragStart = itemRect.current.top
+    const measuredTopAtDragStart = itemRect.top
       - dragStartScrollDeltaFromMeasuredRect.current
-    const measuredBottomAtDragStart = itemRect.current.bottom
+    const measuredBottomAtDragStart = itemRect.bottom
       - dragStartScrollDeltaFromMeasuredRect.current
 
     return {
@@ -682,14 +643,14 @@ function SortableInteractiveItem(props: SortableItemProps) {
     'main thread'
     const scrollDelta = syncScrollDeltaForItemTranslateY()
     if (autoScrollStickyDirection.current > 0) {
-      return scrollableBoundaryRect.current.bottom
-        - itemRect.current.bottom
+      return scrollableBoundaryRect.bottom
+        - itemRect.bottom
         - scrollableStickyLowerOffset
         + scrollDelta.measuredRectDeltaY
     }
     if (autoScrollStickyDirection.current < 0) {
-      return scrollableBoundaryRect.current.top
-        - itemRect.current.top
+      return scrollableBoundaryRect.top
+        - itemRect.top
         + scrollableStickyUpperOffset
         + scrollDelta.measuredRectDeltaY
     }
@@ -708,11 +669,11 @@ function SortableInteractiveItem(props: SortableItemProps) {
     'main thread'
     const scrollDelta = syncScrollDeltaForItemTranslateY()
     return {
-      top: itemRect.current.top - scrollDelta.measuredRectDeltaY
+      top: itemRect.top - scrollDelta.measuredRectDeltaY
         + visualTranslateY,
-      left: itemRect.current.left + latestDragTranslate.current.x,
-      width: itemRect.current.width,
-      height: itemRect.current.height,
+      left: itemRect.left + latestDragTranslate.current.x,
+      width: itemRect.width,
+      height: itemRect.height,
     }
   }, [
     itemRect,
@@ -736,10 +697,13 @@ function SortableInteractiveItem(props: SortableItemProps) {
       opacity: '0',
     })
     dragSourceHidden.current = true
+    dirtyKeysRef.current[sortingKey] = true
   }, [
     MTSRef,
     dragSourceHidden,
     scrollableBoundaryId,
+    dirtyKeysRef,
+    sortingKey,
   ])
 
   const showDragSourceItem = useCallback(() => {
@@ -814,6 +778,7 @@ function SortableInteractiveItem(props: SortableItemProps) {
     const visualTranslateY = getVisualTranslateY()
     if (scrollableBoundaryId) {
       MTSRef.current?.MTSSetTransform(0, 0)
+      console.info('reset local drag visual')
       updateDragOverlayTransform(visualTranslateY)
     } else {
       MTSRef.current?.MTSSetTransform(
@@ -821,6 +786,7 @@ function SortableInteractiveItem(props: SortableItemProps) {
         visualTranslateY,
       )
     }
+    dirtyKeysRef.current[sortingKey] = true
     return visualTranslateY
   }, [
     MTSRef,
@@ -828,6 +794,8 @@ function SortableInteractiveItem(props: SortableItemProps) {
     latestDragTranslate,
     scrollableBoundaryId,
     updateDragOverlayTransform,
+    dirtyKeysRef,
+    sortingKey,
   ])
 
   const emitSortableDragMove = useCallback((
@@ -940,7 +908,7 @@ function SortableInteractiveItem(props: SortableItemProps) {
 
   useEffect(() => {
     runOnMainThread(setChildrenMTSRef)(MTSRef, sortingKey)
-    runOnMainThread(refreshDraggingRects)()
+    refreshDraggingRects()
   }, [
     data,
     refreshDraggingRects,
@@ -984,8 +952,23 @@ function SortableInteractiveItem(props: SortableItemProps) {
     dragStartScrollDeltaFromMeasuredRect.current = scrollTop
       - itemMeasuredScrollTop.current
     latestDragEvent.current = event
+    if (scrollableBoundaryId && scrollableBoundaryRect.height > 0) {
+      const draggedItem = getDragStartItemBounds(0)
+      const { distanceToTop, distanceToBottom } = getEdgeDistance(
+        draggedItem,
+        scrollableBoundaryRect,
+      )
+      const overflow = getAutoScrollOverflow(distanceToTop, distanceToBottom)
+      if (overflow !== 0) {
+        autoScrollStickyDirection.current = overflow > 0 ? 1 : -1
+      }
+    }
     activateDragOverlay()
     handleDragStart?.(pagePoint, sortingKey, event)
+    if (autoScrollStickyDirection.current !== 0) {
+      const visualTranslateY = getVisualTranslateY()
+      emitSortableDragMove(visualTranslateY, event)
+    }
   }
 
   const itemDragging = (
@@ -995,11 +978,11 @@ function SortableInteractiveItem(props: SortableItemProps) {
     'main thread'
     latestDragTranslate.current = translate
     latestDragEvent.current = event
-    if (scrollableBoundaryId && scrollableBoundaryRect.current.height > 0) {
+    if (scrollableBoundaryId && scrollableBoundaryRect.height > 0) {
       const draggedItem = getDragStartItemBounds(translate.y)
       const { distanceToTop, distanceToBottom } = getEdgeDistance(
         draggedItem,
-        scrollableBoundaryRect.current,
+        scrollableBoundaryRect,
       )
       const translateDeltaY = translate.y - lastAutoScrollTranslateY.current
       const overflow = getAutoScrollOverflow(distanceToTop, distanceToBottom)
@@ -1037,26 +1020,12 @@ function SortableInteractiveItem(props: SortableItemProps) {
     handleDragMove?.(translate, sortingKey, event)
   }
 
-  const itemDragEnd = (
-    _pagePoint: Point,
-    event: MainThread.MouseEvent | MainThread.TouchEvent,
-  ) => {
+  const resetLocalDragVisuals = () => {
     'main thread'
-    resetAutoScrollDragState()
-    autoScrollStartScrollTop.current = 0
-    dragStartScrollDeltaFromMeasuredRect.current = 0
-    latestDragEvent.current = null
-    stopAutoScrollLoop()
-    handleDragEnd?.(sortingKey, event)
-  }
-
-  const dataKeyOrderSignature = useMemo(
-    () => (data ?? []).map(item => item.getSortingKey()).join('|'),
-    [data],
-  )
-
-  usePreCommit(() => {
-    'main thread'
+    if (!dirtyKeysRef.current[sortingKey]) {
+      return
+    }
+    console.info('reset local drag visual2')
     MTSRef.current?.MTSSetTransform(0, 0)
     const overlayWasActive = dragSourceHidden.current
     showDragSourceItem()
@@ -1070,6 +1039,35 @@ function SortableInteractiveItem(props: SortableItemProps) {
         })
       }
     }
+    dirtyKeysRef.current[sortingKey] = false
+  }
+
+  const itemDragEnd = (
+    _pagePoint: Point,
+    event: MainThread.MouseEvent | MainThread.TouchEvent,
+  ) => {
+    'main thread'
+    resetAutoScrollDragState()
+    autoScrollStartScrollTop.current = 0
+    dragStartScrollDeltaFromMeasuredRect.current = 0
+    latestDragEvent.current = null
+    stopAutoScrollLoop()
+    const orderChanged = handleDragEnd?.(sortingKey, event) ?? false
+    if (!orderChanged) {
+      // no data update -> no precommit will run -> reset locally now
+      resetLocalDragVisuals()
+    }
+    // if orderChanged: precommit will run resetLocalDragVisuals in the same frame as setData
+  }
+
+  const dataKeyOrderSignature = useMemo(
+    () => (data ?? []).map(item => item.getSortingKey()).join('|'),
+    [data],
+  )
+
+  usePreCommit(() => {
+    'main thread'
+    resetLocalDragVisuals()
   }, [dataKeyOrderSignature])
 
   if (as === 'Draggable') {
@@ -1089,10 +1087,9 @@ function SortableInteractiveItem(props: SortableItemProps) {
         allowedDirection={['up', 'down']}
         {...(!scrollableBoundaryId && boundaryId
           && {
-            minTranslateY:
-              -(itemRectCopy.current.top - boundaryRectCopy.current.top),
-            maxTranslateY: boundaryRectCopy.current.bottom
-              - itemRectCopy.current.bottom,
+            minTranslateY: -(itemRect.top - boundaryRect.top),
+            maxTranslateY: boundaryRect.bottom
+              - itemRect.bottom,
           })}
       >
         {children}
@@ -1114,10 +1111,9 @@ function SortableInteractiveItem(props: SortableItemProps) {
         enableDragging={enableSorting}
         {...(!scrollableBoundaryId && boundaryId
           && {
-            minTranslateY:
-              -(itemRectCopy.current.top - boundaryRectCopy.current.top),
-            maxTranslateY: boundaryRectCopy.current.bottom
-              - itemRectCopy.current.bottom,
+            minTranslateY: -(itemRect.top - boundaryRect.top),
+            maxTranslateY: boundaryRect.bottom
+              - itemRect.bottom,
           })}
         allowedDirection={['up', 'down']}
       >

--- a/packages/lynx-ui-sortable/src/Sortable.tsx
+++ b/packages/lynx-ui-sortable/src/Sortable.tsx
@@ -15,6 +15,7 @@ import {
 import type { RefObject } from '@lynx-js/react'
 
 import type { Point } from '@lynx-js/lynx-ui-common'
+import { usePreCommit } from '@lynx-js/lynx-ui-common'
 import {
   Draggable,
   DraggableArea,
@@ -46,12 +47,33 @@ interface EdgeDistance {
   distanceToTop: number
   distanceToBottom: number
 }
-interface ClippedOverflowResult {
-  clippedStickyDirection: number
-  overflow: number
+
+function getEdgeDistance(
+  itemBounds: VerticalBounds,
+  boundaryRect: VerticalBounds,
+): EdgeDistance {
+  'main thread'
+  return {
+    distanceToTop: itemBounds.top - boundaryRect.top,
+    distanceToBottom: boundaryRect.bottom - itemBounds.bottom,
+  }
 }
 
-const AUTO_SCROLL_QUANTUM = 8 / 11
+function getAutoScrollTriggerOverflow(
+  edgeDistance: EdgeDistance,
+  upperTriggerZone: number,
+  lowerTriggerZone: number,
+) {
+  'main thread'
+  if (edgeDistance.distanceToTop < upperTriggerZone) {
+    return edgeDistance.distanceToTop - upperTriggerZone
+  }
+  if (edgeDistance.distanceToBottom < lowerTriggerZone) {
+    return lowerTriggerZone - edgeDistance.distanceToBottom
+  }
+  return 0
+}
+
 const AUTO_SCROLL_MAX_STEP = 18
 const AUTO_SCROLL_VELOCITY_FACTOR = 0.35
 
@@ -65,69 +87,6 @@ function getSortableItemElementId(sortingKey: string) {
 
 function getSortableDragOverlayElementId(sortingKey: string) {
   return `sortable-drag-overlay-${getNormalizedElementKey(sortingKey)}`
-}
-
-function getEdgeDistance(
-  itemBounds: VerticalBounds,
-  boundaryRect: VerticalBounds,
-): EdgeDistance {
-  'main thread'
-  return {
-    distanceToTop: itemBounds.top - boundaryRect.top,
-    distanceToBottom: boundaryRect.bottom - itemBounds.bottom,
-  }
-}
-
-function getClippedStickyDirection(edgeDistance: EdgeDistance) {
-  'main thread'
-  if (edgeDistance.distanceToTop < 0) {
-    return -1
-  }
-  if (edgeDistance.distanceToBottom < 0) {
-    return 1
-  }
-  return 0
-}
-
-function getStickyOverflow(
-  edgeDistance: EdgeDistance,
-  stickyUpperOffset: number,
-  stickyLowerOffset: number,
-) {
-  'main thread'
-  if (edgeDistance.distanceToTop < stickyUpperOffset) {
-    return edgeDistance.distanceToTop - stickyUpperOffset
-  }
-  if (edgeDistance.distanceToBottom < stickyLowerOffset) {
-    return stickyLowerOffset - edgeDistance.distanceToBottom
-  }
-  return 0
-}
-
-function getClippedAutoScrollOverflow(
-  clippedStickyDirection: number,
-  overflow: number,
-  edgeDistance: EdgeDistance,
-  stickyUpperOffset: number,
-  stickyLowerOffset: number,
-): ClippedOverflowResult {
-  'main thread'
-  if (clippedStickyDirection < 0) {
-    if (edgeDistance.distanceToTop >= stickyUpperOffset) {
-      return { clippedStickyDirection: 0, overflow }
-    }
-    if (overflow < 0) {
-      return { clippedStickyDirection, overflow: 0 }
-    }
-  } else if (clippedStickyDirection > 0) {
-    if (edgeDistance.distanceToBottom >= stickyLowerOffset) {
-      return { clippedStickyDirection: 0, overflow }
-    }
-    if (overflow > 0) {
-      return { clippedStickyDirection, overflow: 0 }
-    }
-  }
-  return { clippedStickyDirection, overflow }
 }
 
 export function SortableRoot<T>(props: SortableRootProps<T>) {
@@ -229,7 +188,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
   }, [dragOverlayRefMap])
 
   const { handleDragEnd, handleDragMove, handleDragStart } = useSortable({
-    data: data as SortableData<unknown>[],
+    data: data,
     sizeMap: sizeMap,
     itemRefMap: childrenRefMap,
     itemMTSRefMap: childrenMTSRefMap,
@@ -394,7 +353,7 @@ function SortableDragOverlayItem(props: SortableItemProps) {
     height: '0px',
     opacity: 0,
     visibility: 'hidden',
-    // zIndex: '10000',
+    zIndex: '10000',
     transform: 'translate(0px, 0px)',
   } as const), [])
 
@@ -490,7 +449,6 @@ function SortableInteractiveItem(props: SortableItemProps) {
   const autoScrollingRef = useMainThreadRef(false)
   const lastAutoScrollTranslateY = useMainThreadRef(0)
   const autoScrollDistanceSum = useMainThreadRef(0)
-  const pendingAutoScrollDistance = useMainThreadRef(0)
   const autoScrollCompensationY = useMainThreadRef(0)
   const autoScrollStartScrollTop = useMainThreadRef(0)
   const itemMeasuredScrollTop = useMainThreadRef(0)
@@ -498,8 +456,6 @@ function SortableInteractiveItem(props: SortableItemProps) {
   const autoScrollOverflow = useMainThreadRef(0)
   const autoScrollDirection = useMainThreadRef(0)
   const autoScrollStickyDirection = useMainThreadRef(0)
-  const dragStartClippedStickyDirection = useMainThreadRef(0)
-  const dragOverlayActive = useMainThreadRef(false)
   const dragSourceHidden = useMainThreadRef(false)
   const latestDragTranslate = useMainThreadRef<Point>({ x: 0, y: 0 })
   const latestDragEvent = useMainThreadRef<
@@ -684,44 +640,6 @@ function SortableInteractiveItem(props: SortableItemProps) {
     return false
   }, [scrollableBoundaryLowerEdgeRef, scrollableBoundaryUpperEdgeRef])
 
-  const consumeQuantizedAutoScroll = useCallback((offset: number) => {
-    'main thread'
-    if (isAutoScrollBlocked(offset)) {
-      pendingAutoScrollDistance.current = 0
-      return 0
-    }
-
-    // if (offset > 0) {
-    //   if (scrollableBoundaryUpperEdgeRef) {
-    //     scrollableBoundaryUpperEdgeRef.current = false
-    //   }
-    // } else if (offset < 0 && scrollableBoundaryLowerEdgeRef) {
-    //   scrollableBoundaryLowerEdgeRef.current = false
-    // }
-
-    pendingAutoScrollDistance.current += offset
-    const quantumCount = Math.trunc(
-      pendingAutoScrollDistance.current / AUTO_SCROLL_QUANTUM,
-    )
-    if (quantumCount === 0) {
-      return 0
-    }
-
-    const quantizedOffset = quantumCount * AUTO_SCROLL_QUANTUM
-    if (isAutoScrollBlocked(quantizedOffset)) {
-      pendingAutoScrollDistance.current = 0
-      return 0
-    }
-
-    pendingAutoScrollDistance.current -= quantizedOffset
-    return quantizedOffset
-  }, [
-    isAutoScrollBlocked,
-    pendingAutoScrollDistance,
-    scrollableBoundaryLowerEdgeRef,
-    scrollableBoundaryUpperEdgeRef,
-  ])
-
   const getDragStartItemBounds = useCallback((translateY: number) => {
     'main thread'
     const measuredTopAtDragStart = itemRect.current.top
@@ -740,61 +658,24 @@ function SortableInteractiveItem(props: SortableItemProps) {
     distanceToBottom: number,
   ) => {
     'main thread'
-    return getStickyOverflow(
+    return getAutoScrollTriggerOverflow(
       { distanceToTop, distanceToBottom },
       scrollableStickyUpperOffset,
       scrollableStickyLowerOffset,
     )
   }, [scrollableStickyLowerOffset, scrollableStickyUpperOffset])
 
-  const getDragStartClippedStickyDirection = useCallback(() => {
-    'main thread'
-    if (!scrollableBoundaryId || scrollableBoundaryRect.current.height <= 0) {
-      return 0
-    }
-
-    const draggedItem = getDragStartItemBounds(0)
-    return getClippedStickyDirection(
-      getEdgeDistance(draggedItem, scrollableBoundaryRect.current),
-    )
-  }, [
-    getDragStartItemBounds,
-    scrollableBoundaryId,
-    scrollableBoundaryRect,
-  ])
-
-  const getDragStartClippedAutoScrollOverflow = useCallback((
-    overflow: number,
-    distanceToTop: number,
-    distanceToBottom: number,
-  ) => {
-    'main thread'
-    const result = getClippedAutoScrollOverflow(
-      dragStartClippedStickyDirection.current,
-      overflow,
-      { distanceToTop, distanceToBottom },
-      scrollableStickyUpperOffset,
-      scrollableStickyLowerOffset,
-    )
-    dragStartClippedStickyDirection.current = result.clippedStickyDirection
-    return result.overflow
-  }, [
-    dragStartClippedStickyDirection,
-    scrollableStickyLowerOffset,
-    scrollableStickyUpperOffset,
-  ])
-
   const getAutoScrollDirection = useCallback((
-    stickyDirection: number,
+    overflowDirection: number,
     translateDeltaY: number,
   ) => {
     'main thread'
     if (translateDeltaY === 0) {
-      return autoScrollDirection.current || stickyDirection
+      return autoScrollDirection.current || overflowDirection
     }
 
     const dragDirection = translateDeltaY > 0 ? 1 : -1
-    return dragDirection === stickyDirection ? stickyDirection : 0
+    return dragDirection === overflowDirection ? overflowDirection : 0
   }, [autoScrollDirection])
 
   const getVisualTranslateY = useCallback(() => {
@@ -823,43 +704,13 @@ function SortableInteractiveItem(props: SortableItemProps) {
     syncScrollDeltaForItemTranslateY,
   ])
 
-  const getStickyTranslateY = useCallback((stickyDirection: number) => {
-    'main thread'
-    const scrollDelta = syncScrollDeltaForItemTranslateY()
-    if (stickyDirection > 0) {
-      return scrollableBoundaryRect.current.bottom
-        - itemRect.current.bottom
-        - scrollableStickyLowerOffset
-        + scrollDelta.measuredRectDeltaY
-    }
-    if (stickyDirection < 0) {
-      return scrollableBoundaryRect.current.top
-        - itemRect.current.top
-        + scrollableStickyUpperOffset
-        + scrollDelta.measuredRectDeltaY
-    }
-    return latestDragTranslate.current.y + scrollDelta.dragDeltaY
-  }, [
-    itemRect,
-    latestDragTranslate,
-    scrollableBoundaryRect,
-    scrollableStickyLowerOffset,
-    scrollableStickyUpperOffset,
-    syncScrollDeltaForItemTranslateY,
-  ])
-
   const getVisualBounds = useCallback((visualTranslateY: number) => {
     'main thread'
     const scrollDelta = syncScrollDeltaForItemTranslateY()
     return {
-      top: itemRect.current.top
-        - scrollDelta.measuredRectDeltaY
-        + visualTranslateY,
-      bottom: itemRect.current.bottom
-        - scrollDelta.measuredRectDeltaY
+      top: itemRect.current.top - scrollDelta.measuredRectDeltaY
         + visualTranslateY,
       left: itemRect.current.left + latestDragTranslate.current.x,
-      right: itemRect.current.right + latestDragTranslate.current.x,
       width: itemRect.current.width,
       height: itemRect.current.height,
     }
@@ -867,46 +718,6 @@ function SortableInteractiveItem(props: SortableItemProps) {
     itemRect,
     latestDragTranslate,
     syncScrollDeltaForItemTranslateY,
-  ])
-
-  const getVisualEdgeDistance = useCallback((visualTranslateY: number) => {
-    'main thread'
-    return getEdgeDistance(
-      getVisualBounds(visualTranslateY),
-      scrollableBoundaryRect.current,
-    )
-  }, [getVisualBounds, scrollableBoundaryRect])
-
-  const logStickyPosition = useCallback((
-    visualTranslateY: number,
-    rawStickyDirection: number,
-    overflow: number,
-    rawOverflow: number,
-    scrollDirection: number,
-    blockedByScrollableEdge: boolean,
-    distanceToTop: number,
-    distanceToBottom: number,
-    translateY: number,
-  ) => {
-    'main thread'
-    if (
-      rawStickyDirection === 0 && dragStartClippedStickyDirection.current === 0
-    ) {
-      return
-    }
-
-    const stickyTranslateY = getStickyTranslateY(rawStickyDirection)
-    const visualEdgeDistance = getVisualEdgeDistance(visualTranslateY)
-    console.info(
-      `[lynx-ui-sortable][SortableItem] stickyPosition, sortableKey: ${sortingKey}, translateY: ${translateY}, visualTranslateY: ${visualTranslateY}, stickyTranslateY: ${stickyTranslateY}, stickyDeltaY: ${
-        visualTranslateY - stickyTranslateY
-      }, rawStickyDirection: ${rawStickyDirection}, overflow: ${overflow}, rawOverflow: ${rawOverflow}, scrollDirection: ${scrollDirection}, blockedByScrollableEdge: ${blockedByScrollableEdge}, dragStartClippedStickyDirection: ${dragStartClippedStickyDirection.current}, distanceToTop: ${distanceToTop}, distanceToBottom: ${distanceToBottom}, visualDistanceToTop: ${visualEdgeDistance.distanceToTop}, visualDistanceToBottom: ${visualEdgeDistance.distanceToBottom}`,
-    )
-  }, [
-    dragStartClippedStickyDirection,
-    getVisualEdgeDistance,
-    getStickyTranslateY,
-    sortingKey,
   ])
 
   const getDragOverlayElement = useCallback(() => {
@@ -949,10 +760,6 @@ function SortableInteractiveItem(props: SortableItemProps) {
 
   const updateDragOverlayTransform = useCallback((visualTranslateY: number) => {
     'main thread'
-    if (!dragOverlayActive.current) {
-      return
-    }
-
     const overlay = getDragOverlayElement()
     if (!overlay) {
       return
@@ -964,7 +771,6 @@ function SortableInteractiveItem(props: SortableItemProps) {
       `translate(${bounds.left}px, ${bounds.top}px)`,
     )
   }, [
-    dragOverlayActive,
     getDragOverlayElement,
     getVisualBounds,
   ])
@@ -982,8 +788,6 @@ function SortableInteractiveItem(props: SortableItemProps) {
       return
     }
 
-    dragOverlayActive.current = true
-
     const visualTranslateY = getVisualTranslateY()
     const bounds = getVisualBounds(visualTranslateY)
     overlay.setStyleProperties({
@@ -994,11 +798,10 @@ function SortableInteractiveItem(props: SortableItemProps) {
       height: `${bounds.height}px`,
       opacity: '1',
       visibility: 'visible',
-      // 'z-index': '10000',
+      'z-index': '10000',
       transform: `translate(${bounds.left}px, ${bounds.top}px)`,
     })
   }, [
-    dragOverlayActive,
     getDragOverlayElement,
     getVisualBounds,
     getVisualTranslateY,
@@ -1006,33 +809,10 @@ function SortableInteractiveItem(props: SortableItemProps) {
     scrollableBoundaryId,
   ])
 
-  const deactivateDragOverlay = useCallback(() => {
-    'main thread'
-    showDragSourceItem()
-
-    if (!dragOverlayActive.current) {
-      return
-    }
-
-    const overlay = getDragOverlayElement()
-    if (overlay) {
-      overlay.setStyleProperties({
-        opacity: '0',
-        visibility: 'hidden',
-        transform: 'translate(0px, 0px)',
-      })
-    }
-    dragOverlayActive.current = false
-  }, [
-    dragOverlayActive,
-    getDragOverlayElement,
-    showDragSourceItem,
-  ])
-
   const applyVisualTranslate = useCallback(() => {
     'main thread'
     const visualTranslateY = getVisualTranslateY()
-    if (dragOverlayActive.current) {
+    if (scrollableBoundaryId) {
       MTSRef.current?.MTSSetTransform(0, 0)
       updateDragOverlayTransform(visualTranslateY)
     } else {
@@ -1044,9 +824,9 @@ function SortableInteractiveItem(props: SortableItemProps) {
     return visualTranslateY
   }, [
     MTSRef,
-    dragOverlayActive,
     getVisualTranslateY,
     latestDragTranslate,
+    scrollableBoundaryId,
     updateDragOverlayTransform,
   ])
 
@@ -1101,7 +881,6 @@ function SortableInteractiveItem(props: SortableItemProps) {
 
     const direction = autoScrollDirection.current || (overflow > 0 ? 1 : -1)
     if (isAutoScrollBlocked(direction)) {
-      pendingAutoScrollDistance.current = 0
       const visualTranslateY = applyVisualTranslate()
       emitSortableDragMove(visualTranslateY, latestDragEvent.current)
       setAutoScrolling(false)
@@ -1110,33 +889,23 @@ function SortableInteractiveItem(props: SortableItemProps) {
 
     const step = direction * Math.min(
       AUTO_SCROLL_MAX_STEP,
-      Math.max(
-        AUTO_SCROLL_QUANTUM,
-        Math.abs(overflow) * AUTO_SCROLL_VELOCITY_FACTOR,
-      ),
+      Math.abs(overflow) * AUTO_SCROLL_VELOCITY_FACTOR,
     )
-    const emittedOffset = consumeQuantizedAutoScroll(step)
     const finishScrolledFrame = () => {
       'main thread'
       finishAutoScrollFrame()
     }
 
-    if (emittedOffset === 0) {
-      finishScrolledFrame()
-    } else {
-      scrollScrollableBoundaryBy(emittedOffset, finishScrolledFrame)
-    }
+    scrollScrollableBoundaryBy(step, finishScrolledFrame)
   }, [
     applyVisualTranslate,
     autoScrollDirection,
     autoScrollOverflow,
     autoScrollingRef,
-    consumeQuantizedAutoScroll,
     emitSortableDragMove,
     finishAutoScrollFrame,
     isAutoScrollBlocked,
     latestDragEvent,
-    pendingAutoScrollDistance,
     scrollScrollableBoundaryBy,
     setAutoScrolling,
   ])
@@ -1189,12 +958,10 @@ function SortableInteractiveItem(props: SortableItemProps) {
     'main thread'
     lastAutoScrollTranslateY.current = 0
     autoScrollDistanceSum.current = 0
-    pendingAutoScrollDistance.current = 0
     autoScrollCompensationY.current = 0
     autoScrollOverflow.current = 0
     autoScrollDirection.current = 0
     autoScrollStickyDirection.current = 0
-    dragStartClippedStickyDirection.current = 0
     latestDragTranslate.current = { x: 0, y: 0 }
   }, [
     autoScrollCompensationY,
@@ -1202,10 +969,8 @@ function SortableInteractiveItem(props: SortableItemProps) {
     autoScrollDistanceSum,
     autoScrollOverflow,
     autoScrollStickyDirection,
-    dragStartClippedStickyDirection,
     lastAutoScrollTranslateY,
     latestDragTranslate,
-    pendingAutoScrollDistance,
   ])
 
   const itemDragStart = (
@@ -1218,8 +983,6 @@ function SortableInteractiveItem(props: SortableItemProps) {
     autoScrollStartScrollTop.current = scrollTop
     dragStartScrollDeltaFromMeasuredRect.current = scrollTop
       - itemMeasuredScrollTop.current
-    dragStartClippedStickyDirection.current =
-      getDragStartClippedStickyDirection()
     latestDragEvent.current = event
     activateDragOverlay()
     handleDragStart?.(pagePoint, sortingKey, event)
@@ -1239,70 +1002,33 @@ function SortableInteractiveItem(props: SortableItemProps) {
         scrollableBoundaryRect.current,
       )
       const translateDeltaY = translate.y - lastAutoScrollTranslateY.current
-      const rawOverflow = getAutoScrollOverflow(distanceToTop, distanceToBottom)
-      const overflow = getDragStartClippedAutoScrollOverflow(
-        rawOverflow,
-        distanceToTop,
-        distanceToBottom,
-      )
+      const overflow = getAutoScrollOverflow(distanceToTop, distanceToBottom)
 
       lastAutoScrollTranslateY.current = translate.y
 
       if (overflow === 0) {
         stopAutoScrollLoop()
         const visualTranslateY = applyVisualTranslate()
-        logStickyPosition(
-          visualTranslateY,
-          rawOverflow > 0 ? 1 : (rawOverflow < 0 ? -1 : 0),
-          overflow,
-          rawOverflow,
-          0,
-          false,
-          distanceToTop,
-          distanceToBottom,
-          translate.y,
-        )
         emitSortableDragMove(visualTranslateY, event)
       } else {
-        const stickyDirection = overflow > 0 ? 1 : -1
-        const rawStickyDirection = rawOverflow > 0 ? 1 : -1
+        const overflowDirection = overflow > 0 ? 1 : -1
         const scrollDirection = getAutoScrollDirection(
-          stickyDirection,
+          overflowDirection,
           translateDeltaY,
         )
-        const previousScrollDirection = autoScrollDirection.current
-        if (
-          previousScrollDirection !== 0
-          && previousScrollDirection !== scrollDirection
-        ) {
-          pendingAutoScrollDistance.current = 0
-        }
         autoScrollOverflow.current = overflow
-        autoScrollStickyDirection.current = stickyDirection
+        autoScrollStickyDirection.current = overflowDirection
         autoScrollDirection.current = scrollDirection
         const visualTranslateY = applyVisualTranslate()
         const blockedByScrollableEdge = scrollDirection !== 0
           && isAutoScrollBlocked(scrollDirection)
         if (scrollDirection === 0) {
-          pendingAutoScrollDistance.current = 0
           setAutoScrolling(false)
         } else if (blockedByScrollableEdge) {
-          pendingAutoScrollDistance.current = 0
           setAutoScrolling(false)
         } else {
           startAutoScrollLoop()
         }
-        logStickyPosition(
-          visualTranslateY,
-          rawStickyDirection,
-          overflow,
-          rawOverflow,
-          scrollDirection,
-          blockedByScrollableEdge,
-          distanceToTop,
-          distanceToBottom,
-          translate.y,
-        )
         emitSortableDragMove(visualTranslateY, event)
       }
       return
@@ -1316,7 +1042,6 @@ function SortableInteractiveItem(props: SortableItemProps) {
     event: MainThread.MouseEvent | MainThread.TouchEvent,
   ) => {
     'main thread'
-    deactivateDragOverlay()
     resetAutoScrollDragState()
     autoScrollStartScrollTop.current = 0
     dragStartScrollDeltaFromMeasuredRect.current = 0
@@ -1325,10 +1050,27 @@ function SortableInteractiveItem(props: SortableItemProps) {
     handleDragEnd?.(sortingKey, event)
   }
 
-  const resetStyle = useMemo(
-    () => ({ transform: 'translate(0, 0)' }),
+  const dataKeyOrderSignature = useMemo(
+    () => (data ?? []).map(item => item.getSortingKey()).join('|'),
     [data],
   )
+
+  usePreCommit(() => {
+    'main thread'
+    MTSRef.current?.MTSSetTransform(0, 0)
+    const overlayWasActive = dragSourceHidden.current
+    showDragSourceItem()
+    if (overlayWasActive) {
+      const overlay = getDragOverlayElement()
+      if (overlay) {
+        overlay.setStyleProperties({
+          opacity: '0',
+          visibility: 'hidden',
+          transform: 'translate(0px, 0px)',
+        })
+      }
+    }
+  }, [dataKeyOrderSignature])
 
   if (as === 'Draggable') {
     return (
@@ -1336,7 +1078,6 @@ function SortableInteractiveItem(props: SortableItemProps) {
         id={itemElementId}
         MTSRef={MTSRef}
         trigger='immediate'
-        style={resetStyle}
         className={className}
         enableDragging={enableSorting}
         draggableProps={{
@@ -1363,7 +1104,6 @@ function SortableInteractiveItem(props: SortableItemProps) {
         id={itemElementId}
         MTSRef={MTSRef}
         trigger='immediate'
-        style={resetStyle}
         className={className}
         draggableProps={{
           'main-thread:bindlayoutchange': handleMTSLayoutChange,

--- a/packages/lynx-ui-sortable/src/SortableContext.ts
+++ b/packages/lynx-ui-sortable/src/SortableContext.ts
@@ -23,6 +23,7 @@ interface SortableContextType<T = unknown> {
   dragOverlayRefMap?: MutableRefObject<
     Record<string, MainThread.Element | null>
   >
+  dirtyKeysRef: MutableRefObject<Record<string, boolean>>
   scrollableStickyUpperOffset: number
   scrollableStickyLowerOffset: number
   debugLog: boolean
@@ -60,6 +61,7 @@ export const SortableContext = createContext<SortableContextType>({
   enableSorting: true,
   scrollableStickyUpperOffset: 0,
   scrollableStickyLowerOffset: 0,
+  dirtyKeysRef: { current: {} },
   updateItemSize: noop,
   setChildrenRef: noop,
   setChildrenMTSRef: noop,

--- a/packages/lynx-ui-sortable/src/SortableContext.ts
+++ b/packages/lynx-ui-sortable/src/SortableContext.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import { createContext } from '@lynx-js/react'
-import type { RefObject } from '@lynx-js/react'
+import type { MutableRefObject, RefObject } from '@lynx-js/react'
 
 import { noop } from '@lynx-js/lynx-ui-common'
 import type { Point } from '@lynx-js/lynx-ui-common'
@@ -14,12 +14,27 @@ import type { SortableData } from './types'
 
 interface SortableContextType<T = unknown> {
   data: SortableData<T>[]
+  isDragOverlay: boolean
   boundaryId?: string
+  scrollableBoundaryId?: string
+  scrollableBoundaryUpperEdgeRef?: MutableRefObject<boolean>
+  scrollableBoundaryLowerEdgeRef?: MutableRefObject<boolean>
+  scrollableScrollTopRef?: MutableRefObject<number>
+  dragOverlayRefMap?: MutableRefObject<
+    Record<string, MainThread.Element | null>
+  >
+  scrollableStickyUpperOffset: number
+  scrollableStickyLowerOffset: number
+  debugLog: boolean
   enableSorting: boolean
   updateItemSize: (sortingKey: string, size: number) => void
   setChildrenRef: (refI: RefObject<DraggableRef>, key: string) => void
   setChildrenMTSRef: (
     refI: RefObject<DraggableRef>,
+    key: string,
+  ) => void
+  setDragOverlayRef: (
+    refI: RefObject<MainThread.Element | null>,
     key: string,
   ) => void
   handleDragStart: (
@@ -40,10 +55,15 @@ interface SortableContextType<T = unknown> {
 
 export const SortableContext = createContext<SortableContextType>({
   data: [],
+  isDragOverlay: false,
+  debugLog: false,
   enableSorting: true,
+  scrollableStickyUpperOffset: 0,
+  scrollableStickyLowerOffset: 0,
   updateItemSize: noop,
   setChildrenRef: noop,
   setChildrenMTSRef: noop,
+  setDragOverlayRef: noop,
   handleDragStart: noop,
   handleDragMove: noop,
   handleDragEnd: noop,

--- a/packages/lynx-ui-sortable/src/types/index.docs.ts
+++ b/packages/lynx-ui-sortable/src/types/index.docs.ts
@@ -29,6 +29,58 @@ export interface SortableData<T> {
 
 export interface SortableRootProps<T> {
   /**
+   * Whether SortableRoot should render and own a vertical `scroll-view` as its scrollable boundary.
+   * @defaultValue false
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh SortableRoot 是否渲染并持有一个纵向 `scroll-view` 作为可滚动边界。
+   */
+  scrollable?: boolean
+  /**
+   * Class name applied to the owned `scroll-view` when `scrollable` is true.
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh `scrollable` 为 true 时应用到内部 `scroll-view` 的类名。
+   */
+  scrollableClassName?: string
+  /**
+   * Class name applied to the owned content boundary view when `scrollable` is true.
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh `scrollable` 为 true 时应用到内部内容边界 view 的类名。
+   */
+  scrollableContentClassName?: string
+  /**
+   * Whether the owned `scroll-view` can be scrolled by user gestures.
+   * @defaultValue true
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh 内部 `scroll-view` 是否允许用户手势滚动。
+   */
+  scrollableEnableScroll?: boolean
+  /**
+   * Distance between the dragged item and the upper edge of the owned or configured scrollable boundary while auto-scrolling upward.
+   * @defaultValue 0
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh 向上自动滚动时，拖拽项与可滚动边界上边缘之间保持的距离。
+   */
+  scrollableStickyUpperOffset?: number
+  /**
+   * Distance between the dragged item and the lower edge of the owned or configured scrollable boundary while auto-scrolling downward.
+   * @defaultValue 0
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh 向下自动滚动时，拖拽项与可滚动边界下边缘之间保持的距离。
+   */
+  scrollableStickyLowerOffset?: number
+  /**
    * Whether to enable sorting.
    * @defaultValue true
    * @Android
@@ -61,6 +113,14 @@ export interface SortableRootProps<T> {
    * @zh 作为边界限制的项的唯一键。如果项被拖出边界，排序将被取消。
    */
   boundaryId?: string
+  /**
+   * The unique id of a scrollable boundary container. When the dragged item reaches the edge of this container, Sortable will call `scrollBy` on it so the list can continue moving with the drag direction.
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh 可滚动边界容器的唯一 id。当拖拽项触达该容器边缘时，Sortable 会对其调用 `scrollBy`，使列表随拖拽方向继续滚动。
+   */
+  scrollableBoundaryId?: string
   /**
    * Callback function that is triggered when sorting ends. The parameter is the sorted data.
    * @Android

--- a/packages/lynx-ui-sortable/src/types/index.docs.ts
+++ b/packages/lynx-ui-sortable/src/types/index.docs.ts
@@ -29,28 +29,31 @@ export interface SortableData<T> {
 
 export interface SortableRootProps<T> {
   /**
-   * Whether SortableRoot should render and own a vertical `scroll-view` as its scrollable boundary.
-   * @defaultValue false
+   * Specifies which container element SortableRoot should render and own as the scrollable boundary.
+   * - `'ScrollView'`: render an internal vertical `scroll-view`.
+   * - Omit (default): render a plain `view` without scrolling capability.
    * @Android
    * @iOS
    * @Harmony
-   * @zh SortableRoot 是否渲染并持有一个纵向 `scroll-view` 作为可滚动边界。
+   * @zh 指定 SortableRoot 渲染并持有的滚动容器类型。
+   * - `'ScrollView'`：渲染一个内部的纵向 `scroll-view`。
+   * - 不传（默认）：渲染普通 `view`，不带滚动能力。
    */
-  scrollable?: boolean
+  as?: 'ScrollView'
   /**
-   * Class name applied to the owned `scroll-view` when `scrollable` is true.
+   * Class name applied to the owned `scroll-view` when `as` is `'ScrollView'`.
    * @Android
    * @iOS
    * @Harmony
-   * @zh `scrollable` 为 true 时应用到内部 `scroll-view` 的类名。
+   * @zh `as` 为 `'ScrollView'` 时应用到内部 `scroll-view` 的类名。
    */
   scrollableClassName?: string
   /**
-   * Class name applied to the owned content boundary view when `scrollable` is true.
+   * Class name applied to the owned content boundary view when `as` is `'ScrollView'`.
    * @Android
    * @iOS
    * @Harmony
-   * @zh `scrollable` 为 true 时应用到内部内容边界 view 的类名。
+   * @zh `as` 为 `'ScrollView'` 时应用到内部内容边界 view 的类名。
    */
   scrollableContentClassName?: string
   /**

--- a/packages/lynx-ui-sortable/src/useSortable.tsx
+++ b/packages/lynx-ui-sortable/src/useSortable.tsx
@@ -22,6 +22,7 @@ interface SortableOptionsType<T> {
   sizeMap: MainThreadRef<Record<string, number>> // sorting key -> size
   itemRefMap: RefObject<Record<string, DraggableRef | null>>
   itemMTSRefMap: MainThreadRef<Record<string, DraggableRef | null>> // sortingKey -> element Ref
+  dirtyKeysRef: MainThreadRef<Record<string, boolean>>
   onDragEnd?: (sortedKeyArray: SortableData<T>[]) => void
   onDragStart?: () => void
   debugLog?: boolean
@@ -34,6 +35,7 @@ export function useSortable<T>(
     data,
     sizeMap,
     itemMTSRefMap,
+    dirtyKeysRef,
     onDragEnd,
     onDragStart,
     debugLog = false,
@@ -57,7 +59,8 @@ export function useSortable<T>(
     item?.MTSSetOtherStyles({
       'z-index': `${zIndex}`,
     })
-  }, [itemMTSRefMap])
+    dirtyKeysRef.current[sortingKey] = true
+  }, [itemMTSRefMap, dirtyKeysRef])
 
   const handleDragStartJS = useCallback(() => {
     onDragStart?.()
@@ -132,12 +135,16 @@ export function useSortable<T>(
   )
 
   const setTransform = useCallback(
-    (item: DraggableRef | null, translate: number) => {
+    (key: string, translate: number) => {
       'main thread'
 
+      const item = key ? itemMTSRefMap.current[key] : null
       item?.MTSSetTransform(0, translate)
+      if (key) {
+        dirtyKeysRef.current[key] = true
+      }
     },
-    [],
+    [itemMTSRefMap, dirtyKeysRef],
   )
 
   // Clamp the previous interacting item to the grid
@@ -149,19 +156,17 @@ export function useSortable<T>(
     )
     const draggingItemSize = sizeMap.current[sortingKey]
     if (lastSwappingKey.current !== null) {
-      const lastSwappingItem = lastSwappingKey.current
-        ? itemMTSRefMap.current[lastSwappingKey.current]
-        : null
+      const lastSwappingItemKey = lastSwappingKey.current
       if (
         Math.abs(swappingItemTranslation.current)
           > draggingItemSize * swapConfirmedPercentage.current
       ) {
         setTransform(
-          lastSwappingItem,
+          lastSwappingItemKey,
           (movingDistance < 0 ? 1 : -1) * draggingItemSize,
         )
       } else {
-        setTransform(lastSwappingItem, 0)
+        setTransform(lastSwappingItemKey, 0)
       }
     }
   }
@@ -252,7 +257,6 @@ export function useSortable<T>(
         return
       }
       const swappingKey = keyArray[swappingIndex]
-      const swappingItem = itemMTSRefMap.current[swappingKey]
 
       if (swappingKey !== lastSwappingKey.current) {
         updateLastSwappingItem(movingDistance, sortingKey, swappingKey)
@@ -261,7 +265,7 @@ export function useSortable<T>(
 
       const unconsumedDistance = movingDistance - consumedDistance
       updateConfirmedInteractedID(unconsumedDistance, sortingKey)
-      setTransform(swappingItem, -unconsumedDistance)
+      setTransform(swappingKey, -unconsumedDistance)
     },
     [
       changedKey,
@@ -309,6 +313,14 @@ export function useSortable<T>(
     return swappedKeyArray
   }, [keyArray, lastSwappedKey])
 
+  const resetSwapTrackingRefs = useCallback(() => {
+    'main thread'
+    lastSwappedKey.current = ''
+    lastSwappingKey.current = ''
+    swappingItemTranslation.current = 0
+    changedKey.current = []
+  }, [changedKey, lastSwappedKey, lastSwappingKey, swappingItemTranslation])
+
   const resetStatus = useCallback((draggingKey?: string) => {
     'main thread'
     changedKey.current.map((key: string) => {
@@ -316,17 +328,18 @@ export function useSortable<T>(
         return
       }
       const item = itemMTSRefMap?.current?.[key]
-      if (
-        item
-        && typeof item.MTSResetInternalTranslateValues === 'function'
-      ) {
+      if (!item) {
+        return
+      }
+      if (typeof item.MTSSetTransform === 'function') {
+        item.MTSSetTransform(0, 0)
+      }
+      if (typeof item.MTSResetInternalTranslateValues === 'function') {
         item.MTSResetInternalTranslateValues()
       }
     })
-    lastSwappedKey.current = ''
-    lastSwappingKey.current = ''
-    changedKey.current = []
-  }, [changedKey, itemMTSRefMap, lastSwappedKey, lastSwappingKey])
+    resetSwapTrackingRefs()
+  }, [changedKey, itemMTSRefMap, resetSwapTrackingRefs])
 
   const rootDragEnd = useCallback((sortedKey: string[]) => {
     const keyToItemMap = new Map(data.map((item, index) => {
@@ -342,14 +355,33 @@ export function useSortable<T>(
     (
       sortingKey: string,
       event: MainThread.MouseEvent | MainThread.TouchEvent,
-    ) => {
+    ): boolean => {
       'main thread'
       mtsLog(debugLog, '[event drag end]', event)
       const sortedKey = sortArray(sortingKey)
-      runOnBackground(rootDragEnd)(sortedKey)
-      resetStatus(sortingKey)
+      let orderChanged = sortedKey.length !== keyArray.length
+      if (!orderChanged) {
+        for (let i = 0; i < sortedKey.length; i++) {
+          if (sortedKey[i] !== keyArray[i]) {
+            orderChanged = true
+            break
+          }
+        }
+      }
+      if (orderChanged) {
+        // data will be updated by consumer -> usePreCommit will reset dirty items
+        runOnBackground(rootDragEnd)(sortedKey)
+        // dom transforms are reset by usePreCommit, but swap tracking refs
+        // must be cleared synchronously to avoid stale state on next drag
+        resetSwapTrackingRefs()
+      } else {
+        // no data update -> no precommit -> reset dirty items synchronously here
+        resetStatus(sortingKey)
+        runOnBackground(rootDragEnd)(sortedKey)
+      }
+      return orderChanged
     },
-    [resetStatus, rootDragEnd, sortArray],
+    [keyArray, resetStatus, resetSwapTrackingRefs, rootDragEnd, sortArray],
   )
 
   return {

--- a/packages/lynx-ui-sortable/src/useSortable.tsx
+++ b/packages/lynx-ui-sortable/src/useSortable.tsx
@@ -73,7 +73,7 @@ export function useSortable<T>(
       runOnBackground(handleDragStartJS)()
       touchStartPoint.current = pagePoint
       changedKey.current.push(sortingKey)
-      // changeItemZIndex(10000, sortingKey)
+      changeItemZIndex(10000, sortingKey)
       mtsLog(debugLog, '[event drag start]', event)
     },
     [handleDragStartJS, touchStartPoint, changedKey, changeItemZIndex],
@@ -283,7 +283,7 @@ export function useSortable<T>(
     ) => {
       'main thread'
       switchHandler(delta.y, sortingKey)
-      // changeItemZIndex(10000, sortingKey)
+      changeItemZIndex(10000, sortingKey)
       mtsLog(debugLog, '[event drag move]', event)
     },
     [switchHandler, changeItemZIndex],

--- a/packages/lynx-ui-sortable/src/useSortable.tsx
+++ b/packages/lynx-ui-sortable/src/useSortable.tsx
@@ -73,7 +73,7 @@ export function useSortable<T>(
       runOnBackground(handleDragStartJS)()
       touchStartPoint.current = pagePoint
       changedKey.current.push(sortingKey)
-      changeItemZIndex(10000, sortingKey)
+      // changeItemZIndex(10000, sortingKey)
       mtsLog(debugLog, '[event drag start]', event)
     },
     [handleDragStartJS, touchStartPoint, changedKey, changeItemZIndex],
@@ -135,7 +135,7 @@ export function useSortable<T>(
     (item: DraggableRef | null, translate: number) => {
       'main thread'
 
-      item?.MTSSetOtherStyles({ 'transform': `translateY(${translate}px)` })
+      item?.MTSSetTransform(0, translate)
     },
     [],
   )
@@ -283,7 +283,7 @@ export function useSortable<T>(
     ) => {
       'main thread'
       switchHandler(delta.y, sortingKey)
-      changeItemZIndex(10000, sortingKey)
+      // changeItemZIndex(10000, sortingKey)
       mtsLog(debugLog, '[event drag move]', event)
     },
     [switchHandler, changeItemZIndex],
@@ -309,12 +309,18 @@ export function useSortable<T>(
     return swappedKeyArray
   }, [keyArray, lastSwappedKey])
 
-  const resetStatus = useCallback(() => {
+  const resetStatus = useCallback((draggingKey?: string) => {
     'main thread'
     changedKey.current.map((key: string) => {
+      if (key === draggingKey) {
+        return
+      }
       const item = itemMTSRefMap?.current?.[key]
-      if (item && typeof item.MTSResetInternalTranslateValues === 'function') {
-        item?.MTSResetInternalTranslateValues()
+      if (
+        item
+        && typeof item.MTSResetInternalTranslateValues === 'function'
+      ) {
+        item.MTSResetInternalTranslateValues()
       }
     })
     lastSwappedKey.current = ''
@@ -341,7 +347,7 @@ export function useSortable<T>(
       mtsLog(debugLog, '[event drag end]', event)
       const sortedKey = sortArray(sortingKey)
       runOnBackground(rootDragEnd)(sortedKey)
-      resetStatus()
+      resetStatus(sortingKey)
     },
     [resetStatus, rootDragEnd, sortArray],
   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## feat: improve sortable scroll support

- Add ScrollView ScrollBy example with scroll-offset control buttons
- Add Sortable ScrollableBoundary example demonstrating scroll-aware drag-and-drop inside a bounded container
- Add Sortable ShortScrollView example with programmatic scroll control during sorting
- Add CSS for ScrollView and Sortable examples (ScrollBy, ScrollableBoundary, ShortScrollView)
- Extend example configs to expose new examples in ScrollView and Sortable example groups
- Extend SortableRoot to support scrollable-boundary mode with scroll position tracking, sticky-edge offsets, and overlay rendering
- Render drag-overlay elements and expose setDragOverlayRef for overlay registration
- Expand SortableContext to include drag-overlay state, scroll/boundary refs, sticky offset fields, and debug flag
- Refactor SortableInteractiveItem to use ref-based geometry snapshots and quantized auto-scroll loops for boundary-aware dragging
- Constrain drag translations using itemRectCopy/boundaryRectCopy and adjust non-scrollable-path behavior
- Add scrollable-related props to SortableRootProps docs (scrollable, scrollableClassName, scrollableContentClassName, scrollableEnableScroll, scrollableStickyUpperOffset, scrollableStickyLowerOffset, scrollableBoundaryId)
- Update useSortable to apply native transform via MTSSetTransform and implement selective item reset logic on drag end
<!-- end of auto-generated comment: release notes by coderabbit.ai -->