### PR TITLE
chore: add pkg.pr.new previews

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: Build
 
 on:
   workflow_call:
+    inputs:
+      upload-package-artifacts:
+        default: false
+        required: false
+        type: boolean
 env:
   CI: 1
   TURBO_TELEMETRY_DISABLED: 1
@@ -100,6 +105,18 @@ jobs:
           pnpm turbo build --summarize
         env:
           NODE_OPTIONS: --max-old-space-size=32768
+      - name: Pack Package Artifacts
+        if: inputs.upload-package-artifacts
+        run: tar -czf package-artifacts.tgz packages/*/dist
+      - name: Upload Package Artifacts
+        if: inputs.upload-package-artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: package-artifacts-${{ github.sha }}
+          path: package-artifacts.tgz
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true
       - name: Upload Turbo Summary
         if: runner.debug == '1'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,65 @@
+name: pkg.pr.new
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "!**"
+
+permissions: {}
+
+env:
+  CI: 1
+  TURBO_TELEMETRY_DISABLED: 1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    if: github.repository == 'lynx-family/lynx-ui'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build.yml
+    with:
+      upload-package-artifacts: true
+
+  publish:
+    name: Publish Preview Packages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.repository == 'lynx-family/lynx-ui'
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "24"
+          package-manager-cache: false
+      - name: Install
+        run: |
+          npm install -g corepack@latest
+          corepack enable
+          pnpm install --frozen-lockfile
+      - name: Download Package Artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: package-artifacts-${{ github.sha }}
+      - name: Extract Package Artifacts
+        run: tar -xzf package-artifacts.tgz
+      - name: Publish Preview Packages
+        run: >
+          pnpm exec pkg-pr-new publish
+          --pnpm
+          --commentWithSha
+          --packageManager=pnpm
+          './packages/*'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @lynx-js/lynx-ui
 
+[![pkg.pr.new](https://pkg.pr.new/badge/lynx-family/lynx-ui)](https://pkg.pr.new/~/lynx-family/lynx-ui)
+
 `@lynx-js/lynx-ui` is the official headless UI library for ReactLynx, provided as a reference for building flexible, universal, and high-performance ReactLynx components.
 
 ## Introduction

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "jsonc-parser": "3.3.1",
     "knip": "^5.80.0",
     "nano-staged": "^0.8.0",
+    "pkg-pr-new": "^0.0.75",
     "postcss-value-parser": "^4.2.0",
     "sort-package-json": "^2.12.0",
     "stylelint": "^17.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       nano-staged:
         specifier: ^0.8.0
         version: 0.8.0
+      pkg-pr-new:
+        specifier: ^0.0.75
+        version: 0.0.75
       postcss-value-parser:
         specifier: ^4.2.0
         version: 4.2.0
@@ -5643,6 +5646,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pkg-pr-new@0.0.75:
+    resolution: {integrity: sha512-u9mdErTewKSMsr+ceCt8VcNuNP0ro5AXiPXhUVApuEyqr2Zlvt+DdCFBcm+yGWN8mhOdZJ27meIDbnoZgfzpOw==}
+    hasBin: true
+
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
@@ -11079,6 +11086,8 @@ snapshots:
   pify@4.0.1: {}
 
   pirates@4.0.7: {}
+
+  pkg-pr-new@0.0.75: {}
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
Adds pkg.pr.new preview package publishing for lynx-ui.

This adds a dedicated GitHub Actions workflow that calls the existing reusable build workflow, has that build optionally upload package dist artifacts, then downloads those artifacts before running one pkg.pr.new publish command for ./packages/*. This publishes the aggregate package and component subpackages together without rebuilding in the publish job.

Also adds the pkg.pr.new badge to the root README and locks pkg-pr-new as a root dev dependency, matching pkg.pr.new guidance to run from the lockfile in CI.

Validated with:
- pnpm install --frozen-lockfile
- pnpm turbo build
- pnpm dprint check README.md .github/workflows/pkg-pr-new.yml package.json pnpm-lock.yaml
- pnpm dprint check .github/workflows/build.yml .github/workflows/pkg-pr-new.yml
- pnpm check:sherif
- pnpm check:manypkg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Enable pkg.pr.new preview package publishing for lynx-ui

- Add `upload-package-artifacts` workflow input to `.github/workflows/build.yml` to conditionally create and upload a tarball of `packages/*/dist`
- Create `.github/workflows/pkg-pr-new.yml` to call the reusable build workflow with artifact uploads enabled and publish preview packages by downloading artifacts and running `pnpm exec pkg-pr-new publish './packages/*'`
- Add pkg.pr.new badge to README.md linking to lynx-family/lynx-ui
- Pin `pkg-pr-new` as a root devDependency in package.json to run from the lockfile in CI
- Validate CI flow and repository state with `pnpm install --frozen-lockfile`, `pnpm turbo build`, `dprint` checks, and pnpm checks (`check:sherif`, `check:manypkg`)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->