### PR TITLE
test(skill-lynx-ui): add trigger eval coverage

### DIFF
--- a/.changeset/soft-rivers-trigger-evals.md
+++ b/.changeset/soft-rivers-trigger-evals.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/skill-lynx-ui": patch
+---
+
+Add trigger eval coverage to the lynx-ui skill package.

--- a/packages/skill-lynx-ui/README.md
+++ b/packages/skill-lynx-ui/README.md
@@ -10,7 +10,8 @@ It is structured so ``another platform can copy the package contents directly in
 packages/skill-lynx-ui
 |-- SKILL.md
 |-- evals/
-|   `-- evals.json
+|   |-- evals.json
+|   `-- trigger_eval.json
 `-- references
     |-- foundation.md
     |-- component-overview.md
@@ -46,6 +47,7 @@ Detailed content lives in these files:
 - `api.md`: component API source extracted from `types/index.docs.ts` or `src/types/index.docs.ts`
 - `references/components/*/examples.md`: aggregated example entries for a component, sourced from this repo
 - `evals/evals.json`: eval coverage for enriched lynx-ui task routing
+- `evals/trigger_eval.json`: trigger coverage for lynx-ui skill activation
 
 ## Maintenance
 

--- a/packages/skill-lynx-ui/README_zh.md
+++ b/packages/skill-lynx-ui/README_zh.md
@@ -10,7 +10,8 @@
 packages/skill-lynx-ui
 ├── SKILL.md
 ├── evals/
-│   └── evals.json
+│   ├── evals.json
+│   └── trigger_eval.json
 └── references
     ├── foundation.md
     ├── component-overview.md

--- a/packages/skill-lynx-ui/evals/trigger_eval.json
+++ b/packages/skill-lynx-ui/evals/trigger_eval.json
@@ -1,0 +1,66 @@
+[
+  {
+    "query": "Help me choose the right lynx-ui primitive for a temporary action panel: Dialog, Sheet, or Popover.",
+    "should_trigger": true
+  },
+  {
+    "query": "I am adding @lynx-js/lynx-ui Button to a ReactLynx screen. Should the handler use onClick or bindtap?",
+    "should_trigger": true
+  },
+  {
+    "query": "Set up Luna theming for a lynx-ui app and apply lunaris-dark using the documented theme classes.",
+    "should_trigger": true
+  },
+  {
+    "query": "My lynx-ui ScrollView contains expensive cards. Which component should wrap the card body so it mounts near visibility?",
+    "should_trigger": true
+  },
+  {
+    "query": "Build a lynx-ui screen with Checkbox, RadioGroup, and Switch, and verify the public props before coding.",
+    "should_trigger": true
+  },
+  {
+    "query": "I need lynx-ui styling with Tailwind and LunaPreset. What preset order and theme setup should I use?",
+    "should_trigger": true
+  },
+  {
+    "query": "Can motion-mini handle this small lynx-ui transition, or should I use the full motion package?",
+    "should_trigger": true
+  },
+  {
+    "query": "Troubleshoot a lynx-ui import issue where @lynx-js/lynx-ui does not expose the component I expected.",
+    "should_trigger": true
+  },
+  {
+    "query": "Review this ReactLynx main thread script and explain whether runOnMainThread is used correctly.",
+    "should_trigger": false
+  },
+  {
+    "query": "Analyze this Lynx trace URL and find the FCP bottleneck in LoadTemplate and LoadJSApp.",
+    "should_trigger": false
+  },
+  {
+    "query": "Fix TypeScript module augmentation for GlobalProps and InitData in a ReactLynx project.",
+    "should_trigger": false
+  },
+  {
+    "query": "Convert this React class component to a ReactLynx function component with hooks.",
+    "should_trigger": false
+  },
+  {
+    "query": "Decode a .tasm file into JSON using the Lynx TASM CLI and compare the result.",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a responsive React web dashboard with shadcn/ui cards and a desktop sidebar.",
+    "should_trigger": false
+  },
+  {
+    "query": "Explain how CSS flex gap works in Lynx compared with the web rendering model.",
+    "should_trigger": false
+  },
+  {
+    "query": "Use Node.js to read a CSV file and generate a chart in an Excel workbook.",
+    "should_trigger": false
+  }
+]


### PR DESCRIPTION
## Summary

- Add `evals/trigger_eval.json` for `@lynx-js/skill-lynx-ui` with positive and negative trigger cases.
- Update the skill package README payload diagrams to include the trigger eval file.
- Add a changeset for the skill package payload update.

## Verification

- `jq empty packages/skill-lynx-ui/evals/trigger_eval.json`
- Node schema check: 16 trigger cases (+8/-8)
- `pnpm --filter @lynx-js/skill-lynx-ui pack --dry-run`
- `pnpm turbo build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Add trigger evaluation coverage to `@lynx-js/skill-lynx-ui`

- Add `evals/trigger_eval.json` with 16 trigger evaluation cases (8 positive, 8 negative) to establish trigger activation criteria
- Update `README.md` to document the new trigger evaluation file in the published package structure
- Update `README_zh.md` to document the expanded evals directory
- Add changeset to reflect patch version bump for trigger eval coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->