### PR TITLE
ci(skill): check skill eval definitions

### DIFF
--- a/.changeset/skill-lynx-ui-eval-checks.md
+++ b/.changeset/skill-lynx-ui-eval-checks.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/skill-lynx-ui": patch
+---
+
+Align lynx-ui skill eval definitions with the marketplace validation schema.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,33 @@ jobs:
           pnpm dprint check
           pnpm biome check
           pnpm dlx sherif@latest
-      - name: Skill References Check
-        run: pnpm check:skills-references
       - name: Changeset Target Check
         run: pnpm check:changesets
       - name: Changeset Check
         run: pnpm changeset status --since=origin/main || echo "::warning::Changeset check failed, but continuing execution."
+
+  check-skills:
+    name: Check Skills
+    runs-on: lynx-ubuntu-24.04-medium
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "24"
+          package-manager-cache: false
+      - name: Install
+        run: |
+          npm install -g corepack@latest
+          corepack enable
+          pnpm install --frozen-lockfile
+      - name: Check Skills
+        run: |
+          pnpm check:skills-references
+          pnpm check:skills-eval-definitions
 
   luna-vars:
     name: LUNA Vars
@@ -155,6 +176,7 @@ jobs:
         --silent
   done:
     needs:
+      - check-skills
       - code-style-check
       - luna-vars
       - check-exports

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check:manypkg": "pnpm dlx @manypkg/cli check",
     "check:mdx": "node tools/scripts/check-mdx-top-level-esm.mjs",
     "check:sherif": "pnpm dlx sherif@latest",
+    "check:skills-eval-definitions": "pnpm --filter @lynx-js/skill-lynx-ui check:eval-definitions",
     "check:skills-references": "pnpm --filter @lynx-js/skill-lynx-ui check:references",
     "coverage": "vitest --coverage",
     "ensure:skills-changeset": "node tools/skill-lynx-ui/ensure-changeset.mjs",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "typedoc": "^0.28.0",
     "typescript": "catalog:",
     "typescript-eslint": "^8.19.1",
