### PR TITLE
fix: delay rect refresh to avoid layout jank

### DIFF
--- a/.changeset/true-singers-drop.md
+++ b/.changeset/true-singers-drop.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-sortable": patch
+---
+
+fix: delay rect refresh to avoid layout jank

--- a/packages/lynx-ui-sortable/src/Sortable.tsx
+++ b/packages/lynx-ui-sortable/src/Sortable.tsx
@@ -14,7 +14,7 @@ import {
 import type { RefObject } from '@lynx-js/react'
 
 import type { Point } from '@lynx-js/lynx-ui-common'
-import { usePreCommit } from '@lynx-js/lynx-ui-common'
+import { delayFrames, usePreCommit } from '@lynx-js/lynx-ui-common'
 import {
   Draggable,
   DraggableArea,
@@ -908,7 +908,7 @@ function SortableInteractiveItem(props: SortableItemProps) {
 
   useEffect(() => {
     runOnMainThread(setChildrenMTSRef)(MTSRef, sortingKey)
-    refreshDraggingRects()
+    delayFrames(1, refreshDraggingRects)
   }, [
     data,
     refreshDraggingRects,


### PR DESCRIPTION
Defer the rect calculation until after the next frame, preventing id not found for querySelector in the first frame.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Delay rect refresh to avoid layout jank

- Add Changesets entry for `@lynx-js/lynx-ui-sortable` patch release
- Defer `refreshDraggingRects` calculation by one frame in `Sortable.tsx` using `delayFrames` to prevent id not found errors in querySelector on the first frame

<!-- end of auto-generated comment: release notes by coderabbit.ai -->