### PR TITLE
chore(deps): upgrade @lynx-js/react-use to 0.2.2

### DIFF
--- a/.changeset/react-use-0-2-2.md
+++ b/.changeset/react-use-0-2-2.md
@@ -1,0 +1,9 @@
+---
+"@lynx-js/lynx-ui-button": patch
+"@lynx-js/lynx-ui-common": patch
+"@lynx-js/lynx-ui-draggable": patch
+"@lynx-js/lynx-ui-swiper": patch
+"@lynx-js/lynx-ui-switch": patch
+---
+
+Update `@lynx-js/react-use` to 0.2.2.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: 0.12.4
       version: 0.12.4
     '@lynx-js/react-use':
-      specifier: 0.1.3
-      version: 0.1.3
+      specifier: 0.2.2
+      version: 0.2.2
     '@lynx-js/rspeedy':
       specifier: 0.12.2
       version: 0.12.2
@@ -891,7 +891,7 @@ importers:
         version: link:../lynx-ui-common
       '@lynx-js/react-use':
         specifier: 'catalog:'
-        version: 0.1.3(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.2.2(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -947,7 +947,7 @@ importers:
         version: 2.1.1(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(@lynx-js/types@3.6.0)
       '@lynx-js/react-use':
         specifier: 'catalog:'
-        version: 0.1.3(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.2.2(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
@@ -1006,7 +1006,7 @@ importers:
         version: link:../lynx-ui-common
       '@lynx-js/react-use':
         specifier: 'catalog:'
-        version: 0.1.3(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.2.2(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
@@ -1414,7 +1414,7 @@ importers:
         version: link:../lynx-ui-common
       '@lynx-js/react-use':
         specifier: 'catalog:'
-        version: 0.1.3(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.2.2(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
@@ -1439,7 +1439,7 @@ importers:
         version: link:../lynx-ui-common
       '@lynx-js/react-use':
         specifier: 'catalog:'
-        version: 0.1.3(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.2.2(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -2520,8 +2520,8 @@ packages:
       '@lynx-js/react':
         optional: true
 
-  '@lynx-js/react-use@0.1.3':
-    resolution: {integrity: sha512-48NX1DZfIqdpcFPKR3SdI/E0D2INJzgMDtl9IK0vbqWKPgj6LgUPZN0iqIDd7Juy3in5c2bv6E9jCpoq5ONeVw==}
+  '@lynx-js/react-use@0.2.2':
+    resolution: {integrity: sha512-+cFNtHNraLojSWwZL0uHFLHqoh/bCQU1fT7L2gSOqkwnKYmyDbtZOj+CXtHyDPVHEaGTYqqRt93ZuYA2jztD2Q==}
     peerDependencies:
       '@lynx-js/react': '>=0.105.1'
 
@@ -7741,7 +7741,7 @@ snapshots:
     transitivePeerDependencies:
       - webpack
 
-  '@lynx-js/react-use@0.1.3(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@lynx-js/react-use@0.2.2(@lynx-js/react@0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@lynx-js/react': 0.114.0(@lynx-js/types@3.6.0)(@types/react@18.3.28)
       immer: 10.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   "@lynx-js/qrcode-rsbuild-plugin": 0.4.6
   "@rsbuild/plugin-react": ^1.4.1
   "@rslib/core": ^0.16.0
-  "@lynx-js/react-use": 0.1.3
+  "@lynx-js/react-use": 0.2.2
   "@lynx-js/motion": 0.0.3
   "@types/react": "^18.3.8"
   clsx: ^2.1.1


### PR DESCRIPTION
Upgrades the shared @lynx-js/react-use catalog entry from 0.1.3 to the latest 0.2.2 release and refreshes the workspace lockfile for all consuming packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Upgrade the shared `@lynx-js/react-use` catalog entry from `0.1.3` to `0.2.2`.
- Add a changeset to bump `@lynx-js/react-use` to `0.2.2` and apply `patch` releases to `lynx-ui-button`, `lynx-ui-common`, `lynx-ui-draggable`, `lynx-ui-swiper`, and `lynx-ui-switch`.
- Refresh the workspace lockfile for consuming packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->