### PR TITLE
feat(sortable): add disabled item support

### DIFF
--- a/.changeset/sortable-disabled-items.md
+++ b/.changeset/sortable-disabled-items.md
@@ -1,0 +1,16 @@
+---
+"@lynx-js/lynx-ui-sortable": minor
+---
+
+feat(sortable): support `disabled` items that always keep their absolute position
+
+`SortableItem` now accepts a `disabled` prop. Disabled items cannot be dragged
+themselves and are never displaced by other items' dragging — they always keep
+their absolute position in the final sorted order. Other items can still
+freely cross over them, and only the relative order of non-disabled items can
+change.
+
+The cross-over translate compensation is scoped to the disabled gap strictly
+between the swap target and its previous movable neighbor, so consecutive
+swaps across alternating locked / unlocked items land each item at the
+expected slot without over-shooting.

--- a/apps/examples/Sortable/DisableItems/index.css
+++ b/apps/examples/Sortable/DisableItems/index.css
@@ -1,0 +1,151 @@
+@import "../shared/base.css";
+@import "../shared/palette.css";
+
+.demo-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 24px 16px;
+  z-index: 0;
+}
+
+.outside-panel {
+  width: 100%;
+  height: 112px;
+  flex-shrink: 0;
+  border-radius: 16px;
+  padding: 18px 20px;
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.outside-panel--top {
+  margin-bottom: 12px;
+}
+
+.outside-panel--bottom {
+  margin-top: 12px;
+}
+
+.outside-panel-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.outside-panel-copy {
+  margin-top: 8px;
+  font-size: 13px;
+  line-height: 18px;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.scroll-by-actions {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 12px;
+}
+
+.scroll-by-button {
+  flex: 1;
+  height: 40px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.16);
+}
+
+.scroll-by-button--primary {
+  background-color: #ffffff;
+}
+
+.scroll-by-button-text {
+  font-size: 14px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.scroll-by-button--primary .scroll-by-button-text {
+  color: #1f2937;
+}
+
+.short-scroll-view {
+  width: 100%;
+  height: 360px;
+  flex-shrink: 0;
+  border-radius: 18px;
+  border-width: 1px;
+  border-color: rgba(255, 255, 255, 0.22);
+  background-color: rgba(0, 0, 0, 0.16);
+  z-index: 0;
+}
+
+.short-sortable-root {
+  justify-content: flex-start;
+  min-height: 100%;
+  padding: 16px 12px;
+  height: max-content;
+}
+
+.sortable-item {
+  display: flex;
+  flex-direction: column;
+  height: 92px;
+  padding-bottom: 10px;
+  flex-shrink: 0;
+  background-color: transparent;
+}
+
+.sortable-item-surface {
+  display: flex;
+  flex-direction: row;
+  justify-content: end;
+  align-items: center;
+  width: 100%;
+  height: 82px;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.sortable-item-surface--locked {
+  opacity: 0.55;
+  border-width: 1px;
+  border-color: rgba(255, 255, 255, 0.45);
+}
+
+.sortable-item-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  padding-left: 18px;
+}
+
+.sortable-item-title {
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.sortable-item-subtitle {
+  margin-top: 5px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.sortable-item-area {
+  width: 76px;
+}
+
+.sortable-item-area--locked {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.28);
+}
+
+.drag-here-text--locked {
+  color: rgba(255, 255, 255, 0.85);
+}

--- a/apps/examples/Sortable/DisableItems/index.tsx
+++ b/apps/examples/Sortable/DisableItems/index.tsx
@@ -1,0 +1,153 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useCallback, useMemo, useState } from '@lynx-js/react'
+
+import './index.css'
+
+import { SortableItem, SortableItemArea, SortableRoot } from '@lynx-js/lynx-ui'
+import type { SortableData } from '@lynx-js/lynx-ui'
+
+import type { SortableDemoItem } from '../shared/data'
+import { createDemoData } from '../shared/data'
+
+// Items that are locked from sorting. These rows cannot be dragged themselves
+// and they always keep their absolute positions in the result.
+const LOCKED_KEYS = new Set(['0', '5', '7', '10', '11'])
+
+function scrollShortBoundaryBy(offset: number) {
+  'main thread'
+  lynx.querySelector('#disableItemsScrollView')?.invoke('scrollBy', {
+    offset,
+  })
+}
+
+export function App() {
+  const [data, setData] = useState<SortableData<SortableDemoItem>[]>(
+    () => createDemoData(18),
+  )
+
+  const handleSortEnd = useCallback(
+    (sortedData: SortableData<SortableDemoItem>[]) => {
+      setData(sortedData)
+    },
+    [],
+  )
+
+  const lockedKeys = useMemo(() => LOCKED_KEYS, [])
+
+  const renderSortableItem = useCallback(
+    (item: SortableData<SortableDemoItem>) => {
+      const { id, tone } = item.dataItem
+      const numericId = Number(id)
+      const paletteIndex = numericId % 6
+      const isLocked = lockedKeys.has(item.getSortingKey())
+
+      return (
+        <SortableItem
+          key={item.getSortingKey()}
+          as='DraggableRoot'
+          className='sortable-item'
+          sortingKey={item.getSortingKey()}
+          disabled={isLocked}
+        >
+          <view
+            className={`sortable-item-surface sortable-item--${paletteIndex} ${
+              isLocked ? 'sortable-item-surface--locked' : ''
+            }`}
+          >
+            <view className='sortable-item-content'>
+              <text className={`sortable-item-title drag-here-text--${tone}`}>
+                {`Row ${numericId + 1}`}
+              </text>
+              <text className='sortable-item-subtitle'>
+                {isLocked
+                  ? 'Locked · cannot be dragged or displaced'
+                  : 'Drag handle on the right to reorder'}
+              </text>
+            </view>
+            {isLocked
+              ? (
+                <view className='sortable-item-area sortable-item-area--locked'>
+                  <text className='drag-here-text drag-here-text--locked'>
+                    Locked
+                  </text>
+                </view>
+              )
+              : (
+                <SortableItemArea className='sortable-item-area'>
+                  <text className={`drag-here-text drag-here-text--${tone}`}>
+                    Drag
+                  </text>
+                </SortableItemArea>
+              )}
+          </view>
+        </SortableItem>
+      )
+    },
+    [lockedKeys],
+  )
+
+  const handleScrollUpTap = useCallback(() => {
+    'main thread'
+    scrollShortBoundaryBy(-160)
+  }, [])
+
+  const handleScrollDownTap = useCallback(() => {
+    'main thread'
+    scrollShortBoundaryBy(160)
+  }, [])
+
+  return (
+    <view className='demo-container lunaris-dark luna-gradient-berry'>
+      <view className='outside-panel outside-panel--top'>
+        <text className='outside-panel-title'>Locked rows demo</text>
+        <text className='outside-panel-copy'>
+          Rows 1, 6, 8 and 12 are locked. They never move and are never
+          displaced, but other rows can freely cross over them while sorting.
+        </text>
+      </view>
+
+      <view className='scroll-by-actions'>
+        <view
+          className='scroll-by-button'
+          main-thread:bindtap={handleScrollUpTap}
+        >
+          <text className='scroll-by-button-text'>Scroll Up</text>
+        </view>
+        <view
+          className='scroll-by-button scroll-by-button--primary'
+          main-thread:bindtap={handleScrollDownTap}
+        >
+          <text className='scroll-by-button-text'>Scroll Down</text>
+        </view>
+      </view>
+
+      <SortableRoot
+        data={data}
+        onSortEnd={handleSortEnd}
+        boundaryId='disableItemsSortableRoot'
+        as='ScrollView'
+        scrollableBoundaryId='disableItemsScrollView'
+        scrollableClassName='short-scroll-view'
+        scrollableContentClassName='sortable-root short-sortable-root'
+        scrollableStickyUpperOffset={12}
+        scrollableStickyLowerOffset={12}
+      >
+        {renderSortableItem}
+      </SortableRoot>
+
+      <view className='outside-panel outside-panel--bottom'>
+        <text className='outside-panel-title'>Behavior</text>
+        <text className='outside-panel-copy'>
+          Locked rows always keep their absolute positions. Other rows are
+          reordered around them, sliding past at a higher speed so the gap stays
+          in sync with the dragged item.
+        </text>
+      </view>
+    </view>
+  )
+}
+
+root.render(<App />)

--- a/apps/examples/Sortable/lynx.config.mjs
+++ b/apps/examples/Sortable/lynx.config.mjs
@@ -11,6 +11,7 @@ const defaultConfig = exampleConfig({
   SortableShortScrollView: './ShortScrollView/index.tsx',
   SortableNoBoundary: './NoBoundary/index.tsx',
   SortableDisableSorting: './DisableSorting/index.tsx',
+  SortableDisableItems: './DisableItems/index.tsx',
 }, { needWeb: false })
 
 export default defaultConfig

--- a/packages/lynx-ui-sortable/SKILL.md
+++ b/packages/lynx-ui-sortable/SKILL.md
@@ -1,0 +1,238 @@
+# lynx-ui-sortable SKILL
+
+`Sortable` is a headless drag-to-reorder list primitive for ReactLynx. It performs reordering on the main thread for smooth, gesture-driven animations and exposes a composable `SortableRoot` / `SortableItem` / `SortableItemArea` API. For massive datasets, prefer `List` or `FeedList`; `Sortable` targets small to medium reorder-able lists.
+
+## 1. Core Capabilities
+
+- **Headless Composition**: Three building blocks — `SortableRoot`, `SortableItem`, and (optional) `SortableItemArea` — let you keep full control of the visual layer.
+- **Two Drag Surfaces**: Each `SortableItem` can act as `as='Draggable'` (whole row is the drag surface, default) or `as='DraggableRoot'` (only the inner `SortableItemArea` starts a drag).
+- **Owned ScrollView**: Set `as='ScrollView'` on `SortableRoot` to render an internal `<scroll-view>` boundary; pair with `scrollableBoundaryId`, `scrollableStickyUpperOffset`, and `scrollableStickyLowerOffset` to get auto-scroll while dragging near edges.
+- **External Boundary**: Use `boundaryId` to point at any element in the page tree as the drop boundary — drags exiting that area are cancelled.
+- **Disabled Items (locked rows)**: `<SortableItem disabled>` produces a row that cannot be dragged, cannot be displaced, and **always keeps its absolute position** in the committed order. Other items can freely cross over it; only the relative order of non-disabled items can change.
+- **Lifecycle Callbacks**: `onSortStart` and `onSortEnd(sortedData)` on the root. `sortedData` reflects the new order of `SortableData<T>` items, with disabled items pinned at their original indices.
+- **Imperative Toggle**: `enableSorting` on the root (`true` by default) globally turns sorting on/off without unmounting items.
+
+## 2. AI Coding Guide
+
+### Minimal Usable Example
+
+`SortableRoot` accepts a render-prop child, **not** static children. Each row is a `SortableItem` whose `sortingKey` MUST match `SortableData.getSortingKey()`.
+
+```tsx
+import { useState } from '@lynx-js/react'
+import {
+  SortableItem,
+  SortableItemArea,
+  SortableRoot,
+  type SortableData,
+} from '@lynx-js/lynx-ui'
+
+interface Row { id: string; title: string }
+
+function BasicSortable() {
+  const [data, setData] = useState<SortableData<Row>[]>(() =>
+    Array.from({ length: 6 }, (_, i) => {
+      const id = String(i)
+      return {
+        dataItem: { id, title: `Row ${i + 1}` },
+        getSortingKey: () => id,
+      }
+    })
+  )
+
+  return (
+    <SortableRoot
+      data={data}
+      onSortEnd={setData}
+      as='ScrollView'
+      scrollableClassName='sortable-scroll'
+      scrollableContentClassName='sortable-content'
+    >
+      {(item) => (
+        <SortableItem
+          key={item.getSortingKey()}
+          sortingKey={item.getSortingKey()}
+          as='DraggableRoot'
+          className='sortable-row'
+        >
+          <view className='sortable-row-surface'>
+            <text>{item.dataItem.title}</text>
+            <SortableItemArea className='sortable-handle'>
+              <text>⋮</text>
+            </SortableItemArea>
+          </view>
+        </SortableItem>
+      )}
+    </SortableRoot>
+  )
+}
+```
+
+### Recommended Prompt Formula
+
+> **Scenario Description** + **Drag Surface (whole row vs handle)** + **Boundary / ScrollView Setup** + **Locked Rows** + **Reorder Callback**
+
+**Example Prompts:**
+
+- "Build a sortable list of 10 cards inside a 360px tall scroll-view. Drag from a small handle on the right of each card; commit reorder via `onSortEnd`."
+- "Create a sortable settings list where the first and last rows are locked and never move; other rows can be reordered between them and across them."
+- "Render a sortable list with a custom external boundary — only allow dragging within a specific container, and cancel sorting if dragged outside."
+
+## 3. Use Cases & Best Practices
+
+### Whole-row drag surface (default)
+
+```tsx
+<SortableItem
+  key={item.getSortingKey()}
+  sortingKey={item.getSortingKey()}
+>
+  <MyRowSurface data={item.dataItem} />
+</SortableItem>
+```
+
+Touching anywhere on the row starts a drag. Best for tile / card layouts.
+
+**Example Path**: `apps/examples/Sortable/Basic/index.tsx`
+
+### Handle-only drag surface
+
+```tsx
+<SortableItem
+  key={item.getSortingKey()}
+  sortingKey={item.getSortingKey()}
+  as='DraggableRoot'
+>
+  <view className='row'>
+    <view className='row-content'>{/* tap content */}</view>
+    <SortableItemArea className='row-handle'>
+      <text>⋮</text>
+    </SortableItemArea>
+  </view>
+</SortableItem>
+```
+
+Required when row content has its own gestures (taps, switches). Only `SortableItemArea` starts a drag.
+
+**Example Path**: `apps/examples/Sortable/Basic/index.tsx`
+
+### Owned `ScrollView` with auto-scroll near edges
+
+```tsx
+<SortableRoot
+  as='ScrollView'
+  scrollableBoundaryId='mySortableScroll'
+  scrollableClassName='short-scroll-view'
+  scrollableContentClassName='sortable-root short-sortable-root'
+  scrollableStickyUpperOffset={12}
+  scrollableStickyLowerOffset={12}
+  data={data}
+  onSortEnd={setData}
+>
+  {renderRow}
+</SortableRoot>
+```
+
+When the dragged row reaches `12px` from the upper / lower edge, the internal `scroll-view` calls `scrollBy` so the list keeps moving with the drag. Call `lynx.querySelector('#mySortableScroll')?.invoke('scrollBy', { offset })` to scroll programmatically.
+
+**Example Path**: `apps/examples/Sortable/ShortScrollView/index.tsx`
+
+### External boundary (no owned ScrollView)
+
+```tsx
+<view id='myBoundary' className='boundary'>
+  <SortableRoot data={data} onSortEnd={setData} boundaryId='myBoundary'>
+    {renderRow}
+  </SortableRoot>
+</view>
+```
+
+Drags exiting `#myBoundary` are cancelled. Use this when the sortable list is embedded inside an existing scroll container or modal that you control outside `Sortable`.
+
+**Example Path**: `apps/examples/Sortable/NoBoundary/index.tsx`
+
+### Locked rows that never move (`disabled`)
+
+```tsx
+const LOCKED = new Set(['0', '5', '7', '11'])
+
+<SortableRoot data={data} onSortEnd={setData} as='ScrollView'>
+  {(item) => {
+    const isLocked = LOCKED.has(item.getSortingKey())
+    return (
+      <SortableItem
+        key={item.getSortingKey()}
+        sortingKey={item.getSortingKey()}
+        as='DraggableRoot'
+        disabled={isLocked}
+      >
+        <view className={isLocked ? 'row row--locked' : 'row'}>
+          <text>{item.dataItem.title}</text>
+          {isLocked
+            ? <view className='row-area row-area--locked'><text>Locked</text></view>
+            : <SortableItemArea className='row-area'><text>⋮</text></SortableItemArea>}
+        </view>
+      </SortableItem>
+    )
+  }}
+</SortableRoot>
+```
+
+Behavior of a `disabled` row:
+
+- **Cannot be dragged itself.** No touch / longpress is bound; tapping it never starts a sort.
+- **Never displaced** by any other row's drag. It always stays at its current screen position.
+- **Position preserved in `onSortEnd`.** Its index in the committed `sortedData` is identical to its index in the input `data`. Only the relative order of non-disabled rows can change.
+- **Cross-over allowed.** A non-disabled row dragged over a disabled row will skip past it (the disabled row does not move, the dragged row keeps moving), and the swap target on the far side animates with a higher speed so it ends exactly at the dragged row's original slot, with no visual overlap or jump.
+
+Use this for fixed headers/footers, sticky default actions, or rows whose absolute position is part of the design.
+
+**Example Path**: `apps/examples/Sortable/DisableItems/index.tsx`
+
+### Disable sorting globally
+
+```tsx
+<SortableRoot data={data} onSortEnd={setData} enableSorting={readOnly === false}>
+  {renderRow}
+</SortableRoot>
+```
+
+`enableSorting={false}` instantly removes drag bindings from every non-disabled item without unmounting. Useful for read-only modes.
+
+**Example Path**: `apps/examples/Sortable/DisableSorting/index.tsx`
+
+## 4. FAQ
+
+**Q: Why is `children` a function in `SortableRoot`?**
+
+A: `Sortable` needs to associate each rendered node with an internal `sortingKey` and ref map. The render-prop signature `(item: SortableData<T>) => ReactNode` makes that wiring explicit and lets `SortableRoot` re-render only the rows whose data identity actually changed.
+
+**Q: Where is the source of truth for the order?**
+
+A: Your application state is. `SortableRoot` is controlled by `data` and reports the committed order through `onSortEnd(sortedData)`. You typically `setData(sortedData)` in the handler. While dragging, only main-thread transforms move; the React `data` does not change until release.
+
+**Q: My handle (`SortableItemArea`) does not start a drag.**
+
+A: Confirm `as='DraggableRoot'` on the surrounding `SortableItem`. With the default `as='Draggable'`, the whole row is the drag surface and `SortableItemArea` is treated as plain content.
+
+**Q: Disabled rows still appear to move during drag.**
+
+A: They should not. If you see this, check that the `disabled` prop is actually `true` for those rows on every render (a stable `Set` via `useMemo` is recommended), and that the row's `sortingKey` is unique and stable across renders. Disabled items are never displaced, never picked as a swap target, and always keep their absolute index in `onSortEnd`.
+
+**Q: How do I make the dragged row visually float above its neighbors?**
+
+A: `Sortable` already raises the dragged row's `z-index` to `10000` while dragging and resets it after release; no extra styling is required.
+
+**Q: Auto-scroll does not happen when I drag near the edges.**
+
+A: Auto-scroll requires either `as='ScrollView'` on `SortableRoot` (so it owns the scroll-view) or a `scrollableBoundaryId` pointing at an existing scrollable element. Plain `as` (default) renders a `view` with no scrolling, so there is nothing to auto-scroll.
+
+**Q: I see a wrong reorder commit when I drag back over a disabled gap and release.**
+
+A: Make sure you are on a version that includes the disabled-aware confirmed-swap reset. If you can still reproduce the case where releasing inside a disabled gap commits a stale swap, see `apps/examples/Sortable/DisableItemsStaleSwap/index.tsx` for the canonical repro and file an issue.
+
+## 5. Sub components
+
+- **`SortableRoot`**: Renders the boundary (plain `view` or owned `<scroll-view>`), owns drag state, and receives `data` / `onSortEnd`.
+- **`SortableItem`**: Renders one row. Required props: `sortingKey`. Common props: `as` (`'Draggable'` | `'DraggableRoot'`), `disabled`, `className`.
+- **`SortableItemArea`**: Optional inner drag handle. Only meaningful when its parent `SortableItem` is `as='DraggableRoot'`. Style this as the visible drag affordance (e.g. a grip icon).

--- a/packages/lynx-ui-sortable/src/Sortable.tsx
+++ b/packages/lynx-ui-sortable/src/Sortable.tsx
@@ -147,6 +147,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     {},
   )
   const dirtyKeysRef = useMainThreadRef<Record<string, boolean>>({})
+  const disabledKeysRef = useMainThreadRef<Record<string, boolean>>({})
   const scrollableBoundaryUpperEdgeRef = useMainThreadRef(false)
   const scrollableBoundaryLowerEdgeRef = useMainThreadRef(false)
   const scrollableScrollTopRef = useMainThreadRef(0)
@@ -210,6 +211,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     itemRefMap: childrenRefMap,
     itemMTSRefMap: childrenMTSRefMap,
     dirtyKeysRef,
+    disabledKeysRef,
     onDragEnd: handleInternalSortEnd,
     onDragStart: handleInternalSortStart,
     debugLog,
@@ -234,6 +236,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
       : undefined,
     dragOverlayRefMap: scrollable ? dragOverlayRefMap : undefined,
     dirtyKeysRef,
+    disabledKeysRef,
     scrollableStickyUpperOffset,
     scrollableStickyLowerOffset,
     updateItemSize,
@@ -257,6 +260,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     scrollableScrollTopRef,
     dragOverlayRefMap,
     dirtyKeysRef,
+    disabledKeysRef,
     scrollableStickyLowerOffset,
     scrollableStickyUpperOffset,
     updateItemSize,
@@ -395,7 +399,13 @@ function SortableDragOverlayItem(props: SortableItemProps) {
 }
 
 function SortableInteractiveItem(props: SortableItemProps) {
-  const { className, children, sortingKey, as = 'Draggable' } = props
+  const {
+    className,
+    children,
+    sortingKey,
+    as = 'Draggable',
+    disabled = false,
+  } = props
   const {
     data,
     enableSorting,
@@ -406,6 +416,7 @@ function SortableInteractiveItem(props: SortableItemProps) {
     scrollableScrollTopRef,
     dragOverlayRefMap,
     dirtyKeysRef,
+    disabledKeysRef,
     scrollableStickyUpperOffset,
     scrollableStickyLowerOffset,
     updateItemSize,
@@ -917,6 +928,25 @@ function SortableInteractiveItem(props: SortableItemProps) {
     sortingKey,
   ])
 
+  const syncDisabledKey = useCallback(
+    (key: string, isDisabled: boolean) => {
+      'main thread'
+      if (isDisabled) {
+        disabledKeysRef.current[key] = true
+      } else {
+        delete disabledKeysRef.current[key]
+      }
+    },
+    [disabledKeysRef],
+  )
+
+  useEffect(() => {
+    runOnMainThread(syncDisabledKey)(sortingKey, disabled)
+    return () => {
+      runOnMainThread(syncDisabledKey)(sortingKey, false)
+    }
+  }, [disabled, sortingKey, syncDisabledKey])
+
   const handleMTSLayoutChange = (e: MainThread.LayoutChangeEvent) => {
     'main thread'
     updateItemSize(sortingKey, e.detail.height)
@@ -1070,6 +1100,8 @@ function SortableInteractiveItem(props: SortableItemProps) {
     resetLocalDragVisuals()
   }, [dataKeyOrderSignature])
 
+  const itemDraggable = enableSorting && !disabled
+
   if (as === 'Draggable') {
     return (
       <Draggable
@@ -1077,7 +1109,7 @@ function SortableInteractiveItem(props: SortableItemProps) {
         MTSRef={MTSRef}
         trigger='immediate'
         className={className}
-        enableDragging={enableSorting}
+        enableDragging={itemDraggable}
         draggableProps={{
           'main-thread:bindlayoutchange': handleMTSLayoutChange,
         }}
@@ -1108,7 +1140,7 @@ function SortableInteractiveItem(props: SortableItemProps) {
         onMTSDragStart={itemDragStart}
         onMTSDragEnd={itemDragEnd}
         onMTSDragging={itemDragging}
-        enableDragging={enableSorting}
+        enableDragging={itemDraggable}
         {...(!scrollableBoundaryId && boundaryId
           && {
             minTranslateY: -(itemRect.top - boundaryRect.top),

--- a/packages/lynx-ui-sortable/src/SortableContext.ts
+++ b/packages/lynx-ui-sortable/src/SortableContext.ts
@@ -24,6 +24,7 @@ interface SortableContextType<T = unknown> {
     Record<string, MainThread.Element | null>
   >
   dirtyKeysRef: MutableRefObject<Record<string, boolean>>
+  disabledKeysRef: MutableRefObject<Record<string, boolean>>
   scrollableStickyUpperOffset: number
   scrollableStickyLowerOffset: number
   debugLog: boolean
@@ -62,6 +63,7 @@ export const SortableContext = createContext<SortableContextType>({
   scrollableStickyUpperOffset: 0,
   scrollableStickyLowerOffset: 0,
   dirtyKeysRef: { current: {} },
+  disabledKeysRef: { current: {} },
   updateItemSize: noop,
   setChildrenRef: noop,
   setChildrenMTSRef: noop,

--- a/packages/lynx-ui-sortable/src/types/index.docs.ts
+++ b/packages/lynx-ui-sortable/src/types/index.docs.ts
@@ -189,4 +189,34 @@ export interface SortableItemProps {
    * @zh 指定底层组件。若整个子节点区域均可拖动，使用默认值 'Draggable'；否则使用 'DraggableRoot'，'DraggableRoot' 需与子节点 'DraggableArea' 一起使用。仅触摸其子节点 'DraggableArea' 时可拖动。
    */
   as?: 'Draggable' | 'DraggableRoot'
+  /**
+   * Whether this item is locked from sorting.
+   *
+   * A disabled item:
+   * - Cannot be dragged itself. Touch / long-press gestures are not bound on
+   *   it, so interacting with it never starts a sort operation.
+   * - Cannot be displaced by other items being dragged. It always stays at
+   *   its current position.
+   * - Always keeps its absolute position in the final sorted order. Other
+   *   items can still freely cross over it; only the relative order of
+   *   non-disabled items can change.
+   *
+   * Note that this only affects the disabled item itself. Other (non-disabled)
+   * items keep their full interactivity.
+   *
+   * @defaultValue false
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh 是否禁用该项的拖拽排序。
+   *
+   * 被禁用的项：
+   * - 自身无法被拖动。其上不会绑定 touch / longpress 等手势，触摸该项不会触发任何排序操作。
+   * - 不会因为其他项的拖动而发生位移，始终保持在原位置。
+   * - 在最终排序结果中始终保持其绝对位置不变；其他项仍可自由地越过它进行排序，
+   *   仅未被禁用项之间的相对顺序会发生变化。
+   *
+   * 该属性只影响被禁用的项自身；其它（未被禁用的）项的交互能力不受影响。
+   */
+  disabled?: boolean
 }

--- a/packages/lynx-ui-sortable/src/useSortable.tsx
+++ b/packages/lynx-ui-sortable/src/useSortable.tsx
@@ -23,6 +23,7 @@ interface SortableOptionsType<T> {
   itemRefMap: RefObject<Record<string, DraggableRef | null>>
   itemMTSRefMap: MainThreadRef<Record<string, DraggableRef | null>> // sortingKey -> element Ref
   dirtyKeysRef: MainThreadRef<Record<string, boolean>>
+  disabledKeysRef: MainThreadRef<Record<string, boolean>>
   onDragEnd?: (sortedKeyArray: SortableData<T>[]) => void
   onDragStart?: () => void
   debugLog?: boolean
@@ -36,6 +37,7 @@ export function useSortable<T>(
     sizeMap,
     itemMTSRefMap,
     dirtyKeysRef,
+    disabledKeysRef,
     onDragEnd,
     onDragStart,
     debugLog = false,
@@ -49,6 +51,7 @@ export function useSortable<T>(
   const touchStartPoint = useMainThreadRef<Point>({ x: 0, y: 0 })
   const lastSwappingKey = useMainThreadRef<string>('')
   const swappingItemTranslation = useMainThreadRef<number>(0)
+  const lastCrossedDisabledSize = useMainThreadRef<number>(0)
   const changedKey = useMainThreadRef<string[]>([]) // Store all the moved item. Remember to reset them
   const lastSwappedKey = useMainThreadRef<string>('') // Store the last swapped item. Use it to do the sorting.
 
@@ -85,54 +88,115 @@ export function useSortable<T>(
   const swappingIndexAndDistance: (
     movingDistance: number,
     sortingKey: string,
-  ) => { index: number, distance: number } = useCallback(
-    (movingDistance, sortingKey) => {
-      'main thread'
-      const index = keyArray.indexOf(sortingKey)
-      if (keyArray.length === 0 || index < 0 || index >= keyArray.length) {
-        mtsLog(debugLog, '[swappingIndexAndDistance] invalid index', index)
-        return { index: -1, distance: 0 }
-      }
+  ) => { index: number, distance: number, crossedDisabledSize: number } =
+    useCallback(
+      (movingDistance, sortingKey) => {
+        'main thread'
+        const index = keyArray.indexOf(sortingKey)
+        if (keyArray.length === 0 || index < 0 || index >= keyArray.length) {
+          mtsLog(debugLog, '[swappingIndexAndDistance] invalid index', index)
+          return { index: -1, distance: 0, crossedDisabledSize: 0 }
+        }
 
-      const absDistance = Math.abs(movingDistance)
-      const direction = movingDistance > 0 ? 1 : -1
-      let currentIndex = index + direction
-      let accumulatedDistance = 0
-      while (true) {
-        if (currentIndex < 0 || currentIndex >= keyArray.length) {
-          return {
-            index: -1,
-            distance: (movingDistance > 0 ? 1 : -1)
-              * (absDistance - accumulatedDistance),
+        const absDistance = Math.abs(movingDistance)
+        const direction = movingDistance > 0 ? 1 : -1
+        let currentIndex = index + direction
+        let accumulatedDistance = 0
+        // The total size of the contiguous disabled (locked) items immediately
+        // preceding the current candidate movable, i.e. the disabled gap
+        // between the previous movable neighbor (or the drag start) and the
+        // movable we are about to evaluate. Every time we pass a movable
+        // without picking it as the swap target, this gap resets to 0, so
+        // each potential swap target only sees the locked items strictly
+        // between it and its previous movable neighbor — never a cumulative
+        // total from the drag origin.
+        let disabledGap = 0
+        while (true) {
+          if (currentIndex < 0 || currentIndex >= keyArray.length) {
+            return {
+              index: -1,
+              distance: (movingDistance > 0 ? 1 : -1)
+                * (absDistance - accumulatedDistance),
+              crossedDisabledSize: disabledGap,
+            }
           }
-        }
-        const size = sizeMap.current[keyArray[currentIndex]]
-        if (typeof size !== 'number') {
-          mtsLog(
-            debugLog,
-            `[swappingIndexAndDistance] item size not found for key ${sortingKey}, stopping at index ${currentIndex}.`,
-          )
-          return {
-            index: -1,
-            distance: (movingDistance > 0 ? 1 : -1) * accumulatedDistance,
+          const currentKey = keyArray[currentIndex]
+          // Disabled (locked) items are never picked as a swap candidate and
+          // never displaced. The dragged item is allowed to cross over them by
+          // skipping past while still consuming their height, so the dragged
+          // item's physical displacement keeps in sync with `accumulatedDistance`
+          // and the disabled item's absolute position is preserved.
+          if (disabledKeysRef.current[currentKey]) {
+            const disabledSize = sizeMap.current[currentKey]
+            if (typeof disabledSize !== 'number') {
+              mtsLog(
+                debugLog,
+                `[swappingIndexAndDistance] disabled item size not found for key ${currentKey}, stopping at index ${currentIndex}.`,
+              )
+              return {
+                index: -1,
+                distance: (movingDistance > 0 ? 1 : -1) * accumulatedDistance,
+                crossedDisabledSize: disabledGap,
+              }
+            }
+            // The dragged item is still physically over this disabled item,
+            // so no swap target should be produced yet.
+            if (accumulatedDistance + disabledSize >= absDistance) {
+              mtsLog(
+                debugLog,
+                `[swappingIndexAndDistance] still over disabled item ${currentKey} at index ${currentIndex}.`,
+              )
+              return {
+                index: -1,
+                distance: (movingDistance > 0 ? 1 : -1) * accumulatedDistance,
+                crossedDisabledSize: disabledGap,
+              }
+            }
+            mtsLog(
+              debugLog,
+              `[swappingIndexAndDistance] cross disabled item ${currentKey} at index ${currentIndex}.`,
+            )
+            accumulatedDistance += disabledSize
+            disabledGap += disabledSize
+            currentIndex += direction
+            continue
           }
-        }
-        accumulatedDistance += size
+          const size = sizeMap.current[currentKey]
+          if (typeof size !== 'number') {
+            mtsLog(
+              debugLog,
+              `[swappingIndexAndDistance] item size not found for key ${sortingKey}, stopping at index ${currentIndex}.`,
+            )
+            return {
+              index: -1,
+              distance: (movingDistance > 0 ? 1 : -1) * accumulatedDistance,
+              crossedDisabledSize: disabledGap,
+            }
+          }
+          accumulatedDistance += size
 
-        if (accumulatedDistance >= absDistance) {
-          return {
-            index: currentIndex,
-            // This distance is the remained dragging distance needs to be consumed by current interacting item.
-            // E.g.: the total delta is 458 and all item is all 100px tall. Then the first 400 will be consumed the previous clamped items. And the 58 is current interacting item.
-            distance: (movingDistance > 0 ? 1 : -1)
-              * (accumulatedDistance - size),
+          if (accumulatedDistance >= absDistance) {
+            return {
+              index: currentIndex,
+              // This distance is the remained dragging distance needs to be consumed by current interacting item.
+              // E.g.: the total delta is 458 and all item is all 100px tall. Then the first 400 will be consumed the previous clamped items. And the 58 is current interacting item.
+              distance: (movingDistance > 0 ? 1 : -1)
+                * (accumulatedDistance - size),
+              // Only the disabled items strictly between the previous movable
+              // neighbor and this swap target. Locked items further back have
+              // already been accounted for when their own following movable
+              // became (and was clamped as) a swap target.
+              crossedDisabledSize: disabledGap,
+            }
           }
+          // We just passed this movable without choosing it as the swap target,
+          // so the disabled gap "in front of" the next candidate restarts here.
+          disabledGap = 0
+          currentIndex += direction
         }
-        currentIndex += direction
-      }
-    },
-    [keyArray, sizeMap],
-  )
+      },
+      [keyArray, sizeMap, disabledKeysRef],
+    )
 
   const setTransform = useCallback(
     (key: string, translate: number) => {
@@ -161,9 +225,14 @@ export function useSortable<T>(
         Math.abs(swappingItemTranslation.current)
           > draggingItemSize * swapConfirmedPercentage.current
       ) {
+        // The previous swap target's "swapped" position must include the
+        // height of any disabled items the dragged item had crossed over to
+        // reach it; otherwise it would visually overlap with the (still
+        // in-place) disabled items after we leave it behind.
         setTransform(
           lastSwappingItemKey,
-          (movingDistance < 0 ? 1 : -1) * draggingItemSize,
+          (movingDistance < 0 ? 1 : -1)
+            * (draggingItemSize + lastCrossedDisabledSize.current),
         )
       } else {
         setTransform(lastSwappingItemKey, 0)
@@ -244,13 +313,17 @@ export function useSortable<T>(
   const switchHandler = useCallback(
     (movingDistance: number, sortingKey: string) => {
       'main thread'
-      const { index: swappingIndex, distance: consumedDistance } =
-        swappingIndexAndDistance(movingDistance, sortingKey)
+      const {
+        index: swappingIndex,
+        distance: consumedDistance,
+        crossedDisabledSize = 0,
+      } = swappingIndexAndDistance(movingDistance, sortingKey)
       mtsLog(
         debugLog,
         'swappingIndexAndDistance',
         swappingIndex,
         consumedDistance,
+        crossedDisabledSize,
       )
       if (swappingIndex < 0) {
         clampPreviousItem(consumedDistance, sortingKey)
@@ -265,7 +338,18 @@ export function useSortable<T>(
 
       const unconsumedDistance = movingDistance - consumedDistance
       updateConfirmedInteractedID(unconsumedDistance, sortingKey)
-      setTransform(swappingKey, -unconsumedDistance)
+      // When the dragged item has crossed over disabled items, those items do
+      // not translate. To avoid the swap target jumping, scale its translate
+      // proportionally as the dragged item progresses over it: while the
+      // dragged item moves `swappingItemSize` over the swap target, the swap
+      // target translates `swappingItemSize + crossedDisabledSize`, ending
+      // exactly at the dragged item's original slot without any jump.
+      const swappingItemSize = sizeMap.current[swappingKey] ?? 0
+      const speedMultiplier = swappingItemSize > 0
+        ? (swappingItemSize + crossedDisabledSize) / swappingItemSize
+        : 1
+      setTransform(swappingKey, -unconsumedDistance * speedMultiplier)
+      lastCrossedDisabledSize.current = crossedDisabledSize
     },
     [
       changedKey,
@@ -297,7 +381,6 @@ export function useSortable<T>(
     'main thread'
     const draggingIndex = keyArray.indexOf(sortingKey)
     const swappedIndex = keyArray.indexOf(lastSwappedKey.current)
-    const swappedKeyArray = [...keyArray]
 
     mtsLog(debugLog, 'sortArray with lastSwappedKey ', lastSwappedKey.current)
 
@@ -305,21 +388,56 @@ export function useSortable<T>(
       draggingIndex === -1 || swappedIndex === -1
       || draggingIndex === swappedIndex
     ) {
-      return swappedKeyArray
+      return [...keyArray]
     }
 
-    const [draggedItem] = swappedKeyArray.splice(draggingIndex, 1)
-    swappedKeyArray.splice(swappedIndex, 0, draggedItem)
-    return swappedKeyArray
-  }, [keyArray, lastSwappedKey])
+    // Disabled items must keep their absolute positions in the result. We
+    // splice only the movable (non-disabled) sequence and then reinsert
+    // disabled items at their original indices.
+    const disabledIndices: Record<number, string> = {}
+    const movableKeys: string[] = []
+    for (let i = 0; i < keyArray.length; i++) {
+      const k = keyArray[i]
+      if (disabledKeysRef.current[k]) {
+        disabledIndices[i] = k
+      } else {
+        movableKeys.push(k)
+      }
+    }
+    const movableDraggingIdx = movableKeys.indexOf(sortingKey)
+    const movableSwappedIdx = movableKeys.indexOf(lastSwappedKey.current)
+    if (movableDraggingIdx === -1 || movableSwappedIdx === -1) {
+      return [...keyArray]
+    }
+    const [draggedItem] = movableKeys.splice(movableDraggingIdx, 1)
+    movableKeys.splice(movableSwappedIdx, 0, draggedItem)
+    const result: string[] = []
+    let cursor = 0
+    for (let i = 0; i < keyArray.length; i++) {
+      if (disabledIndices[i] === undefined) {
+        result.push(movableKeys[cursor])
+        cursor++
+      } else {
+        result.push(disabledIndices[i])
+      }
+    }
+    return result
+  }, [keyArray, lastSwappedKey, disabledKeysRef])
 
   const resetSwapTrackingRefs = useCallback(() => {
     'main thread'
     lastSwappedKey.current = ''
     lastSwappingKey.current = ''
     swappingItemTranslation.current = 0
+    lastCrossedDisabledSize.current = 0
     changedKey.current = []
-  }, [changedKey, lastSwappedKey, lastSwappingKey, swappingItemTranslation])
+  }, [
+    changedKey,
+    lastSwappedKey,
+    lastSwappingKey,
+    swappingItemTranslation,
+    lastCrossedDisabledSize,
+  ])
 
   const resetStatus = useCallback((draggingKey?: string) => {
     'main thread'


### PR DESCRIPTION
This change adds the ability to mark sortable items as disabled:
- Disabled items cannot be dragged and act as hard sorting boundaries
- Other items cannot cross disabled items or displace them
- Includes a full demo example showing locked rows in a scrollable list
- Updates context, types, and core sorting logic to support the new feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## feat(sortable): add disabled item support

Add ability to mark sortable items as disabled so they cannot be dragged and act as hard sorting boundaries.

- Track disabled item keys in SortableRoot and expose via disabledKeysRef in SortableContext
- Gate dragging per item by computing itemDraggable = enableSorting && !disabled
- Extend useSortable swap algorithm to skip disabled keys as swap candidates while consuming their sizes and return crossed-disabled-size for translation math
- Compensate clamp/translate calculations with crossed-disabled-size to prevent visual overlap and jumps when dragging across locked items
- Preserve disabled items' absolute indices in sortArray by rearranging only movable keys and reinserting disabled items at original positions
- Add disabled?: boolean to SortableItemProps with docs describing locked behavior and default false
- Reset swap tracking and lastCrossedDisabledSize when swaps end to avoid stale state
- Add DisableItems example page and stylesheet demonstrating locked rows in a scrollable sortable list with programmatic scroll controls
- Add SortableDisableItems entry to examples lynx.config.mjs
- Add changeset and SKILL.md documentation describing disabled-row behavior, usage patterns, and best practices for lynx-ui sortable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->