### PR TITLE
fix(presence): preserve dialog enter timing on rapid toggles

### DIFF
--- a/.changeset/steady-presence-overlays.md
+++ b/.changeset/steady-presence-overlays.md
@@ -1,5 +1,6 @@
 ---
 "@lynx-example/lynx-ui-dialog": patch
+"@lynx-js/lynx-ui-dialog": patch
 "@lynx-js/lynx-ui-presence": patch
 ---
 
@@ -8,3 +9,4 @@ Fix presence edge cases for rapid visibility toggles during enter and exit trans
 - Recover when an enter interrupts an in-progress exit.
 - Keep open and close callbacks balanced across interrupted transitions.
 - Remove mounted containers when dismissal occurs before entering starts.
+- Handle cancelled Dialog transitions during rapid visibility changes.

--- a/packages/lynx-ui-dialog/src/Dialog.tsx
+++ b/packages/lynx-ui-dialog/src/Dialog.tsx
@@ -150,7 +150,9 @@ export const DialogBackdrop = (props: DialogBackdropProps) => {
 
   const {
     handleKFStart,
+    handleKFCancel,
     handleKFEnd,
+    handleTransitionCancel,
     handleTransitionEnd,
     handleTransitionStart,
   } = animationHandlers
@@ -171,8 +173,9 @@ export const DialogBackdrop = (props: DialogBackdropProps) => {
       bindanimationstart={handleKFStart}
       bindanimationend={handleKFEnd}
       bindtransitionstart={handleTransitionStart}
+      bindtransitioncancel={handleTransitionCancel}
       bindtransitionend={handleTransitionEnd}
-      bindanimationcancel={handleKFEnd}
+      bindanimationcancel={handleKFCancel}
       event-through={false}
       style={{
         width: '100%',
@@ -271,7 +274,9 @@ export function DialogContent(props: DialogContentProps) {
   })
   const {
     handleKFStart,
+    handleKFCancel,
     handleKFEnd,
+    handleTransitionCancel,
     handleTransitionEnd,
     handleTransitionStart,
   } = animationHandlers
@@ -285,8 +290,9 @@ export function DialogContent(props: DialogContentProps) {
       bindanimationstart={handleKFStart}
       bindanimationend={handleKFEnd}
       bindtransitionstart={handleTransitionStart}
+      bindtransitioncancel={handleTransitionCancel}
       bindtransitionend={handleTransitionEnd}
-      bindanimationcancel={handleKFEnd}
+      bindanimationcancel={handleKFCancel}
       {...dialogContentProps}
     >
       {children}

--- a/packages/lynx-ui-presence/src/usePresence.tsx
+++ b/packages/lynx-ui-presence/src/usePresence.tsx
@@ -61,6 +61,48 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
     showScheduleIdRef.current += 1
   }
 
+  const cancelEnteringWait = () => {
+    enteringLoopIdRef.current += 1
+  }
+
+  const cancelLeavingWait = () => {
+    leavingLoopIdRef.current += 1
+  }
+
+  const scheduleShow = () => {
+    const scheduleId = showScheduleIdRef.current
+    log(
+      debugLog,
+      '[lynx-ui-presence][usePresence] set mount=true',
+    )
+    setMount(true)
+    log(
+      debugLog,
+      '[lynx-ui-presence][usePresence] schedule set Entering in 8 frames',
+    )
+    delayFrames(8, () => {
+      if (scheduleId !== showScheduleIdRef.current || !showRef.current) return
+      setPresenceState(PresenceState.Entering)
+    })
+    if (enableDelay) {
+      log(
+        debugLog,
+        '[lynx-ui-presence][usePresence] schedule set DelayedEntering in 16 frames',
+      )
+      delayFrames(16, () => {
+        if (scheduleId !== showScheduleIdRef.current || !showRef.current) {
+          return
+        }
+        setPresenceState(PresenceState.DelayedEntering)
+      })
+    }
+  }
+
+  const restartShow = () => {
+    cancelShowTimer()
+    scheduleShow()
+  }
+
   const notAnimating = () => (isKFAnimating.current === false
     && isTransitionAnimating.current === false)
 
@@ -87,9 +129,9 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
       }
     }
     if (state === PresenceState.Leaving && notAnimating()) {
-      cancelShowTimer()
+      cancelLeavingWait()
       if (showRef.current) {
-        setPresenceState(enteringStateWithDelay)
+        restartShow()
       } else {
         setPresenceState(PresenceState.Left)
       }
@@ -170,9 +212,7 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
         debugLog,
         '[lynx-ui-presence][usePresence] skip mount=false because show=true (Left)',
       )
-      setMount(true)
-      cancelShowTimer()
-      setPresenceState(enteringStateWithDelay)
+      restartShow()
       return
     }
     if (!isInitialRender.current && hasNotifiedOpen.current) {
@@ -184,6 +224,7 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
   }
 
   const handleStateLeaving = () => {
+    cancelEnteringWait()
     leavingWaitFramesRef.current = 0
     leavingLoopIdRef.current += 1
     const loopId = leavingLoopIdRef.current
@@ -201,9 +242,8 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
           debugLog,
           `[lynx-ui-presence][usePresence] leaving timeout reached, loopId: ${loopId}, frames: ${leavingWaitFramesRef.current}`,
         )