-    "vitest": "2.1.8"
+    "vitest": "2.1.8",
+    "yaml": "2.9.0"
   },
   "packageManager": "pnpm@10.33.2",
   "engines": {

--- a/packages/skill-lynx-ui/SKILL.md
+++ b/packages/skill-lynx-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lynx-ui
-description: Use when building with lynx-ui: select components, verify public APIs, adapt examples, configure Luna themes, choose motion packages, compose screens, or troubleshoot lynx-ui usage.
+description: "Use when building with lynx-ui: select components, verify public APIs, adapt examples, configure Luna themes, choose motion packages, compose screens, or troubleshoot lynx-ui usage."
 ---
 
 # lynx-ui

--- a/packages/skill-lynx-ui/evals/evals.json
+++ b/packages/skill-lynx-ui/evals/evals.json
@@ -3,10 +3,11 @@
   "evals": [
     {
       "id": 1,
+      "name": "official-approach-for-list-flow",
       "prompt": "I already have a ReactLynx app and want to add lynx-ui for a new interactive list flow. Please use the official lynx-ui approach and keep the code close to the docs unless the project structure forces small changes.",
       "expected_output": "The response routes through lynx-ui setup or capability guidance, prefers official docs examples, and avoids generic React rewrites.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Mentions an official lynx-ui docs page or example as the recommended source of truth",
         "Points to a local lynx-ui reference file or section in addition to the official docs anchor",
         "Frames the answer around adapting the official lynx-ui approach rather than inventing a generic React abstraction"
@@ -14,10 +15,11 @@
     },
     {
       "id": 2,
+      "name": "luna-token-theming",
       "prompt": "Can you help me add consistent theming to this lynx-ui screen? I think we should use Luna tokens if that's the recommended path.",
       "expected_output": "The response routes into theming and tokens guidance, points to the Luna docs, and keeps the answer in lynx-ui terms.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Recommends Luna themes or tokens as the default theming path",
         "Points to the Luna themes/tokens docs page rather than only naming token concepts",
         "Maps the recommendation to concrete Luna semantic tokens for surfaces, text, borders, or actions"
@@ -25,10 +27,11 @@
     },
     {
       "id": 3,
+      "name": "motion-package-selection",
       "prompt": "I need a small transition for a lynx-ui interaction. Should I use motion or motion-mini, and can you keep it aligned with the official docs?",
       "expected_output": "The response routes into motion guidance, explains motion vs motion-mini, and prefers the official docs path.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Chooses between motion and motion-mini with an explicit recommendation",
         "Justifies the choice using lynx-ui or official-doc-aligned criteria",
         "Avoids generic animation-library advice that ignores lynx-ui"
@@ -36,10 +39,11 @@
     },
     {
       "id": 4,
+      "name": "scroll-view-with-lazy-component",
       "prompt": "I have a long lynx-ui ScrollView with expensive cards. Which lynx-ui components are commonly used together so the card bodies mount only when they approach visibility?",
       "expected_output": "The response routes through the component composition guidance and recommends ScrollView with LazyComponent while preserving the required lazy-loading API checks.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Recommends ScrollView with LazyComponent",
         "Explains that LazyComponent should wrap expensive content inside the scrolling container",
         "Points to the component-composition guidance and verifies exact LazyComponent props through its API reference"
@@ -47,10 +51,11 @@
     },
     {
       "id": 5,
+      "name": "dialog-sheet-popover-selection",
       "prompt": "I am not sure whether this lynx-ui action should use a dialog, a sheet, or a popover. Can you help me choose the closest official pattern before we write code?",
       "expected_output": "The response uses lynx-ui routing guidance to compare the relevant primitives, points back to official component docs, and helps the user choose instead of jumping into arbitrary code.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Compares the relevant lynx-ui primitives instead of picking one without explanation",
         "Points back to the closest official lynx-ui component docs or local component-routing guidance",
         "Avoids jumping straight into unrelated implementation code before choosing the component family"
@@ -58,10 +63,11 @@
     },
     {
       "id": 6,
+      "name": "skill-boundary-troubleshooting",
       "prompt": "My lynx-ui example looks fine structurally, but the setup and types are breaking in my ReactLynx project. Can you troubleshoot it and tell me if this is actually a lynx-ui problem or another Lynx skill should handle it?",
       "expected_output": "The response identifies the likely boundary between lynx-ui and adjacent Lynx skills, keeps the fix anchored in official docs if appropriate, and hands off cleanly if the issue is really about ReactLynx architecture or Lynx TypeScript config.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Names the likely boundary between lynx-ui guidance and another local Lynx skill",
         "Mentions reactlynx-best-practices or lynx-typescript when the issue appears architectural or type/config related",
         "Includes a minimal boundary check that still verifies an official lynx-ui install/import assumption before handing off"
@@ -69,10 +75,11 @@
     },
     {
       "id": 7,
+      "name": "button-event-api",
       "prompt": "I have a lynx-ui screen with a primary action button. Should I wire the click with onClick or bindtap? Please keep it aligned with the official lynx-ui Button API.",
       "expected_output": "The response explicitly keeps lynx-ui Button on its documented onClick prop and distinguishes that from raw native event props like bindtap or catchtap.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "States that lynx-ui Button uses onClick",
         "Explicitly warns against using bindtap or catchtap on the lynx-ui Button component",
         "Distinguishes component props from raw native view event props rather than treating them as interchangeable"
@@ -80,10 +87,11 @@
     },
     {
       "id": 8,
+      "name": "built-in-luna-theme-setup",
       "prompt": "Can you show me how to set up styling and theming for lynx-ui and apply one of the built-in Luna themes? Please stay close to the official docs, including the setup path.",
       "expected_output": "The response points to the official styling/theming setup doc, explains the setup path in lynx-ui terms, and recommends a built-in Luna or Lunaris theme as the default application path.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Points to the official styling and theming setup doc, not only the Luna tokens page",
         "Explains setup in terms of documented theme wiring or imports instead of generic theming abstractions",
         "Recommends a built-in Luna or Lunaris theme as the default before suggesting a custom theme"
@@ -91,10 +99,11 @@
     },
     {
       "id": 9,
+      "name": "custom-luna-theme",
       "prompt": "We need our own brand theme in lynx-ui, not just luna-light or luna-dark. Can you explain the official way to define a custom theme and which semantic tokens we should override first?",
       "expected_output": "The response points to the official custom-theme section, keeps the explanation in Luna semantic token terms, and frames custom themes as an override path rather than the default recommendation.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Points to the official Define your own theme section",
         "Frames custom themes as a branding or override path rather than the default recommendation",
         "Explains the first overrides in semantic token terms such as primary, paper, content, or line"
@@ -102,10 +111,11 @@
     },
     {
       "id": 10,
+      "name": "tailwind-luna-preset-setup",
       "prompt": "I want to set up Luna theming with Tailwind in a lynx-ui app. What is the official setup path, which presets do I need, and how do I apply a built-in theme like luna-dark?",
       "expected_output": "The response points to the official styling/theming setup doc, includes the official Tailwind preset packages and preset order, and explains that built-in themes are applied through theme classes such as luna-dark.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Mentions @lynx-js/tailwind-preset for runtime compatibility",
         "Names LunaPreset from @lynx-js/luna-tailwind and LynxPreset from @lynx-js/tailwind-preset with the order [LynxPreset, LunaPreset]",
         "Explains that built-in themes can be applied with classes such as luna-light, luna-dark, lunaris-light, or lunaris-dark"
@@ -113,10 +123,11 @@
     },
     {
       "id": 11,
+      "name": "tailwind-utilities-versus-luna-tokens",
       "prompt": "My Lynx app loads Luna theme tokens, but classes like bg-paper, flex, and rounded-2xl never show up in the built CSS. What does that imply, and should I debug Luna or the Tailwind integration first?",
       "expected_output": "The response identifies the missing utility classes as a base Rspeedy/Lynx Tailwind integration problem, explains the two-layer model, and avoids treating Luna theme loading as proof that the utility pipeline is working.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Explains the two-layer model: base Rspeedy/Lynx Tailwind integration first, then Luna theming",
         "States that missing generic utilities such as flex indicates the base Tailwind integration is incomplete",
         "Distinguishes loaded Luna tokens from generated utility selectors instead of treating them as the same signal"
@@ -124,10 +135,11 @@
     },
     {
       "id": 12,
+      "name": "stale-tailwind-tool-state",
       "prompt": "I updated Tailwind v3, PostCSS, presets, and the Tailwind directives, but the output still looks stale. Then a plugin reload made it start working. What should you conclude before suggesting more config edits?",
       "expected_output": "The response recognizes that config may already be correct, recommends rebuild plus plugin or session refresh after integration changes, and avoids inventing more configuration changes before ruling out stale tool state.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "Recommends rebuild and plugin or session refresh after Tailwind integration changes",
         "Treats stale output as possible cached tool or session state rather than immediate proof of another missing config step",
         "Avoids prescribing extra config edits before ruling out reload or refresh behavior"

--- a/packages/skill-lynx-ui/package.json
+++ b/packages/skill-lynx-ui/package.json
@@ -18,6 +18,7 @@
     "evals"
   ],
   "scripts": {
+    "check:eval-definitions": "node ../../tools/skill-lynx-ui/check-eval-definitions.mjs",
     "check:references": "node ../../tools/skill-lynx-ui/check-references.mjs",
     "clean:generated": "node ../../tools/skill-lynx-ui/clean-generated.mjs",
     "generate:references": "node ../../tools/skill-lynx-ui/generate-references.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       vitest:
         specifier: 2.1.8
         version: 2.1.8(@types/node@24.12.4)(terser@5.47.1)
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
 
   apps/examples/Button:
     dependencies:

--- a/tools/skill-lynx-ui/check-eval-definitions.mjs
+++ b/tools/skill-lynx-ui/check-eval-definitions.mjs
@@ -1,0 +1,217 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const workspaceRoot = path.resolve(__dirname, '..', '..')
+const packageRoot = path.join(workspaceRoot, 'packages', 'skill-lynx-ui')
+const packageJsonPath = path.join(packageRoot, 'package.json')
+const skillMdPath = path.join(packageRoot, 'SKILL.md')
+const evalRoot = path.join(packageRoot, 'evals')
+const skillPackagePrefix = '@lynx-js/skill-'
+
+async function main() {
+  const packageJson = await readJson(packageJsonPath)
+  const skill = parseSkillFrontmatter(await readFile(skillMdPath, 'utf8'))
+  const packageName = packageJson.name
+
+  if (
+    typeof packageName !== 'string'
+    || !packageName.startsWith(skillPackagePrefix)
+  ) {
+    throw new Error(
+      `${packageJsonPath} name must start with ${skillPackagePrefix}`,
+    )
+  }
+
+  const exportDirName = packageName.slice(skillPackagePrefix.length)
+  if (exportDirName !== skill.name) {
+    throw new Error(
+      [
+        'Exported skill directory would not match SKILL.md name:',
+        `- package name: ${packageName}`,
+        `- exported directory: ${exportDirName}`,
+        `- SKILL.md name: ${skill.name}`,
+      ].join('\n'),
+    )
+  }
+
+  const task = await validateTaskEvals(
+    skill.name,
+    path.join(evalRoot, 'evals.json'),
+  )
+  const trigger = await validateTriggerEvals(
+    path.join(evalRoot, 'trigger_eval.json'),
+  )
+
+  console.info(
+    [
+      'Skill eval definition check passed.',
+      `skill=${skill.name}`,
+      `task_evals=${task.taskEvals}`,
+      `expectations=${task.expectations}`,
+      `trigger_evals=${trigger.total}`,
+    ].join(' '),
+  )
+}
+
+function parseSkillFrontmatter(content) {
+  const lines = content.split(/\r?\n/u)
+  if (lines[0]?.trim() !== '---') {
+    throw new Error(`${skillMdPath} missing frontmatter`)
+  }
+
+  const frontmatter = []
+  for (let index = 1; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (line.trim() === '---') {
+      break
+    }
+    frontmatter.push(line)
+  }
+
+  const nameLine = frontmatter.find(line => line.startsWith('name:'))
+  const name = nameLine
+    ?.slice('name:'.length)
+    .trim()
+    .replace(/^['"]|['"]$/g, '')
+  if (!name) {
+    throw new Error(`${skillMdPath} frontmatter missing name`)
+  }
+  return { name }
+}
+
+async function validateTaskEvals(skillName, filePath) {
+  const payload = await readJson(filePath)
+  assertObject(payload, `${filePath} root`)
+  if (payload.skill_name !== skillName) {
+    throw new Error(
+      `${filePath} skill_name must match SKILL.md name \`${skillName}\``,
+    )
+  }
+  if (!Array.isArray(payload.evals) || payload.evals.length === 0) {
+    throw new Error(`${filePath} evals must be a non-empty array`)
+  }
+
+  const ids = new Set()
+  const names = new Set()
+  let expectations = 0
+  for (const [index, item] of payload.evals.entries()) {
+    assertObject(item, `${filePath} eval #${index + 1}`)
+    const id = item.id
+    if (!Number.isInteger(id) || id <= 0) {
+      throw new Error(`${filePath} eval #${index + 1} has invalid id`)
+    }
+    if (ids.has(id)) {
+      throw new Error(`${filePath} duplicate eval id ${id}`)
+    }
+    ids.add(id)
+
+    if (typeof item.name !== 'string' || item.name.trim() === '') {
+      throw new Error(`${filePath} eval id ${id} missing name`)
+    }
+    if (names.has(item.name)) {
+      throw new Error(`${filePath} duplicate eval name ${item.name}`)
+    }
+    names.add(item.name)
+
+    if (typeof item.prompt !== 'string' || item.prompt.trim().length < 20) {
+      throw new Error(`${filePath} eval id ${id} prompt too short`)
+    }
+    if (
+      typeof item.expected_output !== 'string'
+      || item.expected_output.trim().length < 10
+    ) {
+      throw new Error(`${filePath} eval id ${id} missing expected_output`)
+    }
+    if (
+      !Array.isArray(item.files)
+      || item.files.some(file => typeof file !== 'string')
+    ) {
+      throw new Error(
+        `${filePath} eval id ${id} files must be an array of strings`,
+      )
+    }
+    if (!Array.isArray(item.expectations) || item.expectations.length < 3) {
+      throw new Error(
+        `${filePath} eval id ${id} must have at least 3 expectations`,
+      )
+    }
+    if (
+      item.expectations.some(
+        expectation =>
+          typeof expectation !== 'string' || expectation.trim() === '',
+      )
+    ) {
+      throw new Error(
+        `${filePath} eval id ${id} has invalid expectation entries`,
+      )
+    }
+    expectations += item.expectations.length
+  }
+
+  return {
+    expectations,
+    taskEvals: payload.evals.length,
+  }
+}
+
+async function validateTriggerEvals(filePath) {
+  const payload = await readJson(filePath)
+  if (!Array.isArray(payload) || payload.length === 0) {
+    throw new Error(`${filePath} must be a non-empty array`)
+  }
+
+  let positive = 0
+  let negative = 0
+  for (const [index, item] of payload.entries()) {
+    assertObject(item, `${filePath} item #${index + 1}`)
+    if (typeof item.query !== 'string' || item.query.trim().length < 10) {
+      throw new Error(`${filePath} item #${index + 1} query too short`)
+    }
+    if (typeof item.should_trigger !== 'boolean') {
+      throw new Error(
+        `${filePath} item #${index + 1} should_trigger must be boolean`,
+      )
+    }
+    if (item.should_trigger) {
+      positive += 1
+    } else {
+      negative += 1
+    }
+  }
+  if (positive === 0 || negative === 0) {
+    throw new Error(`${filePath} must contain both positive and negative cases`)
+  }
+  return {
+    negative,
+    positive,
+    total: payload.length,
+  }
+}
+
+async function readJson(filePath) {
+  if (!existsSync(filePath)) {
+    throw new Error(`missing JSON file: ${filePath}`)
+  }
+  try {
+    return JSON.parse(await readFile(filePath, 'utf8'))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`invalid JSON in ${filePath}: ${message}`)
+  }
+}
+
+function assertObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`)
+  }
+}
+
+await main()

--- a/tools/skill-lynx-ui/check-eval-definitions.mjs
+++ b/tools/skill-lynx-ui/check-eval-definitions.mjs
@@ -7,6 +7,8 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { parseDocument } from 'yaml'
+
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const workspaceRoot = path.resolve(__dirname, '..', '..')
@@ -62,29 +64,32 @@ async function main() {
 }
 
 function parseSkillFrontmatter(content) {
-  const lines = content.split(/\r?\n/u)
-  if (lines[0]?.trim() !== '---') {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u.exec(content)
+  if (!match) {
     throw new Error(`${skillMdPath} missing frontmatter`)
   }
 
-  const frontmatter = []
-  for (let index = 1; index < lines.length; index += 1) {
-    const line = lines[index]
-    if (line.trim() === '---') {
-      break
-    }
-    frontmatter.push(line)
+  const document = parseDocument(match[1])
+  if (document.errors.length > 0) {
+    throw new Error(
+      `${skillMdPath} has invalid YAML frontmatter: ${
+        document.errors[0].message
+      }`,
+    )
   }
 
-  const nameLine = frontmatter.find(line => line.startsWith('name:'))
-  const name = nameLine
-    ?.slice('name:'.length)
-    .trim()
-    .replace(/^['"]|['"]$/g, '')
-  if (!name) {
+  const frontmatter = document.toJS()
+  assertObject(frontmatter, `${skillMdPath} frontmatter`)
+  if (typeof frontmatter.name !== 'string' || frontmatter.name.trim() === '') {
     throw new Error(`${skillMdPath} frontmatter missing name`)
   }
-  return { name }
+  if (
+    typeof frontmatter.description !== 'string'
+    || frontmatter.description.trim() === ''
+  ) {
+    throw new Error(`${skillMdPath} frontmatter missing description`)
+  }
+  return { name: frontmatter.name }
 }
 
 async function validateTaskEvals(skillName, filePath) {


### PR DESCRIPTION
Adds a dedicated skill-check CI job that runs reference generation checks and eval definition validation together.

Aligns the lynx-ui skill eval definitions with the marketplace schema while keeping the check non-LLM and local.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Add dedicated skill evaluation definition checks to CI pipeline

Introduce a dedicated CI job (`check-skills`) that validates lynx-ui skill evaluation definitions against the marketplace schema while keeping checks local and non-LLM.

- Add `check-skills` CI job to run reference generation and evaluation-definition checks
- Add `tools/skill-lynx-ui/check-eval-definitions.mjs` to validate evals and trigger_eval schemas and enforce required fields and constraints
- Align `packages/skill-lynx-ui/evals/evals.json` with marketplace schema by adding `name` and replacing `assertions` with `expectations`
- Add `check:skills-eval-definitions` script to root `package.json` and `check:eval-definitions` script to `packages/skill-lynx-ui/package.json`
- Add `yaml@2.9.0` devDependency for frontmatter parsing
- Make `done` CI job depend on `check-skills`
- Add changeset for `@lynx-js/skill-lynx-ui` documenting schema alignment
<!-- end of auto-generated comment: release notes by coderabbit.ai -->