### PR TITLE
fix(scroll-view): forward experimental nested scroll props

### DIFF
--- a/.changeset/forward-nested-scroll-props.md
+++ b/.changeset/forward-nested-scroll-props.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-ui-scroll-view": patch
+---
+
+Forward experimental nested scroll behavior props to the underlying scroll-view element.

--- a/packages/lynx-ui-scroll-view/src/index.tsx
+++ b/packages/lynx-ui-scroll-view/src/index.tsx
@@ -89,6 +89,8 @@ function ScrollViewImpl(
     temporaryBlockScrollClass = 'BDXLynxViewPager',
     temporaryBlockScrollTag = 0,
     temporaryNestedScroll,
+    experimentalNestedScrollForward,
+    experimentalNestedScrollBackward,
     androidTouchSlop,
     'main-thread:gesture': gesture,
   } = props
@@ -190,6 +192,12 @@ function ScrollViewImpl(
     'main-thread:gesture'?: GestureKind
     'enable-new-nested'?: boolean
     'enable-nested-scroll'?: boolean
+    'temporary-nested-scroll-forward'?: ScrollViewProps[
+      'experimentalNestedScrollForward'
+    ]
+    'temporary-nested-scroll-backward'?: ScrollViewProps[
+      'experimentalNestedScrollBackward'
+    ]
     'force-can-scroll'?: boolean
     'ios-block-gesture-class'?: string
     'ios-recognized-view-tag'?: number
@@ -220,6 +228,12 @@ function ScrollViewImpl(
     'enable-scroll': enableScroll,
     ...(androidTouchSlop !== undefined
       && { 'android-touch-slop': androidTouchSlop }),
+    ...(experimentalNestedScrollForward !== undefined && {
+      'temporary-nested-scroll-forward': experimentalNestedScrollForward,
+    }),
+    ...(experimentalNestedScrollBackward !== undefined && {
+      'temporary-nested-scroll-backward': experimentalNestedScrollBackward,
+    }),
     ...registerEvents,
   }
 

--- a/packages/lynx-ui-scroll-view/src/types/index.docs.ts
+++ b/packages/lynx-ui-scroll-view/src/types/index.docs.ts
@@ -270,6 +270,28 @@ export interface ScrollViewProps
   'main-thread:gesture'?: BaseGesture
 
   /**
+   * Adapts Harmony nested scroll behavior. 'selfOnly' scrolls only this component. 'selfFirst' scrolls this component first, then the parent after this component reaches a scroll boundary. 'parentFirst' scrolls the parent first, then this component after the parent reaches a scroll boundary. 'parallel' scrolls this component and the parent at the same time.
+   * @zh 适配 Harmony 的嵌套滚动行为。'selfOnly' 表示只自身滚动，不与父组件联动。'selfFirst' 表示自身先滚动，自身滚动到边界以后父组件滚动。'parentFirst' 表示父组件先滚动，父组件滚动到边界以后自身滚动。'parallel' 表示自身和父组件同时滚动。
+   * @Harmony
+   */
+  experimentalNestedScrollForward?:
+    | 'selfOnly'
+    | 'selfFirst'
+    | 'parentFirst'
+    | 'parallel'
+
+  /**
+   * Adapts Harmony nested scroll behavior. 'selfOnly' scrolls only this component. 'selfFirst' scrolls this component first, then the parent after this component reaches a scroll boundary. 'parentFirst' scrolls the parent first, then this component after the parent reaches a scroll boundary. 'parallel' scrolls this component and the parent at the same time.
+   * @zh 适配 Harmony 的嵌套滚动行为。'selfOnly' 表示只自身滚动，不与父组件联动。'selfFirst' 表示自身先滚动，自身滚动到边界以后父组件滚动。'parentFirst' 表示父组件先滚动，父组件滚动到边界以后自身滚动。'parallel' 表示自身和父组件同时滚动。
+   * @Harmony
+   */
+  experimentalNestedScrollBackward?:
+    | 'selfOnly'
+    | 'selfFirst'
+    | 'parentFirst'
+    | 'parallel'
+
+  /**
    * Android touch recognition mode. When inside a component that supports 'paging' mode, 'paging' must be enabled.
    * @zh Android 触摸识别模式，当处于支持 'paging' 模式的元件中时，需要开启 'paging' 模式。
    * @Android


### PR DESCRIPTION
## Summary

Forward `experimentalNestedScrollForward` and `experimentalNestedScrollBackward` from `ScrollView` props to the underlying `scroll-view` element using the native dash-case attributes `temporary-nested-scroll-forward` and `temporary-nested-scroll-backward`.

## Why

The public props were declared in the scroll-view type docs but were not included in `elementProps`, so the native element never received the nested scroll behavior configuration.

## Impact

Consumers can now configure Harmony nested scroll behavior through `ScrollView` as documented, while the native element attribute names remain unchanged.

## Validation

- `pnpm --filter @lynx-js/lynx-ui-scroll-view build`
- `pnpm check:all`
- Previous run on this branch: `pnpm turbo build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Forward `temporary-nested-scroll-forward` and `temporary-nested-scroll-backward` to the native `scroll-view` from `ScrollViewImpl` via dash-case `elementProps`
- Extend `ScrollViewProps` with Harmony-only `experimentalNestedScrollForward` and `experimentalNestedScrollBackward` and document their nested-scroll behavior options
- Add a Changesets patch entry for `@lynx-js/lynx-ui-scroll-view` to reflect the forwarded nested-scroll props
<!-- end of auto-generated comment: release notes by coderabbit.ai -->