### PR TITLE
fix(input): refresh keyboard aware responder metrics

### DIFF
--- a/.changeset/soft-lemons-resize.md
+++ b/.changeset/soft-lemons-resize.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-input": patch
+---
+
+Refresh KeyboardAwareResponder scroll metrics when the responder layout changes.

--- a/packages/lynx-ui-input/src/KeyboardAwareResponder.tsx
+++ b/packages/lynx-ui-input/src/KeyboardAwareResponder.tsx
@@ -29,16 +29,28 @@ export function KeyboardAwareResponderImpl(props: KeyboardAwareResponderProps) {
     ...rest
   } = props
   const { width = '100%', height = '100%', ...restStyle } = style ?? {}
-  const { keyboardAwareResponder, keyboardAwareResponderScrollInfoCollected } =
-    useContext(KeyboardAwareRootContext)
+  const {
+    keyboardAwareResponder,
+    keyboardAwareResponderScrollInfoCollected,
+  } = useContext(KeyboardAwareRootContext)
 
   const dummyRefAtKeyboardHeight = useRef<NodesRef>(null)
-  useEffect(() => {
+  const scrollContentId =
+    `keyboard-aware-trigger-scroll-content-${scrollviewId}`
+
+  const collectKeyboardAwareResponderScrollInfo = () =>
     keyboardAwareResponderScrollInfoCollected?.(
       scrollviewId,
-      `keyboard-aware-trigger-scroll-content-${scrollviewId}`,
+      scrollContentId,
       dummyRefAtKeyboardHeight,
     )
+
+  const handleResponderLayoutChange = () => {
+    collectKeyboardAwareResponderScrollInfo()
+  }
+
+  useEffect(() => {
+    collectKeyboardAwareResponderScrollInfo()
   }, [dummyRefAtKeyboardHeight, keyboardAwareResponder])
 
   return (
@@ -48,6 +60,7 @@ export function KeyboardAwareResponderImpl(props: KeyboardAwareResponderProps) {
       {...rest}
       ref={keyboardAwareResponder}
       flatten={false}
+      bindlayoutchange={handleResponderLayoutChange}
     >
       {as === 'ScrollView'
         ? (
@@ -59,7 +72,7 @@ export function KeyboardAwareResponderImpl(props: KeyboardAwareResponderProps) {
             scrollOrientation='vertical'
           >
             <view
-              id={`keyboard-aware-trigger-scroll-content-${scrollviewId}`}
+              id={scrollContentId}
               style={{
                 width: '100%',
                 display: 'linear',

--- a/packages/lynx-ui-input/src/KeyboardAwareRoot.tsx
+++ b/packages/lynx-ui-input/src/KeyboardAwareRoot.tsx
@@ -168,7 +168,7 @@ export function KeyboardAwareRootImpl(props: KeyboardAwareRootProps) {
     offset: number,
     smooth: boolean,
   ) => {
-    getRectByRef(focusedRef, false, scrollContentId).then(
+    getRectByRef(focusedRef, true, scrollContentId).then(
       (focusedRect) => {
         getRectByRef(keyboardAwareResponderRef, true).then(
           (responderRect) => {


### PR DESCRIPTION
## Summary
- Refresh KeyboardAwareResponder scroll metrics when the responder layout changes.
- Reuse the scroll content id for initial and layout-change metric collection.
- Add a patch changeset for @lynx-js/lynx-ui-input.

## Test Plan
- pnpm exec vitest run
- pnpm turbo build
- pnpm check:all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Refresh KeyboardAwareResponder scroll metrics when responder layout changes

- Centralize scroll metric collection in a helper and invoke it on mount and responder layout changes
- Reuse a computed scrollContentId for both initial and layout-change metric collection
- Bind a new layout-change handler via bindlayoutchange to trigger refreshed metrics
- Document a patch release for `@lynx-js/lynx-ui-input` keyboard input handling improvements
- Adjust scrollToTarget focusedRef rect retrieval to use the updated boolean flag
<!-- end of auto-generated comment: release notes by coderabbit.ai -->