### PR TITLE
fix(swiper): prevent blank space after long loop drags

### DIFF
--- a/.changeset/swiper-loop-long-drag.md
+++ b/.changeset/swiper-loop-long-drag.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/lynx-ui-swiper': patch
+---
+
+Prevent a looped swiper from exposing blank space or settling outside the rendered items after a long drag.

--- a/packages/lynx-ui-swiper/__tests__/loopOffset.test.ts
+++ b/packages/lynx-ui-swiper/__tests__/loopOffset.test.ts
@@ -1,0 +1,74 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  fixPrecisionMT,
+  normalizeLoopOffset,
+  normalizeLoopTransition,
+} from '../src/utils/index'
+
+describe('swiper loop offset utils', () => {
+  it('normalizes offsets after dragging through multiple loops', () => {
+    expect(normalizeLoopOffset(-1300, 500)).toBe(-300)
+    expect(normalizeLoopOffset(1200, 500)).toBe(-300)
+    expect(normalizeLoopOffset(-1500, 500)).toBe(0)
+    expect(normalizeLoopOffset(1500, 500)).toBe(0)
+  })
+
+  it('preserves the logical index when normalizing the loop offset', () => {
+    const size = 100
+    const dataCount = 5
+    const mod = (value: number) => ((value % dataCount) + dataCount) % dataCount
+    const getIndex = (offset: number, direction: 'normal' | 'revert') => {
+      const rawIndex = fixPrecisionMT(-offset / size)
+      return mod(
+        direction === 'normal'
+          ? Math.floor(rawIndex)
+          : Math.ceil(rawIndex),
+      )
+    }
+
+    for (const offset of [-1350, -650, 250, 1250]) {
+      const normalizedOffset = normalizeLoopOffset(
+        offset,
+        size * dataCount,
+      )
+      expect(getIndex(normalizedOffset, 'normal')).toBe(
+        getIndex(offset, 'normal'),
+      )
+      expect(getIndex(normalizedOffset, 'revert')).toBe(
+        getIndex(offset, 'revert'),
+      )
+    }
+  })
+
+  it('preserves the paging distance after normalizing a loop transition', () => {
+    expect(normalizeLoopTransition(-570, -600, 500)).toEqual({
+      offset: -70,
+      finalOffset: -100,
+    })
+    expect(normalizeLoopTransition(70, 100, 500)).toEqual({
+      offset: -430,
+      finalOffset: -400,
+    })
+    expect(normalizeLoopTransition(-1270, -1300, 500)).toEqual({
+      offset: -270,
+      finalOffset: -300,
+    })
+    expect(normalizeLoopTransition(1230, 1200, 500)).toEqual({
+      offset: -270,
+      finalOffset: -300,
+    })
+  })
+
+  it('returns a stable offset when the loop has no size', () => {
+    expect(normalizeLoopOffset(100, 0)).toBe(0)
+    expect(normalizeLoopTransition(100, 200, 0)).toEqual({
+      offset: 0,
+      finalOffset: 0,
+    })
+  })
+})

--- a/packages/lynx-ui-swiper/src/hooks/useOffset.ts
+++ b/packages/lynx-ui-swiper/src/hooks/useOffset.ts
@@ -11,7 +11,7 @@ import {
 import { useTapLock } from '@lynx-js/react-use'
 import type { MainThread } from '@lynx-js/types'
 
-import { limiter } from '../utils'
+import { limiter, normalizeLoopOffset, normalizeLoopTransition } from '../utils'
 import { useAnimate } from './useAnimate'
 import { useAutoplay } from './useAutoPlay'
 import { useAxisLock } from './useAxisLock'
@@ -239,27 +239,15 @@ function useOffset(
 
   function calcLoop(start: number, end: number) {
     'main thread'
-    let startOffset = start
-    let finalOffset = end
     if (dataCount === 0) {
       return { offset: 0, finalOffset: 0 }
     }
-    const totalWidth = fullSize * dataCount
-    if (loop) {
-      if (finalOffset < -totalWidth + fullSize) {
-        // If go beyond last item, like n + 1 item, let the destination be 1
-        finalOffset = finalOffset + totalWidth
-        startOffset = startOffset + totalWidth
-      } else if (finalOffset > 0) {
-        // If go before first item, like -1 item, let the destination be n - 1
-        finalOffset = finalOffset - totalWidth
-        startOffset = startOffset - totalWidth
-      }
+
+    if (!loop) {
+      return { offset: start, finalOffset: end }
     }
-    return {
-      offset: startOffset,
-      finalOffset,
-    }
+
+    return normalizeLoopTransition(start, end, fullSize * dataCount)
   }
 
   const {
@@ -527,6 +515,9 @@ function useOffset(
     let offsetInner = sign * (event.detail.x - touchStartRef.current)
       + lastScrollOffsetRef.current
     offsetInner = calcBounceOffsetAndLimit(offsetInner)
+    if (loop) {
+      offsetInner = normalizeLoopOffset(offsetInner, fullSize * dataCount)
+    }
     setOffset(offsetInner)
     velocityTouchMove(event)
     swipeCallbackTouchMove(event)

--- a/packages/lynx-ui-swiper/src/utils/index.ts
+++ b/packages/lynx-ui-swiper/src/utils/index.ts
@@ -86,6 +86,35 @@ function limiterMTS(
   return { offset: finalOffset, reachingLimit }
 }
 
+function normalizeLoopOffset(offset: number, totalSize: number) {
+  'main thread'
+  if (totalSize <= 0) {
+    return 0
+  }
+
+  const normalizedOffset = -(((-offset % totalSize) + totalSize) % totalSize)
+  return normalizedOffset === 0 ? 0 : normalizedOffset
+}
+
+function normalizeLoopTransition(
+  startOffset: number,
+  finalOffset: number,
+  totalSize: number,
+) {
+  'main thread'
+  if (totalSize <= 0) {
+    return { offset: 0, finalOffset: 0 }
+  }
+
+  const normalizedFinalOffset = normalizeLoopOffset(finalOffset, totalSize)
+  const normalizationDelta = normalizedFinalOffset - finalOffset
+
+  return {
+    offset: startOffset + normalizationDelta,
+    finalOffset: normalizedFinalOffset,
+  }
+}
+
 const EPSILON = 1e-10
 
 export function fixPrecisionMT(num: number): number {
@@ -114,4 +143,11 @@ export function eqOrLtMT(a: number, b: number, epsilon = EPSILON) {
   return Math.abs(a - b) < epsilon || a < b
 }
 
-export { easeOut, limiter, limiterMTS, limiterForFirstScreen }
+export {
+  easeOut,
+  limiter,
+  limiterForFirstScreen,
+  limiterMTS,
+  normalizeLoopOffset,
+  normalizeLoopTransition,
+}


### PR DESCRIPTION
Normalize loop offsets continuously during touch movement so a drag cannot outrun the rendered duplicate range.

Preserve logical index reporting and release animation distance while handling offsets across any number of loop cycles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Normalize loop offsets during long swiper drags
- Preserve logical indices and release animation distances across loop cycles
- Cover loop normalization utilities with Vitest tests
- Publish a patch changeset for `@lynx-js/lynx-ui-swiper`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->