-        cancelShowTimer()
         if (showRef.current) {
-          setPresenceState(enteringStateWithDelay)
+          restartShow()
         } else {
           setPresenceState(PresenceState.Left)
         }
@@ -217,6 +257,7 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
   }
 
   const handleStateEnteringWithDelay = () => {
+    cancelLeavingWait()
     enteringWaitFramesRef.current = 0
     enteringLoopIdRef.current += 1
     const loopId = enteringLoopIdRef.current
@@ -233,7 +274,11 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
           debugLog,
           `[lynx-ui-presence][usePresence] entering timeout reached, loopId: ${loopId}, frames: ${enteringWaitFramesRef.current}`,
         )
-        setPresenceState(PresenceState.Entered)
+        if (showRef.current) {
+          setPresenceState(PresenceState.Entered)
+        } else {
+          setPresenceState(PresenceState.Leaving)
+        }
         return
       }
       enteringWaitFramesRef.current += 1
@@ -263,32 +308,6 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
   }, [state])
 
   // ==== Show change part ====
-  const handleShow = (scheduleId: number) => {
-    log(
-      debugLog,
-      '[lynx-ui-presence][usePresence] set mount=true',
-    )
-    setMount(true)
-    log(
-      debugLog,
-      '[lynx-ui-presence][usePresence] schedule set Entering in 8 frames',
-    )
-    delayFrames(8, () => {
-      if (scheduleId !== showScheduleIdRef.current) return
-      setPresenceState(PresenceState.Entering)
-    })
-    if (enableDelay) {
-      log(
-        debugLog,
-        '[lynx-ui-presence][usePresence] schedule set DelayedEntering in 16 frames',
-      )
-      delayFrames(16, () => {
-        if (scheduleId !== showScheduleIdRef.current) return
-        setPresenceState(PresenceState.DelayedEntering)
-      })
-    }
-  }
-
   const handleDismiss = () => {
     if (
       state === PresenceState.Entered || state === PresenceState.Entering
@@ -298,6 +317,7 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
         debugLog,
         '[lynx-ui-presence][usePresence] show=false -> set PresenceState.Leaving',
       )
+      cancelEnteringWait()
       setPresenceState(PresenceState.Leaving)
     } else if (
       (state === PresenceState.Initial || state === PresenceState.Left) && mount
@@ -315,11 +335,10 @@ export function usePresence(props: usePresenceProps): usePresenceReturnType {
       debugLog,
       `[lynx-ui-presence][usePresence] show effect show:${show}, enableDelay:${enableDelay}, state:${state}, mount:${mount}`,
     )
-    cancelShowTimer()
-    const scheduleId = showScheduleIdRef.current
     if (show) {
-      handleShow(scheduleId)
+      restartShow()
     } else {
+      cancelShowTimer()
       handleDismiss()
     }
   }, [show, enableDelay])


### PR DESCRIPTION
This follow-up keeps the rapid Dialog visibility fix from #204 while preserving the original delayed enter timing used to make popup animations reliable.

The previous recovery path could jump directly from interrupted exit states back into Entering. That fixed the blocked overlay in some rapid-click cases, but it bypassed the 8-frame closed baseline used by Presence before applying open classes, so Dialog popup animations could disappear.

This change routes every latest-open recovery through the same delayed show scheduler, guards scheduled enter callbacks against stale close intent, and wires Dialog transition/animation cancel events into Presence so cancelled transitions do not leave animation flags stuck.

Validation:

- pnpm check:luna-vars
- pnpm --filter @lynx-js/lynx-ui-presence --filter @lynx-js/lynx-ui-dialog --filter @lynx-example/lynx-ui-dialog build
- pnpm check:changesets
- pnpm check:changed
- git diff --check
- pnpm turbo build
- Consumer smoke builds after replacing node_modules in tux-web-sandbox and fan-club-an-perks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Wire Dialog transition/animation cancellation events into Presence and restore delayed enter timing for reliable popup animations during rapid visibility toggles.

## Changes

- Update Dialog components to wire cancellation events from animation handlers, binding `animationcancel` and `transitioncancel` events to their respective handlers in `DialogBackdrop` and `DialogContent`
- Introduce loop-id based cancel helpers in `usePresence` for managing entering/leaving waits
- Route animation completion and scheduled timeouts through `restartShow()` to respect `showRef.current` state, guarding against stale close intent
- Wire Dialog transition/animation cancel events to Presence to prevent animation flags from remaining stuck after cancelled transitions
- Update release notes for `@lynx-js/lynx-ui-presence` and `@lynx-js/lynx-ui-dialog` with cancellation handling details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->