### PR TITLE
fix(swiper): preserve custom offset navigation

### DIFF
--- a/.changeset/swiper-custom-offset-limit.md
+++ b/.changeset/swiper-custom-offset-limit.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-swiper": patch
+---
+
+Keep custom-mode swiper navigation from being locked when item content does not fill the container.

--- a/packages/lynx-ui-swiper/src/hooks/useOffsetLimit.ts
+++ b/packages/lynx-ui-swiper/src/hooks/useOffsetLimit.ts
@@ -55,7 +55,10 @@ export function useOffsetLimit({
       }
     } else {
       // If SwiperItem can not occupy the screen, do not apply offsetLimit.
-      if (totalContentWidth <= containerWidth + epsilon) {
+      if (
+        modeConfig.mode === 'normal'
+        && totalContentWidth <= containerWidth + epsilon
+      ) {
         return {
           startLimit: 0,
           // Lock both start/end to the same offset to disable scroll.


### PR DESCRIPTION
Limit the automatic not-enough-content scroll lock to normal swiper layout so custom animations can keep paging even when synthetic item width fits inside the container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix swiper component scroll lock and autoplay timer type issues

- Restrict scroll lock mechanism to normal layout mode, allowing custom animations to continue paging when synthetic item width fits inside container boundaries
- Correct autoplay timer reference type declaration for declaration builds under current workspace type configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->