### PR TITLE
fix: avoid resetting styles when data prop is recreated

### DIFF
--- a/.changeset/stable-sortable-data-signature.md
+++ b/.changeset/stable-sortable-data-signature.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/lynx-ui-sortable': patch
+---
+
+Avoid resetting Sortable item styles when the `data` prop is recreated with the same ordered sorting keys.

--- a/apps/examples/Sortable/PropsDataReset/index.css
+++ b/apps/examples/Sortable/PropsDataReset/index.css
@@ -1,0 +1,30 @@
+@import "@lynx-js/luna-styles/index.css";
+
+@import "../shared/base.css";
+@import "../shared/palette.css";
+
+.props-data-reset-root {
+  justify-content: flex-start;
+  padding-top: 96px;
+}
+
+.props-data-reset-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 24px;
+}
+
+.props-data-reset-title {
+  color: var(--neutral-content);
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.props-data-reset-counter {
+  margin-top: 8px;
+  color: var(--neutral-content-faded);
+  font-size: 12px;
+  font-weight: 600;
+}

--- a/apps/examples/Sortable/PropsDataReset/index.tsx
+++ b/apps/examples/Sortable/PropsDataReset/index.tsx
@@ -1,0 +1,88 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from '@lynx-js/react'
+
+import './index.css'
+
+import { SortableItem, SortableItemArea, SortableRoot } from '@lynx-js/lynx-ui'
+import type { SortableData } from '@lynx-js/lynx-ui'
+
+import type { SortableDemoItem } from '../shared/data'
+import { createDemoData } from '../shared/data'
+
+export function App() {
+  const [values, setValues] = useState<SortableDemoItem[]>(
+    () => createDemoData().map(item => item.dataItem),
+  )
+  const [renderCount, setRenderCount] = useState(0)
+
+  const data = values.map(value => ({
+    dataItem: value,
+    getSortingKey: () => value.id,
+  }))
+
+  const triggerParentRerenders = () => {
+    const rerenderDelays = [2000, 2500, 3000, 40000, 8000]
+    rerenderDelays.forEach((delay) => {
+      setTimeout(() => {
+        setValues(currentValues => [...currentValues])
+        setRenderCount(count => count + 1)
+      }, delay)
+    })
+  }
+
+  const handleSortEnd = (sortedData: SortableData<SortableDemoItem>[]) => {
+    setValues(sortedData.map(item => item.dataItem))
+    setTimeout(() => {
+      setValues(currentValues => [...currentValues])
+      setRenderCount(count => count + 1)
+    }, 0)
+  }
+
+  return (
+    <view
+      className='sortable-root props-data-reset-root lunaris-dark'
+      id='sortableContainer'
+      // Required: establish a stacking context for sortable drag layers
+      style={{ zIndex: '0' }}
+    >
+      <view className='props-data-reset-header'>
+        <text className='props-data-reset-title'>
+          Props Data Reset
+        </text>
+        <text className='props-data-reset-counter'>
+          Rerenders: {renderCount}
+        </text>
+      </view>
+      <SortableRoot
+        data={data}
+        boundaryId='sortableContainer'
+        onSortStart={triggerParentRerenders}
+        onSortEnd={handleSortEnd}
+      >
+        {(item: SortableData<SortableDemoItem>) => {
+          const { id, tone } = item.dataItem
+
+          return (
+            <SortableItem
+              key={item.getSortingKey()}
+              as='DraggableRoot'
+              className={`sortable-item sortable-item--${id}`}
+              sortingKey={item.getSortingKey()}
+            >
+              <SortableItemArea className='sortable-item-area'>
+                <text className={`drag-here-text drag-here-text--${tone}`}>
+                  Drag Here
+                </text>
+              </SortableItemArea>
+            </SortableItem>
+          )
+        }}
+      </SortableRoot>
+    </view>
+  )
+}
+
+root.render(<App />)

--- a/apps/examples/Sortable/lynx.config.mjs
+++ b/apps/examples/Sortable/lynx.config.mjs
@@ -9,6 +9,7 @@ const defaultConfig = exampleConfig({
   SortableWithScrollView: './WithScrollView/index.tsx',
   SortableNoBoundary: './NoBoundary/index.tsx',
   SortableDisableSorting: './DisableSorting/index.tsx',
+  SortablePropsDataReset: './PropsDataReset/index.tsx',
 }, { needWeb: false })
 
 export default defaultConfig

--- a/packages/lynx-ui-sortable/src/Sortable.tsx
+++ b/packages/lynx-ui-sortable/src/Sortable.tsx
@@ -80,8 +80,12 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     onDragStart: onSortStart,
     debugLog,
   })
+  const dataKeySignature = JSON.stringify(
+    data?.map(item => item.getSortingKey()) ?? [],
+  )
   const sortableContextValue = useMemo(() => ({
     data,
+    dataKeySignature,
     enableSorting,
     boundaryId,
     updateItemSize,
@@ -92,6 +96,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     handleDragStart,
   }), [
     data,
+    dataKeySignature,
     enableSorting,
     boundaryId,
     updateItemSize,
@@ -128,7 +133,7 @@ interface boundingClientRectRes {
 export function SortableItem(props: SortableItemProps) {
   const { className, children, sortingKey, as = 'Draggable' } = props
   const {
-    data,
+    dataKeySignature,
     enableSorting,
     boundaryId,
     updateItemSize,
@@ -178,7 +183,13 @@ export function SortableItem(props: SortableItemProps) {
       })
         .exec()
     }
-  }, [setChildrenRef, setChildrenMTSRef, sortingKey, data, boundaryId])
+  }, [
+    setChildrenRef,
+    setChildrenMTSRef,
+    sortingKey,
+    dataKeySignature,
+    boundaryId,
+  ])
 
   const handleMTSLayoutChange = (e: MainThread.LayoutChangeEvent) => {
     'main thread'
@@ -211,7 +222,7 @@ export function SortableItem(props: SortableItemProps) {
 
   const resetStyle = useMemo(
     () => ({ transform: 'translate(0, 0)', zIndex: '0' }),
-    [data],
+    [dataKeySignature],
   )
 
   if (as === 'Draggable') {

--- a/packages/lynx-ui-sortable/src/SortableContext.ts
+++ b/packages/lynx-ui-sortable/src/SortableContext.ts
@@ -14,6 +14,7 @@ import type { SortableData } from './types'
 
 interface SortableContextType<T = unknown> {
   data: SortableData<T>[]
+  dataKeySignature: string
   boundaryId?: string
   enableSorting: boolean
   updateItemSize: (sortingKey: string, size: number) => void
@@ -40,6 +41,7 @@ interface SortableContextType<T = unknown> {
 
 export const SortableContext = createContext<SortableContextType>({
   data: [],
+  dataKeySignature: '[]',
   enableSorting: true,
   updateItemSize: noop,
   setChildrenRef: noop,


### PR DESCRIPTION
Add dataKeySignature to track stable sortable data identity, add demo for props data reset scenario, update context and dependencies to use the signature instead of full data reference for style reset memoization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add `dataKeySignature` field to `SortableContextType` to track stable sorting key identity
- Update `SortableRoot` to compute `dataKeySignature` from item sorting keys and include in context value
- Replace `data` reference with `dataKeySignature` in `SortableItem` dependency arrays and style reset memoization
- Add PropsDataReset example demonstrating data prop recreation without triggering style resets
- Add CSS styles for PropsDataReset example component
- Update Sortable example config to register PropsDataReset example
- Add Changeset entry documenting patch fix for `@lynx-js/lynx-ui-sortable`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->