### PR TITLE
feat(luna): migrate luna-studio source package

### DIFF
--- a/.changeset/silver-studios-begin.md
+++ b/.changeset/silver-studios-begin.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/luna-studio": minor
+---
+
+Add the initial `@lynx-js/luna-studio` source package.

--- a/luna/packages/luna-studio/README.md
+++ b/luna/packages/luna-studio/README.md
@@ -2,6 +2,8 @@
 
 `@lynx-js/luna-studio` is a reusable multi-stage choreography layer for Lynx-based previews and comparison canvases.
 
+> **Note:** `luna-studio` is still experimental, and its API is constantly changing.
+
 It packages the rendering, layout, focus, and interaction plumbing needed for:
 
 - compare / focus / lineup stage arrangements
@@ -59,6 +61,7 @@ Current public exports from `@lynx-js/luna-studio` are grouped by components and
   - `InteractionParams`
   - `InteractionTarget`
   - `FocusKeyResolver`
+  - `StageAppearance`
 - Lynx bridge types
   - `LynxRuntimeCall`
 - Helpers

--- a/luna/packages/luna-studio/README.md
+++ b/luna/packages/luna-studio/README.md
@@ -1,0 +1,417 @@
+# luna-studio
+
+`@lynx-js/luna-studio` is a reusable multi-stage choreography layer for Lynx-based previews and comparison canvases.
+
+It packages the rendering, layout, focus, and interaction plumbing needed for:
+
+- compare / focus / lineup stage arrangements
+- shared or per-stage theme application
+- host-side stage-container interaction handling
+- embedded Lynx runtime callback forwarding
+- app-defined focus resolution and global-props injection
+
+It does **not** ship an application shell.
+
+The following app-level pieces stay outside this package:
+
+- `Studio`
+- `MenuBar`
+- `StudioFrame`
+- keyboard shortcut glue
+- demo-specific runtime handling
+- app-owned layout catalogs and business metadata
+
+If you only need a single device-framed preview, use [`@lynx-js/luna-stage`](../luna-stage) directly.
+
+## Installation
+
+```sh
+npm i @lynx-js/luna-studio @lynx-js/web-core motion react
+```
+
+`luna-studio` depends on `@lynx-js/luna-stage` internally for its rendering primitives and expects the Lynx Web runtime to be available through `@lynx-js/web-core`.
+
+## Public API
+
+Current public exports from `@lynx-js/luna-studio` are grouped by components and types:
+
+- Components
+  - `Choreography`
+- Studio model types
+  - `StudioStage`
+  - `StudioStageSlice`
+  - `StudioResolvedStage`
+  - `ResolveStudioLayoutParams`
+  - `StageGlobalPropsBuilder`
+  - `StudioGridSpec`
+  - `StudioLayout`
+  - `StudioResolvedLayout`
+  - `StudioModeGrid`
+  - `StudioViewMode`
+  - `LunaThemeKey`
+  - `LunaThemeMode`
+  - `LunaThemeVariant`
+- Choreography types
+  - `ChoreographyBaseProps`
+  - `ChoreographyProps`
+  - `ChoreographyInteractionProps`
+  - `ChoreographyViewProps`
+  - `InteractionParams`
+  - `InteractionTarget`
+  - `FocusKeyResolver`
+- Lynx bridge types
+  - `LynxRuntimeCall`
+- Helpers
+  - `resolveStudioLayout`
+  - `indexResolvedLayout`
+  - `getPayloadString`
+
+`ChoreographyView` and `StudioLynxStage` exist inside the package as internal implementation layers, but they are not part of the public component API.
+
+## Quick Start
+
+```tsx
+import { Choreography } from '@lynx-js/luna-studio';
+import type { StudioModeGrid, StudioResolvedLayout } from '@lynx-js/luna-studio';
+
+const modeGrid: StudioModeGrid = {
+  compare: { cols: 2, rows: 1 },
+  focus: { cols: 3, rows: 1 },
+  lineup: { cols: 3, rows: 1 },
+};
+
+const layout: StudioResolvedLayout = {
+  compare: [
+    {
+      id: 'button-light',
+      entry: 'ActButton',
+      theme: 'luna-light',
+      focusKey: 'button',
+      style: { gridColumn: '1 / span 1', gridRow: '1 / span 1' },
+    },
+    {
+      id: 'button-dark',
+      entry: 'ActButton',
+      theme: 'luna-dark',
+      focusKey: 'button',
+      style: { gridColumn: '2 / span 1', gridRow: '1 / span 1' },
+    },
+  ],
+  focus: [
+    {
+      id: 'button-focus',
+      entry: 'ActButton',
+      theme: 'luna-light',
+      focusKey: 'button',
+      style: { gridColumn: '2 / span 1', gridRow: '1 / span 1' },
+    },
+  ],
+  lineup: [
+    {
+      id: 'button-lineup',
+      entry: 'ActButton',
+      theme: 'lunaris-dark',
+      focusKey: 'button',
+      style: { gridColumn: '2 / span 1', gridRow: '1 / span 1' },
+    },
+  ],
+};
+
+export function Demo() {
+  return (
+    <div className='size-full'>
+      <Choreography
+        bundleRoot='/bundles/'
+        layout={layout}
+        modeGrid={modeGrid}
+        viewMode='compare'
+        themeKey='lunaris-dark'
+        interactionTarget='content'
+      />
+    </div>
+  );
+}
+```
+
+If your host prefers an authoring model that separates a resource pool (entry/bundleRoot/theme defaults) from per-mode layout overrides, you can build the resolved layout with `resolveStudioLayout`:
+
+```ts
+import { resolveStudioLayout } from '@lynx-js/luna-studio';
+import type {
+  ResolveStudioLayoutParams,
+  StudioLayout,
+  StudioStage,
+} from '@lynx-js/luna-studio';
+
+const stagePool: Record<string, StudioStage> = {
+  Button: { id: 'Button', entry: 'ActButton', theme: 'luna-light' },
+};
+
+const layoutSpec: StudioLayout = {
+  compare: [{ id: 'Button', style: { gridColumn: '1 / 2', gridRow: '1 / 2' } }],
+  focus: [{ id: 'Button', style: { gridColumn: '1 / 2', gridRow: '1 / 2' } }],
+  lineup: [{ id: 'Button', style: { gridColumn: '1 / 2', gridRow: '1 / 2' } }],
+};
+
+const resolvedLayout = resolveStudioLayout(
+  {
+    stagePool,
+    layoutSpec,
+  } satisfies ResolveStudioLayoutParams,
+);
+```
+
+## Core Concepts
+
+### `StudioStage`
+
+`StudioStage` is the resource/pool definition for a stage (resource locator + defaults).
+
+```ts
+type StudioStage = {
+  id: string;
+  entry: string;
+  theme: LunaThemeKey;
+  bundleRoot?: string;
+  focusKey?: string;
+};
+```
+
+Notes:
+
+- `entry` and `bundleRoot` are the resource locator used to locate the Lynx bundle.
+- `theme` and `focusKey` are stage-level defaults used during layout resolution.
+
+### `StudioResolvedStage`
+
+`StudioResolvedStage` is the per-stage data boundary consumed by the choreography layer.
+
+```ts
+type StudioResolvedStage = {
+  id: string;
+  className?: string;
+  style?: CSSProperties;
+  bundleRoot?: string;
+  focusKey?: string;
+  entry: string;
+  theme: LunaThemeKey;
+};
+```
+
+Notes:
+
+- `id` is the stable stage identity used for layout, motion, and interaction correlation.
+- `className` and `style` apply to the stage container.
+- `bundleRoot` can be provided per-stage; otherwise `Choreography.bundleRoot` may act as a host-level fallback.
+- app-specific metadata should live in app-local extension types rather than reopening the public `StudioResolvedStage` contract.
+
+### `StudioStageSlice`
+
+`StudioStageSlice` is the per-mode layout projection for a stage. It references a pool stage by `id` and carries host-side overrides for that mode.
+
+```ts
+type StudioStageSlice = {
+  id: string;
+  className?: string;
+  style?: CSSProperties;
+  theme?: LunaThemeKey;
+  focusKey?: string;
+};
+```
+
+Notes:
+
+- Slice ids must be unique within the same `StudioViewMode`. `Choreography` uses the resolved `stage.id` as the stable render identity (React key, Motion layout id, and emitted `interaction.stageId`).
+- To render the same Lynx `entry` multiple times, define multiple `StudioStage` pool items with different `id` values but the same `entry`.
+
+### `StudioLayout`
+
+`StudioLayout` is the authoring layout specification for the three built-in presentation modes. Each item references a stage by `id` and carries host-side overrides (e.g., `className`, `style`, `theme`, `focusKey`).
+
+```ts
+type StudioLayout = Record<
+  'compare' | 'focus' | 'lineup',
+  StudioStageSlice[]
+>;
+```
+
+### `StudioResolvedLayout`
+
+`StudioResolvedLayout` contains one stage list for each built-in presentation mode.
+
+```ts
+type StudioResolvedLayout = Record<
+  'compare' | 'focus' | 'lineup',
+  StudioResolvedStage[]
+>;
+```
+
+`modeGrid` can optionally provide the grid dimensions for each mode when the host wants the container layout to be grid-driven.
+
+### `StudioViewMode`
+
+`StudioViewMode` selects which layout slice is active.
+
+| Mode      | Behavior                                                        |
+| --------- | --------------------------------------------------------------- |
+| `compare` | Renders multiple stages side-by-side and allows per-stage theme |
+| `focus`   | Renders a shared theme with 3D focal emphasis                   |
+| `lineup`  | Renders a shared theme in the lineup arrangement                |
+
+## Interaction Model
+
+### `InteractionParams`
+
+`InteractionParams` is the normalized interaction envelope used by choreography callbacks.
+
+```ts
+type InteractionParams =
+  | {
+    target: 'stage';
+    stageId: string;
+    entry: string;
+    payload?: unknown;
+    containerEvent: MouseEvent | PointerEvent;
+  }
+  | {
+    target: 'content';
+    stageId: string;
+    entry: string;
+    payload?: unknown;
+    runtimeCall: LynxRuntimeCall;
+  };
+```
+
+Notes:
+
+- `target: 'stage'` means the interaction is attributed to the host-side stage layer; the raw browser payload is exposed as `containerEvent`.
+- `target: 'content'` means the interaction is attributed to embedded Lynx content; the raw Lynx runtime payload is exposed as `runtimeCall`.
+- `containerEvent.type` distinguishes host-side click / pointer variants.
+- `runtimeCall.name` distinguishes content-side interaction kinds emitted through `onNativeModulesCall`.
+
+### `interactionTarget`
+
+`interactionTarget` controls which layer receives pointer interaction first:
+
+- `'content'`: embedded Lynx content is interactive
+- `'stage'`: the outer stage container is interactive
+
+### `onInteraction`
+
+Receives the normalized choreography interaction envelope.
+
+```ts
+type OnInteraction = (interaction: InteractionParams) => unknown;
+```
+
+Use this as the primary high-level callback when you want one place to observe both host-side stage-container interactions and embedded-content runtime callbacks. The concrete raw payload is available as `interaction.containerEvent` or `interaction.runtimeCall`, depending on `interaction.target`.
+
+### `onLynxRuntimeCall`
+
+Receives raw runtime callbacks emitted from embedded Lynx content.
+
+```ts
+type OnLynxRuntimeCall = (call: LynxRuntimeCall) => unknown;
+
+type LynxRuntimeCall = {
+  entry: string;
+  channel: string;
+  name: string;
+  data: unknown;
+};
+```
+
+Use this only when you need the original Lynx bridge / RPC callback directly, rather than the normalized `onInteraction` abstraction.
+
+This keeps the package surface runtime-neutral:
+
+- no low-level `moduleName` leak
+- `channel` remains the host-facing source identifier
+- app-specific interpretation stays outside the package
+
+### `resolveFocusKey`
+
+`resolveFocusKey` maps a normalized interaction back to a stage-level `focusKey`.
+
+```ts
+type FocusKeyResolver = (
+  interaction: InteractionParams,
+) => string | undefined;
+```
+
+This is the app-owned bridge between generic choreography interactions and business-specific focus semantics.
+
+### `buildStageGlobalProps`
+
+`buildStageGlobalProps` lets the host derive app-specific Lynx global props for each rendered stage.
+
+```ts
+type StageGlobalPropsBuilder = (params: {
+  stage: StudioStage;
+  viewMode: StudioViewMode;
+  activeFocusKey: string;
+  focusKey: string | undefined;
+}) => Record<string, unknown> | undefined;
+```
+
+The two focus-related fields serve different roles:
+
+- `activeFocusKey` is the current choreography-wide active focus identity.
+- `focusKey` is the focus identity of the specific `stage` currently being rendered.
+
+In other words, `activeFocusKey` answers "which focus target is currently active?", while `focusKey` answers "which focus target does this particular stage belong to?".
+
+This makes it easy to derive stage-local props such as:
+
+- whether the current stage is the active/focused stage
+- which shared component or semantic key is currently active elsewhere in the choreography
+- app-specific flags that depend on both the rendered stage and the global focus state
+
+## `Choreography` API
+
+`Choreography` is the main public component in this package.
+
+Internally, it wraps `ChoreographyView`, which is the lower-level renderer responsible for layout, focus state, interaction normalization, and Lynx-stage wiring.
+
+```ts
+type ChoreographyProps = Omit<ChoreographyViewProps, 'mode'> & {
+  viewMode?: StudioViewMode;
+};
+```
+
+Behavior notes:
+
+- `viewMode` defaults to `'compare'`
+- `themeKey` defaults to `'lunaris-dark'`
+- `interactionTarget` defaults to `'content'`
+- `focusKey` is read directly from each resolved stage in `layout` (i.e., from the `StudioResolvedLayout` stage items)
+- `bundleRoot` can provide a choreography-level fallback; per-stage resource roots are taken from each resolved stage in `layout`
+- `layout` is required and should already be fully resolved by the host app
+
+## Scope
+
+This package covers the reusable choreography layer:
+
+- public choreography types and data model
+- grid-driven multi-stage layout and focus presentation
+- normalized stage/content interaction handling
+- the internal `ChoreographyView` renderer
+- the internal Lynx runtime adapter used by `Choreography`
+
+This package does **not** provide:
+
+- a top-level `Studio` shell component
+- built-in demo layout data
+- app chrome such as `MenuBar`
+- app-level keyboard bindings
+- demo-specific runtime event parsing
+- a public `lynx-stage` subpath export
+
+## Intended Consumers
+
+Use `@lynx-js/luna-studio` when you need a reusable multi-stage choreography layer but want to keep your app shell, layout data, business semantics, and event handling local:
+
+- documentation sites embedding multiple Lynx entries
+- design system comparison canvases
+- host apps that need both stage-container interactions and Lynx runtime callbacks
+- future `lynx-website` integration

--- a/luna/packages/luna-studio/package.json
+++ b/luna/packages/luna-studio/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@lynx-js/luna-studio",
+  "version": "0.0.0",
+  "description": "Reusable multi-stage choreography layer for the L.U.N.A project",
+  "keywords": [
+    "luna",
+    "studio",
+    "preview",
+    "choreography",
+    "react",
+    "lynx"
+  ],
+  "homepage": "https://github.com/lynx-family/lynx-ui/tree/main/luna/packages/luna-studio#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-ui.git",
+    "directory": "luna/packages/luna-studio"
+  },
+  "license": "Apache-2.0",
+  "author": "The Lynx Authors",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "rslib build"
+  },
+  "dependencies": {
+    "@lynx-js/luna-core": "workspace:*",
+    "@lynx-js/luna-stage": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/web-core": "catalog:",
+    "@rsbuild/plugin-react": "catalog:",
+    "@rslib/core": "catalog:",
+    "@types/react": "catalog:",
+    "motion": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "@lynx-js/web-core": ">=0.20.0",
+    "motion": ">=12.23.16",
+    "react": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/luna/packages/luna-studio/package.json
+++ b/luna/packages/luna-studio/package.json
@@ -35,7 +35,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "rslib build"
+    "build": "rslib build",
+    "test": "vitest run"
   },
   "dependencies": {
     "@lynx-js/luna-core": "workspace:*",
@@ -49,7 +50,8 @@
     "motion": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "peerDependencies": {
     "@lynx-js/web-core": ">=0.20.0",

--- a/luna/packages/luna-studio/rslib.config.ts
+++ b/luna/packages/luna-studio/rslib.config.ts
@@ -1,0 +1,30 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { pluginReact } from '@rsbuild/plugin-react'
+import { defineConfig } from '@rslib/core'
+
+export default defineConfig({
+  source: {
+    entry: {
+      index: ['src/**', '!src/**/*.test.*', '!src/**/__tests__/**'],
+    },
+    tsconfigPath: './tsconfig.build.json',
+  },
+  lib: [
+    {
+      bundle: false,
+      format: 'esm',
+      syntax: 'es2020',
+      dts: true,
+      output: {
+        target: 'web',
+        sourceMap: true,
+      },
+    },
+  ],
+  plugins: [
+    pluginReact(),
+  ],
+})

--- a/luna/packages/luna-studio/src/choreography/choreography-view.tsx
+++ b/luna/packages/luna-studio/src/choreography/choreography-view.tsx
@@ -133,47 +133,61 @@ function ChoreographyView({
   const containerGrid = modeGrid?.[mode]
 
   // Stable proxies that always invoke the latest props. Safe to call from
-  // event handlers. Only wrapping callbacks where stale-closure behavior would
-  // matter; `onLynxRuntimeCall` is a pass-through with a runtime-meaningful
-  // return value and stays as a direct prop call.
+  // event handlers.
   const resolveFocusKeyEvent = useEventCallback(resolveFocusKey)
   const onInteractionEvent = useEventCallback(onInteraction)
+  const onLynxRuntimeCallEvent = useEventCallback(onLynxRuntimeCall)
 
-  const handleInteraction = (interaction: InteractionParams): void => {
+  const dispatchInteractionEvent = useEventCallback((
+    interaction: InteractionParams,
+  ): void => {
     const nextActiveFocusKey = resolveFocusKeyEvent(interaction)
     if (nextActiveFocusKey !== undefined) {
       setActiveFocusKey(nextActiveFocusKey)
     }
     onInteractionEvent(interaction)
-  }
+  })
 
-  // Container event handlers and runtime-call handlers close over `stage`, so
-  // they're inherently per-stage per-render. We don't try to memoize the
-  // factory functions — instead we keep them cheap and let React handle it.
-  // These handlers all normalize into `interaction.containerEvent`; consumers
-  // can inspect `containerEvent.type` to distinguish click vs pointer events.
-  function getStageContainerEventHandlers(stage: StudioResolvedStage) {
-    if (!containerInteractive) return undefined
-    const dispatch = (e: ReactMouseEvent | ReactPointerEvent) => {
-      handleInteraction(createStageInteraction(stage, e.nativeEvent))
-    }
-    return {
-      onClick: dispatch,
-      onPointerCancel: dispatch,
-      onPointerDown: dispatch,
-      onPointerUp: dispatch,
-    }
-  }
+  const stageContainerEventHandlers = useMemo(() => {
+    const handlers = new Map<
+      string,
+      {
+        onClick: (e: ReactMouseEvent | ReactPointerEvent) => void
+        onPointerCancel: (e: ReactMouseEvent | ReactPointerEvent) => void
+        onPointerDown: (e: ReactMouseEvent | ReactPointerEvent) => void
+        onPointerUp: (e: ReactMouseEvent | ReactPointerEvent) => void
+      }
+    >()
 
-  function getStageRuntimeCallHandler(stage: StudioResolvedStage) {
-    return (call: LynxRuntimeCall) => {
-      handleInteraction(createContentInteraction(stage, call))
-      return onLynxRuntimeCall?.(call)
+    for (const stage of layout[mode]) {
+      const dispatch = (e: ReactMouseEvent | ReactPointerEvent) => {
+        dispatchInteractionEvent(createStageInteraction(stage, e.nativeEvent))
+      }
+      handlers.set(stage.id, {
+        onClick: dispatch,
+        onPointerCancel: dispatch,
+        onPointerDown: dispatch,
+        onPointerUp: dispatch,
+      })
     }
-  }
+    return handlers
+  }, [dispatchInteractionEvent, layout, mode])
+
+  const stageRuntimeCallHandlers = useMemo(() => {
+    const handlers = new Map<string, (call: LynxRuntimeCall) => unknown>()
+
+    for (const stage of layout[mode]) {
+      handlers.set(stage.id, (call: LynxRuntimeCall) => {
+        dispatchInteractionEvent(createContentInteraction(stage, call))
+        return onLynxRuntimeCallEvent(call)
+      })
+    }
+    return handlers
+  }, [dispatchInteractionEvent, layout, mode, onLynxRuntimeCallEvent])
 
   const resolvedActiveFocusKey = useMemo(() => {
-    const focusableStages = layout[mode].filter(stage => hasFocusKey(stage))
+    // eslint-disable-next-line unicorn/no-array-callback-reference
+    const focusableStages = layout[mode].filter(hasFocusKey)
 
     if (
       activeFocusKey !== undefined
@@ -187,21 +201,27 @@ function ChoreographyView({
 
   const rendered: RenderData[] = useMemo(() => {
     const stages = layout[mode]
-    const focusableStages = stages.filter(stage => hasFocusKey(stage))
-    const backgroundStages = focusableStages.filter(
+    // eslint-disable-next-line unicorn/no-array-callback-reference
+    const focusableStages = stages.filter(hasFocusKey)
+    const nonFocusedStages = stages.filter(
       stage => stage.focusKey !== resolvedActiveFocusKey,
     )
 
-    const mid = (backgroundStages.length - 1) / 2
-    const focusedIndex = focusableStages.findIndex(
-      stage => stage.focusKey === resolvedActiveFocusKey,
+    const mid = (nonFocusedStages.length - 1) / 2
+    const focusedIndex = Math.max(
+      0,
+      focusableStages.findIndex(
+        stage => stage.focusKey === resolvedActiveFocusKey,
+      ),
     )
 
     return stages.map((stage) => {
-      const compOrder = backgroundStages.findIndex(
-        bg => bg.focusKey === stage.focusKey,
+      // `compOrder` tracks render identity; `focusKey` is optional focus semantics.
+      const compOrder = nonFocusedStages.findIndex(
+        bg => bg.id === stage.id,
       )
-      const escape = compOrder === -1
+      // Only the active focus stage escapes the surrounding focus layout.
+      const escape = stage.focusKey === resolvedActiveFocusKey
       const { world, zIndex, maskOpacity } = getStageWorldState({
         mode,
         compOrder,
@@ -271,52 +291,60 @@ function ChoreographyView({
   return (
     <div className={className} style={mergedContainerStyle}>
       <AnimatePresence mode='popLayout'>
-        {rendered.map(stage => (
-          <MotionStageContainer
-            layoutId={stage.id}
-            key={stage.id}
-            className={stage.className}
-            {...getStageContainerEventHandlers(stage)}
-            style={{
-              ...stage.style,
-              zIndex: stage.zIndex,
-              pointerEvents: containerInteractive ? 'auto' : 'none',
-            }}
-          >
-            <MotionPresentation
-              variants={slidingVariants}
-              initial='initial'
-              animate='animate'
-              exit='exit'
-              transition={presentationTransition}
+        {rendered.map((stage) => {
+          const stageRuntimeCallHandler = stageRuntimeCallHandlers.get(stage.id)
+
+          return (
+            <MotionStageContainer
+              layoutId={stage.id}
+              key={stage.id}
+              className={stage.className}
+              {...(containerInteractive
+                ? stageContainerEventHandlers.get(stage.id)
+                : undefined)}
+              style={{
+                ...stage.style,
+                zIndex: stage.zIndex,
+                pointerEvents: containerInteractive ? 'auto' : 'none',
+              }}
             >
-              <MotionStage
-                fitProgress={0}
-                fitTransition={fitTransition}
-                world={stage.world}
-                focalLength={mode === 'focus' ? 500 : 0}
-                style={stageOutlineStyle}
-                contentInteractive={contentInteractive}
-                maskColor={maskColor}
-                maskOpacity={stage.maskOpacity}
+              <MotionPresentation
+                variants={slidingVariants}
+                initial='initial'
+                animate='animate'
+                exit='exit'
+                transition={presentationTransition}
               >
-                <StudioLynxStage
-                  entry={stage.entry}
-                  lunaTheme={mode === 'compare'
-                    ? stage.theme
-                    : resolvedThemeKey}
-                  onLynxRuntimeCall={getStageRuntimeCallHandler(stage)}
-                  {...(stage.resolvedBundleRoot === undefined
-                    ? {}
-                    : { bundleRoot: stage.resolvedBundleRoot })}
-                  {...(stage.extraGlobalProps === undefined
-                    ? {}
-                    : { extraGlobalProps: stage.extraGlobalProps })}
-                />
-              </MotionStage>
-            </MotionPresentation>
-          </MotionStageContainer>
-        ))}
+                <MotionStage
+                  fitProgress={0}
+                  fitTransition={fitTransition}
+                  world={stage.world}
+                  focalLength={mode === 'focus' ? 500 : 0}
+                  style={stageOutlineStyle}
+                  contentInteractive={contentInteractive}
+                  maskColor={maskColor}
+                  maskOpacity={stage.maskOpacity}
+                >
+                  <StudioLynxStage
+                    entry={stage.entry}
+                    lunaTheme={mode === 'compare'
+                      ? stage.theme
+                      : resolvedThemeKey}
+                    {...(stageRuntimeCallHandler === undefined
+                      ? {}
+                      : { onLynxRuntimeCall: stageRuntimeCallHandler })}
+                    {...(stage.resolvedBundleRoot === undefined
+                      ? {}
+                      : { bundleRoot: stage.resolvedBundleRoot })}
+                    {...(stage.extraGlobalProps === undefined
+                      ? {}
+                      : { extraGlobalProps: stage.extraGlobalProps })}
+                  />
+                </MotionStage>
+              </MotionPresentation>
+            </MotionStageContainer>
+          )
+        })}
       </AnimatePresence>
     </div>
   )

--- a/luna/packages/luna-studio/src/choreography/choreography-view.tsx
+++ b/luna/packages/luna-studio/src/choreography/choreography-view.tsx
@@ -1,0 +1,325 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { inferThemeMode } from '@lynx-js/luna-core'
+import { useEventCallback } from '@lynx-js/luna-stage'
+import {
+  MotionPresentation,
+  MotionStage,
+  MotionStageContainer,
+} from '@lynx-js/luna-stage/motion'
+import { AnimatePresence } from 'motion/react'
+import type { SpringOptions, Transition } from 'motion/react'
+import type {
+  CSSProperties,
+  JSX,
+  MouseEvent as ReactMouseEvent,
+  PointerEvent as ReactPointerEvent,
+} from 'react'
+import { useMemo, useState } from 'react'
+
+import { StudioLynxStage } from '../lynx-stage'
+import type {
+  ChoreographyViewProps,
+  InteractionParams,
+  LynxRuntimeCall,
+  StudioResolvedStage,
+} from '../types'
+import { getStageWorldState } from '../utils/world'
+
+type RenderData = StudioResolvedStage & {
+  world: { x: number, y: number, z: number }
+  zIndex: number
+  maskOpacity: number
+  // Pre-resolved props for StudioLynxStage. Optional so that omitting them
+  // matches `exactOptionalPropertyTypes` semantics on the consuming side.
+  resolvedBundleRoot?: string
+  extraGlobalProps?: Record<string, unknown>
+}
+
+type FocusableStudioStage = StudioResolvedStage & {
+  focusKey: string
+}
+
+const slidingVariants = {
+  initial: { opacity: 0, x: -300 },
+  animate: { opacity: 1, x: 0 },
+  exit: { opacity: 0, x: 300 },
+}
+
+const presentationTransition: Transition = {
+  type: 'spring',
+  visualDuration: 0.3,
+  bounce: 0.3,
+}
+
+const fitTransition: SpringOptions = { visualDuration: 0.8, bounce: 0.1 }
+
+const BASE_STYLE: CSSProperties = {
+  width: '100%',
+  height: '100%',
+  pointerEvents: 'none',
+  position: 'relative',
+}
+
+const DEFAULT_STAGE_APPEARANCE_BY_MODE = {
+  light: {
+    outlineColor: 'rgb(0 0 0 / 0.04)',
+    maskColor: '#f5f5f5',
+  },
+  dark: {
+    outlineColor: 'rgb(255 255 255 / 0.10)',
+    maskColor: '#00000080',
+  },
+} as const
+
+function hasFocusKey(
+  stage: StudioResolvedStage,
+): stage is FocusableStudioStage {
+  return stage.focusKey !== undefined
+}
+
+function createStageInteraction(
+  stage: StudioResolvedStage,
+  containerEvent: MouseEvent | PointerEvent,
+): InteractionParams {
+  return {
+    target: 'stage',
+    stageId: stage.id,
+    entry: stage.entry,
+    containerEvent,
+  }
+}
+
+function createContentInteraction(
+  stage: StudioResolvedStage,
+  call: LynxRuntimeCall,
+): InteractionParams {
+  return {
+    target: 'content',
+    stageId: stage.id,
+    entry: stage.entry,
+    runtimeCall: call,
+    ...(call.data === undefined ? {} : { payload: call.data }),
+  }
+}
+
+/**
+ * Internal choreography renderer that resolves layout, focus state, interaction
+ * normalization, and Lynx-stage wiring for the active presentation mode.
+ */
+function ChoreographyView({
+  layout,
+  modeGrid,
+  mode = 'compare',
+  defaultFocusKey,
+  className,
+  style,
+  bundleRoot,
+  resolveFocusKey,
+  buildStageGlobalProps,
+  themeKey,
+  stageAppearance,
+  interactionTarget = 'content',
+  onLynxRuntimeCall,
+  onInteraction,
+}: ChoreographyViewProps): JSX.Element {
+  const [activeFocusKey, setActiveFocusKey] = useState<string | undefined>(
+    defaultFocusKey,
+  )
+  const containerInteractive = interactionTarget === 'stage'
+  const contentInteractive = interactionTarget === 'content'
+  const containerGrid = modeGrid?.[mode]
+
+  // Stable proxies that always invoke the latest props. Safe to call from
+  // event handlers. Only wrapping callbacks where stale-closure behavior would
+  // matter; `onLynxRuntimeCall` is a pass-through with a runtime-meaningful
+  // return value and stays as a direct prop call.
+  const resolveFocusKeyEvent = useEventCallback(resolveFocusKey)
+  const onInteractionEvent = useEventCallback(onInteraction)
+
+  const handleInteraction = (interaction: InteractionParams): void => {
+    const nextActiveFocusKey = resolveFocusKeyEvent(interaction)
+    if (nextActiveFocusKey !== undefined) {
+      setActiveFocusKey(nextActiveFocusKey)
+    }
+    onInteractionEvent(interaction)
+  }
+
+  // Container event handlers and runtime-call handlers close over `stage`, so
+  // they're inherently per-stage per-render. We don't try to memoize the
+  // factory functions — instead we keep them cheap and let React handle it.
+  // These handlers all normalize into `interaction.containerEvent`; consumers
+  // can inspect `containerEvent.type` to distinguish click vs pointer events.
+  function getStageContainerEventHandlers(stage: StudioResolvedStage) {
+    if (!containerInteractive) return undefined
+    const dispatch = (e: ReactMouseEvent | ReactPointerEvent) => {
+      handleInteraction(createStageInteraction(stage, e.nativeEvent))
+    }
+    return {
+      onClick: dispatch,
+      onPointerCancel: dispatch,
+      onPointerDown: dispatch,
+      onPointerUp: dispatch,
+    }
+  }
+
+  function getStageRuntimeCallHandler(stage: StudioResolvedStage) {
+    return (call: LynxRuntimeCall) => {
+      handleInteraction(createContentInteraction(stage, call))
+      return onLynxRuntimeCall?.(call)
+    }
+  }
+
+  const resolvedActiveFocusKey = useMemo(() => {
+    const focusableStages = layout[mode].filter(stage => hasFocusKey(stage))
+
+    if (
+      activeFocusKey !== undefined
+      && focusableStages.some(stage => stage.focusKey === activeFocusKey)
+    ) {
+      return activeFocusKey
+    }
+
+    return focusableStages[0]?.focusKey ?? ''
+  }, [activeFocusKey, layout, mode])
+
+  const rendered: RenderData[] = useMemo(() => {
+    const stages = layout[mode]
+    const focusableStages = stages.filter(stage => hasFocusKey(stage))
+    const backgroundStages = focusableStages.filter(
+      stage => stage.focusKey !== resolvedActiveFocusKey,
+    )
+
+    const mid = (backgroundStages.length - 1) / 2
+    const focusedIndex = focusableStages.findIndex(
+      stage => stage.focusKey === resolvedActiveFocusKey,
+    )
+
+    return stages.map((stage) => {
+      const compOrder = backgroundStages.findIndex(
+        bg => bg.focusKey === stage.focusKey,
+      )
+      const escape = compOrder === -1
+      const { world, zIndex, maskOpacity } = getStageWorldState({
+        mode,
+        compOrder,
+        mid,
+        focusedIndex,
+        escape,
+      })
+
+      const resolvedBundleRoot = stage.bundleRoot ?? bundleRoot
+      const extraGlobalProps = buildStageGlobalProps?.({
+        stage,
+        viewMode: mode,
+        activeFocusKey: resolvedActiveFocusKey,
+        focusKey: stage.focusKey,
+      })
+
+      return {
+        ...stage,
+        world,
+        zIndex,
+        maskOpacity,
+        ...(resolvedBundleRoot === undefined ? {} : { resolvedBundleRoot }),
+        ...(extraGlobalProps === undefined ? {} : { extraGlobalProps }),
+      }
+    })
+  }, [bundleRoot, buildStageGlobalProps, layout, mode, resolvedActiveFocusKey])
+
+  const mergedContainerStyle: CSSProperties = useMemo(() => {
+    const gridStyle: CSSProperties | undefined = containerGrid && {
+      display: 'grid',
+      gridTemplateColumns: `repeat(${containerGrid.cols}, minmax(0, 1fr))`,
+      gridTemplateRows: `repeat(${containerGrid.rows}, minmax(0, 1fr))`,
+      alignItems: 'stretch',
+    }
+    return {
+      ...BASE_STYLE,
+      ...gridStyle,
+      ...style,
+    }
+  }, [containerGrid, style])
+
+  const resolvedThemeKey = themeKey ?? 'lunaris-dark'
+  const resolvedThemeMode = inferThemeMode(resolvedThemeKey) ?? 'dark'
+
+  const resolvedStageAppearance = useMemo(() => {
+    const fallback = DEFAULT_STAGE_APPEARANCE_BY_MODE[resolvedThemeMode]
+    const fromDefault = stageAppearance?.default
+    const fromMode = stageAppearance?.[resolvedThemeMode]
+
+    return {
+      outlineColor: fromMode?.outlineColor ?? fromDefault?.outlineColor
+        ?? fallback.outlineColor,
+      maskColor: fromMode?.maskColor ?? fromDefault?.maskColor
+        ?? fallback.maskColor,
+    } as const
+  }, [resolvedThemeMode, stageAppearance])
+
+  const stageOutlineStyle: CSSProperties = useMemo(
+    () => ({
+      backgroundColor: resolvedStageAppearance.outlineColor,
+    }),
+    [resolvedStageAppearance.outlineColor],
+  )
+
+  const maskColor = resolvedStageAppearance.maskColor
+
+  return (
+    <div className={className} style={mergedContainerStyle}>
+      <AnimatePresence mode='popLayout'>
+        {rendered.map(stage => (
+          <MotionStageContainer
+            layoutId={stage.id}
+            key={stage.id}
+            className={stage.className}
+            {...getStageContainerEventHandlers(stage)}
+            style={{
+              ...stage.style,
+              zIndex: stage.zIndex,
+              pointerEvents: containerInteractive ? 'auto' : 'none',
+            }}
+          >
+            <MotionPresentation
+              variants={slidingVariants}
+              initial='initial'
+              animate='animate'
+              exit='exit'
+              transition={presentationTransition}
+            >
+              <MotionStage
+                fitProgress={0}
+                fitTransition={fitTransition}
+                world={stage.world}
+                focalLength={mode === 'focus' ? 500 : 0}
+                style={stageOutlineStyle}
+                contentInteractive={contentInteractive}
+                maskColor={maskColor}
+                maskOpacity={stage.maskOpacity}
+              >
+                <StudioLynxStage
+                  entry={stage.entry}
+                  lunaTheme={mode === 'compare'
+                    ? stage.theme
+                    : resolvedThemeKey}
+                  onLynxRuntimeCall={getStageRuntimeCallHandler(stage)}
+                  {...(stage.resolvedBundleRoot === undefined
+                    ? {}
+                    : { bundleRoot: stage.resolvedBundleRoot })}
+                  {...(stage.extraGlobalProps === undefined
+                    ? {}
+                    : { extraGlobalProps: stage.extraGlobalProps })}
+                />
+              </MotionStage>
+            </MotionPresentation>
+          </MotionStageContainer>
+        ))}
+      </AnimatePresence>
+    </div>
+  )
+}
+
+export { ChoreographyView }

--- a/luna/packages/luna-studio/src/choreography/choreography.tsx
+++ b/luna/packages/luna-studio/src/choreography/choreography.tsx
@@ -1,0 +1,31 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { LayoutGroup } from 'motion/react'
+import type { JSX } from 'react'
+
+import { ChoreographyView } from './choreography-view'
+import type { ChoreographyProps } from '../types'
+
+/**
+ * Public choreography wrapper that provides a stable entry point over `ChoreographyView`.
+ * It adapts `viewMode` to the internal `mode` prop and scopes Motion layout
+ * coordination with a dedicated `LayoutGroup`.
+ */
+function Choreography({
+  viewMode = 'compare',
+  ...choreographyViewProps
+}: ChoreographyProps): JSX.Element {
+  return (
+    <LayoutGroup id='luna-studio'>
+      <ChoreographyView
+        {...choreographyViewProps}
+        mode={viewMode}
+        key='luna-studio-choreography-view'
+      />
+    </LayoutGroup>
+  )
+}
+
+export { Choreography }

--- a/luna/packages/luna-studio/src/choreography/index.ts
+++ b/luna/packages/luna-studio/src/choreography/index.ts
@@ -1,0 +1,15 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export { Choreography } from './choreography'
+export type {
+  ChoreographyBaseProps,
+  ChoreographyInteractionProps,
+  ChoreographyProps,
+  ChoreographyViewProps,
+  FocusKeyResolver,
+  InteractionParams,
+  InteractionTarget,
+  StageAppearance,
+} from '../types'

--- a/luna/packages/luna-studio/src/index.ts
+++ b/luna/packages/luna-studio/src/index.ts
@@ -1,0 +1,38 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Studio Model
+export type {
+  LunaThemeKey,
+  LunaThemeMode,
+  LunaThemeVariant,
+  ResolveStudioLayoutParams,
+  StageGlobalPropsBuilder,
+  StudioGridSpec,
+  StudioLayout,
+  StudioResolvedLayout,
+  StudioModeGrid,
+  StudioResolvedStage,
+  StudioStageSlice,
+  StudioStage,
+  StudioViewMode,
+} from './types'
+export { indexResolvedLayout, resolveStudioLayout } from './types/studio'
+export { getPayloadString } from './types/choreography'
+
+// Choreography
+export { Choreography } from './choreography'
+export type {
+  ChoreographyBaseProps,
+  ChoreographyInteractionProps,
+  ChoreographyProps,
+  ChoreographyViewProps,
+  FocusKeyResolver,
+  InteractionParams,
+  InteractionTarget,
+  StageAppearance,
+} from './choreography'
+
+// Lynx Stage
+export type { LynxRuntimeCall } from './lynx-stage'

--- a/luna/packages/luna-studio/src/lynx-stage/index.ts
+++ b/luna/packages/luna-studio/src/lynx-stage/index.ts
@@ -1,0 +1,6 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export { StudioLynxStage } from './studio-lynx-stage'
+export type { LynxRuntimeCall, StudioLynxStageProps } from '../types'

--- a/luna/packages/luna-studio/src/lynx-stage/studio-lynx-stage.tsx
+++ b/luna/packages/luna-studio/src/lynx-stage/studio-lynx-stage.tsx
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import { LunaLynxStage } from '@lynx-js/luna-stage/lynx'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import type { JSX } from 'react'
 
 import type { StudioLynxStageProps } from '../types'
@@ -20,16 +20,18 @@ function StudioLynxStage({
     extraGlobalProps ?? {}
   ), [extraGlobalProps])
 
-  const handleNativeModulesCall = useMemo(() => (
-    (name: string, data: unknown, channel: string) => {
-      return onLynxRuntimeCall?.({
-        entry,
-        channel,
-        name,
-        data,
-      })
-    }
-  ), [entry, onLynxRuntimeCall])
+  const handleNativeModulesCall = useCallback((
+    name: string,
+    data: unknown,
+    channel: string,
+  ) => {
+    return onLynxRuntimeCall?.({
+      entry,
+      channel,
+      name,
+      data,
+    })
+  }, [entry, onLynxRuntimeCall])
 
   return (
     <LunaLynxStage

--- a/luna/packages/luna-studio/src/lynx-stage/studio-lynx-stage.tsx
+++ b/luna/packages/luna-studio/src/lynx-stage/studio-lynx-stage.tsx
@@ -1,0 +1,44 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { LunaLynxStage } from '@lynx-js/luna-stage/lynx'
+import { useMemo } from 'react'
+import type { JSX } from 'react'
+
+import type { StudioLynxStageProps } from '../types'
+
+type LynxStageGlobalProps = Record<string, unknown>
+
+function StudioLynxStage({
+  entry,
+  onLynxRuntimeCall,
+  extraGlobalProps,
+  ...restProps
+}: StudioLynxStageProps): JSX.Element {
+  const mergedGlobalProps = useMemo<LynxStageGlobalProps>(() => (
+    extraGlobalProps ?? {}
+  ), [extraGlobalProps])
+
+  const handleNativeModulesCall = useMemo(() => (
+    (name: string, data: unknown, channel: string) => {
+      return onLynxRuntimeCall?.({
+        entry,
+        channel,
+        name,
+        data,
+      })
+    }
+  ), [entry, onLynxRuntimeCall])
+
+  return (
+    <LunaLynxStage
+      {...restProps}
+      entry={entry}
+      extraGlobalProps={mergedGlobalProps}
+      onNativeModulesCall={handleNativeModulesCall}
+    />
+  )
+}
+
+export { StudioLynxStage }

--- a/luna/packages/luna-studio/src/types/choreography.ts
+++ b/luna/packages/luna-studio/src/types/choreography.ts
@@ -1,0 +1,147 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { CSSProperties } from 'react'
+
+import type { LynxRuntimeCall } from './lynx-stage'
+import type {
+  LunaThemeKey,
+  LunaThemeMode,
+  StageGlobalPropsBuilder,
+  StudioModeGrid,
+  StudioResolvedLayout,
+  StudioViewMode,
+} from './studio'
+import type { Prettify } from './utils'
+
+export type InteractionTarget = 'stage' | 'content'
+
+interface BaseInteractionParams {
+  /** Stage instance identity used by the choreography layer to correlate interactions. */
+  stageId: string
+  /** Lynx entry rendered inside the stage associated with this interaction. */
+  entry: string
+  /** Optional app-defined payload forwarded from the interaction source. */
+  payload?: unknown
+}
+
+type StageInteractionParams = BaseInteractionParams & {
+  /**
+   * Interaction is attributed to the host-side stage layer.
+   * The original browser event payload is exposed separately as `containerEvent`.
+   */
+  target: 'stage'
+  /**
+   * Original browser event captured from the stage container.
+   * Currently this is sourced from the host-side `onClick`, `onPointerCancel`,
+   * `onPointerDown`, and `onPointerUp` handlers; inspect `containerEvent.type`
+   * for the concrete event kind.
+   */
+  containerEvent: MouseEvent | PointerEvent
+}
+
+type ContentInteractionParams = BaseInteractionParams & {
+  /** Interaction originated from the embedded Lynx content layer. */
+  target: 'content'
+  /**
+   * Original runtime callback emitted from the embedded Lynx content.
+   * Currently this is sourced from `onNativeModulesCall`; inspect
+   * `runtimeCall.name` for the concrete content-side interaction kind.
+   */
+  runtimeCall: LynxRuntimeCall
+}
+
+export type InteractionParams =
+  | StageInteractionParams
+  | ContentInteractionParams
+
+export type FocusKeyResolver = (
+  interaction: InteractionParams,
+) => string | undefined
+
+/**
+ * Visual appearance of the host-side stage chrome (outline + mask).
+ * These values are forwarded to the underlying MotionStage props.
+ */
+export interface StageAppearance {
+  /** Color of the overlay mask above the device frame. */
+  maskColor?: string
+  /** Color of the visible device outline (implemented as outline-layer background). */
+  outlineColor?: string
+}
+
+export interface ChoreographyBaseProps {
+  /** Optional class name applied to the outer choreography container. */
+  className?: string
+  /** Optional inline style merged onto the outer choreography container. */
+  style?: CSSProperties
+  /**
+   * Optional host-level default resource root used when a stage does not define
+   * its own `bundleRoot`.
+   */
+  bundleRoot?: string
+  /** Fully resolved stage layout used by the choreography layer. */
+  layout: StudioResolvedLayout
+  /** Optional grid config that drives the container layout for each mode. */
+  modeGrid?: StudioModeGrid
+  /** Optional initial focus key used when no runtime selection has been made yet. */
+  defaultFocusKey?: string
+  /** Optional builder for app-specific Lynx global props derived from stage + focus state. */
+  buildStageGlobalProps?: StageGlobalPropsBuilder
+  /** Shared theme key applied to all stages in focus/lineup modes. */
+  themeKey?: LunaThemeKey
+  /** Per-theme-mode stage chrome configuration (falls back to built-in defaults). */
+  stageAppearance?: Partial<Record<LunaThemeMode, StageAppearance>> & {
+    /** Fallback appearance used when the current theme mode is not configured. */
+    default?: StageAppearance
+  }
+}
+
+export interface ChoreographyInteractionProps {
+  /** Optional resolver that maps a generic interaction to a choreography focus key. */
+  resolveFocusKey?: FocusKeyResolver
+  /** Chooses whether pointer interaction is handled by stage container or embedded content. */
+  interactionTarget?: InteractionTarget
+  /**
+   * Receives normalized stage/content interaction events.
+   * This is the primary high-level callback for choreography consumers: when
+   * `interaction.target === 'stage'`, the payload includes `containerEvent`;
+   * when `interaction.target === 'content'`, it includes `runtimeCall`.
+   */
+  onInteraction?: (interaction: InteractionParams) => unknown
+  /**
+   * Receives raw runtime calls emitted from the embedded Lynx content.
+   * This is a lower-level escape hatch for consumers that need to inspect or
+   * handle the original Lynx bridge callback directly, rather than the
+   * normalized `onInteraction` abstraction.
+   */
+  onLynxRuntimeCall?: (call: LynxRuntimeCall) => unknown
+}
+
+export type ChoreographyViewProps =
+  & ChoreographyBaseProps
+  & ChoreographyInteractionProps
+  & {
+    /** Active mode selecting which layout slice to render. */
+    mode?: StudioViewMode
+  }
+
+export type ChoreographyProps = Prettify<
+  & Omit<ChoreographyViewProps, 'mode'>
+  & {
+    /** Active presentation mode for the current choreography render. */
+    viewMode?: StudioViewMode
+  }
+>
+
+export function getPayloadString(
+  data: unknown,
+  field = 'id',
+): string | undefined {
+  if (typeof data === 'string') return data
+  if (data === null || typeof data !== 'object') return undefined
+
+  const value = (data as Record<string, unknown>)[field]
+  return typeof value === 'string' ? value : undefined
+}

--- a/luna/packages/luna-studio/src/types/index.ts
+++ b/luna/packages/luna-studio/src/types/index.ts
@@ -1,0 +1,30 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export type {
+  ChoreographyBaseProps,
+  ChoreographyInteractionProps,
+  ChoreographyProps,
+  ChoreographyViewProps,
+  FocusKeyResolver,
+  InteractionParams,
+  InteractionTarget,
+  StageAppearance,
+} from './choreography'
+export type { LynxRuntimeCall, StudioLynxStageProps } from './lynx-stage'
+export type {
+  LunaThemeKey,
+  LunaThemeMode,
+  LunaThemeVariant,
+  ResolveStudioLayoutParams,
+  StageGlobalPropsBuilder,
+  StudioGridSpec,
+  StudioLayout,
+  StudioResolvedLayout,
+  StudioModeGrid,
+  StudioResolvedStage,
+  StudioStageSlice,
+  StudioStage,
+  StudioViewMode,
+} from './studio'

--- a/luna/packages/luna-studio/src/types/lynx-stage.ts
+++ b/luna/packages/luna-studio/src/types/lynx-stage.ts
@@ -1,0 +1,29 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { LunaLynxStageProps } from '@lynx-js/luna-stage/lynx'
+
+import type { Prettify } from './utils'
+
+/**
+ * Generic runtime callback payload emitted from Lynx back into the host Web app.
+ */
+export interface LynxRuntimeCall {
+  /** Lynx bundle entry that emitted the runtime call. */
+  entry: string
+  /** Runtime channel name, derived from the low-level native-module source. */
+  channel: string
+  /** Runtime event name within the channel. */
+  name: string
+  /** Opaque payload forwarded from the Lynx runtime. */
+  data: unknown
+}
+
+export type StudioLynxStageProps = Prettify<
+  & Omit<LunaLynxStageProps, 'onNativeModulesCall'>
+  & {
+    /** Receives runtime calls emitted from the embedded Lynx content. */
+    onLynxRuntimeCall?: (call: LynxRuntimeCall) => unknown
+  }
+>

--- a/luna/packages/luna-studio/src/types/studio.ts
+++ b/luna/packages/luna-studio/src/types/studio.ts
@@ -162,8 +162,13 @@ export function resolveStudioLayout(
   const MODES: StudioViewMode[] = ['compare', 'focus', 'lineup']
 
   for (const mode of MODES) {
+    const slices = (layoutSpec as Partial<StudioLayout>)[mode]
+    if (slices === undefined) {
+      throw new Error(`Missing StudioLayout mode: ${mode}`)
+    }
+
     const seen = new Set<string>()
-    for (const slice of layoutSpec[mode]) {
+    for (const slice of slices) {
       if (seen.has(slice.id)) {
         throw new Error(
           `Duplicate StudioStageSlice.id in mode "${mode}": ${slice.id}. `

--- a/luna/packages/luna-studio/src/types/studio.ts
+++ b/luna/packages/luna-studio/src/types/studio.ts
@@ -1,0 +1,234 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type {
+  LunaThemeKey,
+  LunaThemeMode,
+  LunaThemeVariant,
+} from '@lynx-js/luna-core'
+import type { CSSProperties } from 'react'
+
+import type { Prettify } from './utils'
+
+export type { LunaThemeKey, LunaThemeMode, LunaThemeVariant }
+
+/**
+ * Built-in studio presentation modes.
+ * `compare` allows each stage to render with its own theme for side-by-side comparison,
+ * `focus` renders all stages under a single shared theme and applies 3D focal emphasis,
+ * while `lineup` renders all stages under a single shared theme without that focus treatment.
+ */
+export type StudioViewMode = 'compare' | 'focus' | 'lineup'
+
+export interface StudioGridSpec {
+  cols: number
+  rows: number
+}
+
+export interface StudioStage {
+  /** Stable stage identifier used for pool lookup, layout references, and event correlation. */
+  id: string
+  /** Lynx bundle entry rendered by this stage. */
+  entry: string
+  /**
+   * Optional resource root used together with `entry` to locate the Lynx bundle.
+   * When omitted, `Choreography` may provide a host-level fallback via `bundleRoot`.
+   */
+  bundleRoot?: string
+  /**
+   * Stage-scoped theme key used when the active presentation mode allows
+   * per-stage theming.
+   */
+  theme: LunaThemeKey
+  /** Optional stage-level focus key used by choreography focus ordering and selection. */
+  focusKey?: string
+}
+
+export type StudioResolvedStage = Prettify<
+  StudioStage & {
+    /** Optional layout className applied to the stage container. */
+    className?: string
+    /** Optional inline layout style applied to the stage container. */
+    style?: CSSProperties
+  }
+>
+
+/** Layout data for the three built-in studio presentation modes. */
+export type StudioResolvedLayout = Record<
+  StudioViewMode,
+  StudioResolvedStage[]
+>
+
+/**
+ * Stage slice in an authoring `StudioLayout`.
+ *
+ * This type intentionally excludes resource-locator fields such as `entry` and `bundleRoot`.
+ * Instead, it references a pool stage by `id` and provides per-mode overrides like
+ * `className/style` and optional semantic overrides like `theme/focusKey`.
+ *
+ * Slice ids must be unique within a single view mode. The resolved `stage.id` is used
+ * as the render identity (React key, Motion layout id, and emitted `interaction.stageId`).
+ */
+export type StudioStageSlice = Prettify<
+  & Pick<StudioResolvedStage, 'id' | 'className' | 'style' | 'focusKey'>
+  & Partial<Pick<StudioResolvedStage, 'theme'>>
+>
+
+/**
+ * Authoring layout specification keyed by `StudioViewMode`.
+ * Each mode contains an ordered list of `StudioStageSlice` items.
+ */
+export type StudioLayout = Record<StudioViewMode, StudioStageSlice[]>
+
+export interface ResolveStudioLayoutParams {
+  /**
+   * Resource pool keyed by stage id. Each pool item defines the stage's
+   * resource locator (`entry`, optional `bundleRoot`) and its default semantics
+   * (`theme`, optional `focusKey`).
+   */
+  stagePool: Record<string, StudioStage>
+  /**
+   * Layout specification keyed by view mode. Each item references a pool entry
+   * by `id` and carries host-side projection overrides (e.g. `style`, `className`).
+   */
+  layoutSpec: StudioLayout
+  /**
+   * Optional host-level default bundle root used when a stage pool item does not
+   * define its own `bundleRoot`.
+   */
+  bundleRoot?: string
+}
+
+/**
+ * Resolves an authoring layout specification into a fully render-ready layout for `Choreography`.
+ *
+ * This helper merges three layers of data:
+ * - `stagePool` provides the resource locator (`entry`, optional `bundleRoot`) and stage defaults.
+ * - `layoutSpec` provides per-mode stage ordering and host-side overrides (`className`, `style`, etc.).
+ * - `bundleRoot` provides an optional host-level fallback when a pool stage does not define one.
+ *
+ * Resolution rules:
+ * - `entry`: pool-only
+ * - `bundleRoot`: `pool.bundleRoot ?? params.bundleRoot ?? undefined`
+ * - `theme`: `slice.theme ?? pool.theme`
+ * - `focusKey`: `slice.focusKey ?? pool.focusKey`
+ * - `className/style`: slice-only
+ *
+ * `layoutSpec` must not contain duplicate slice ids within the same view mode.
+ * This is required because the resolved `stage.id` is used as the stable identity
+ * for React keys, Motion layout ids, and emitted `interaction.stageId`.
+ *
+ * Throws if any `layoutSpec` item references a stage id that is missing from `stagePool`.
+ */
+export function resolveStudioLayout(
+  params: ResolveStudioLayoutParams,
+): StudioResolvedLayout {
+  const { stagePool, layoutSpec, bundleRoot } = params
+
+  const resolveSlice = (slice: StudioStageSlice): StudioResolvedStage => {
+    const pool = stagePool[slice.id]
+    if (!pool) {
+      throw new Error(`Missing stagePool item for id: ${slice.id}`)
+    }
+
+    const resolved: StudioResolvedStage = {
+      id: slice.id,
+      entry: pool.entry,
+      theme: slice.theme ?? pool.theme,
+    }
+
+    const resolvedBundleRoot = pool.bundleRoot ?? bundleRoot
+    if (resolvedBundleRoot !== undefined) {
+      resolved.bundleRoot = resolvedBundleRoot
+    }
+
+    const resolvedFocusKey = slice.focusKey ?? pool.focusKey
+    if (resolvedFocusKey !== undefined) {
+      resolved.focusKey = resolvedFocusKey
+    }
+
+    if (slice.className !== undefined) {
+      resolved.className = slice.className
+    }
+
+    if (slice.style !== undefined) {
+      resolved.style = slice.style
+    }
+
+    return resolved
+  }
+
+  const MODES: StudioViewMode[] = ['compare', 'focus', 'lineup']
+
+  for (const mode of MODES) {
+    const seen = new Set<string>()
+    for (const slice of layoutSpec[mode]) {
+      if (seen.has(slice.id)) {
+        throw new Error(
+          `Duplicate StudioStageSlice.id in mode "${mode}": ${slice.id}. `
+            + 'Each mode must use unique stage ids because stage.id is the render identity. '
+            + 'To render the same entry multiple times, define multiple pool stages with different ids.',
+        )
+      }
+      seen.add(slice.id)
+    }
+  }
+
+  const resolved = {} as StudioResolvedLayout
+  for (const mode of MODES) {
+    resolved[mode] = layoutSpec[mode].map((slice) => resolveSlice(slice))
+  }
+  return resolved
+}
+
+export function indexResolvedLayout(layout: StudioResolvedLayout): {
+  focusKeys: Set<string>
+  stageIdToFocusKey: Map<string, string>
+} {
+  const focusKeys = new Set<string>()
+  const stageIdToFocusKey = new Map<string, string>()
+  const focusKeyToStageId = new Map<string, string>()
+
+  const modes = Object.keys(layout) as (keyof StudioResolvedLayout)[]
+  for (const mode of modes) {
+    for (const stage of layout[mode]) {
+      const focusKey = stage.focusKey
+      if (focusKey === undefined) continue
+
+      const focusKeyOwner = focusKeyToStageId.get(focusKey)
+      if (focusKeyOwner !== undefined && focusKeyOwner !== stage.id) {
+        throw new Error(
+          `Duplicate focusKey "${focusKey}" found for stages "${focusKeyOwner}" and "${stage.id}".`,
+        )
+      }
+      focusKeyToStageId.set(focusKey, stage.id)
+      focusKeys.add(focusKey)
+
+      const prevFocusKey = stageIdToFocusKey.get(stage.id)
+      if (prevFocusKey !== undefined && prevFocusKey !== focusKey) {
+        throw new Error(
+          `Conflicting focusKey for stage "${stage.id}": "${prevFocusKey}" vs "${focusKey}".`,
+        )
+      }
+      stageIdToFocusKey.set(stage.id, focusKey)
+    }
+  }
+
+  return { focusKeys, stageIdToFocusKey }
+}
+
+/** Optional mode-to-grid mapping used by grid-driven choreography containers. */
+export type StudioModeGrid = Record<StudioViewMode, StudioGridSpec>
+
+/** Optional builder that derives Lynx global props for a stage render. */
+export type StageGlobalPropsBuilder = (params: {
+  /** Current stage being rendered. */
+  stage: StudioResolvedStage
+  /** Active studio presentation mode. */
+  viewMode: StudioViewMode
+  /** Resolved active focus key for the current choreography state. */
+  activeFocusKey: string
+  /** Stage-level focus key associated with `stage`, if any. */
+  focusKey: string | undefined
+}) => Record<string, unknown> | undefined

--- a/luna/packages/luna-studio/src/types/utils.ts
+++ b/luna/packages/luna-studio/src/types/utils.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export type Prettify<T> =
+  & {
+    [K in keyof T]: T[K]
+  }
+  & {}

--- a/luna/packages/luna-studio/src/utils/world.test.ts
+++ b/luna/packages/luna-studio/src/utils/world.test.ts
@@ -1,0 +1,36 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, it } from 'vitest'
+
+import { getStageWorldState } from './world'
+
+describe('getStageWorldState', () => {
+  it('keeps the centered focus stage aligned without focused index skew', () => {
+    const state = getStageWorldState({
+      mode: 'focus',
+      compOrder: 1,
+      mid: 1,
+      focusedIndex: 4,
+      escape: false,
+    })
+
+    expect(state.world.x).toBeCloseTo(0)
+    expect(state.world.z).toBeCloseTo(-600)
+    expect(state.maskOpacity).toBe(0.5)
+  })
+
+  it('clamps focus mask opacity to the animation-safe range', () => {
+    const state = getStageWorldState({
+      mode: 'focus',
+      compOrder: 20,
+      mid: 0,
+      focusedIndex: 20,
+      escape: false,
+    })
+
+    expect(state.maskOpacity).toBeGreaterThanOrEqual(0)
+    expect(state.maskOpacity).toBeLessThanOrEqual(1)
+  })
+})

--- a/luna/packages/luna-studio/src/utils/world.ts
+++ b/luna/packages/luna-studio/src/utils/world.ts
@@ -18,6 +18,20 @@ export interface StageWorldState {
 
 const WORLD_ORIGIN: WorldPos = { x: 0, y: 0, z: 0 }
 
+function getOrderDirection(orderOffset: number): -1 | 0 | 1 {
+  // Centered stages should not receive a focus-index angle offset.
+  if (orderOffset === 0) return 0
+  return orderOffset > 0 ? 1 : -1
+}
+
+/**
+ * Resolves the presentation transform for a stage.
+ *
+ * In focus mode, `escape` marks the active focused stage, which stays centered,
+ * elevated, and unmasked. Non-focused stages use `compOrder` to fan out around
+ * that active stage, while `focusedIndex` adds a small rotation offset so focus
+ * transitions preserve a sense of direction.
+ */
 export function getStageWorldState({
   mode,
   compOrder,
@@ -31,8 +45,9 @@ export function getStageWorldState({
   focusedIndex: number
   escape: boolean
 }): StageWorldState {
-  const direction = (compOrder - mid) > 0 ? 1 : -1
-  const theta = ((compOrder - mid) * 20 + direction * focusedIndex * 2)
+  const orderOffset = compOrder - mid
+  const direction = getOrderDirection(orderOffset)
+  const theta = (orderOffset * 20 + direction * focusedIndex * 2)
     / 180 * Math.PI
 
   const world: WorldPos = mode === 'focus'
@@ -48,12 +63,19 @@ export function getStageWorldState({
     : 0
 
   const maskOpacity = mode === 'focus'
-    ? (escape ? 0 : 1 - Math.abs(theta * 2 / Math.PI) * 0.6)
+    ? (
+      escape
+        ? 0
+        : Math.max(
+          0,
+          Math.min(1, (1 - Math.abs(theta * 2 / Math.PI) * 0.6) * 0.5),
+        )
+    )
     : 0
 
   return {
     world,
     zIndex,
-    maskOpacity: maskOpacity * 0.5,
+    maskOpacity,
   }
 }

--- a/luna/packages/luna-studio/src/utils/world.ts
+++ b/luna/packages/luna-studio/src/utils/world.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { StudioViewMode } from '../types'
+
+export interface WorldPos {
+  x: number
+  y: number
+  z: number
+}
+
+export interface StageWorldState {
+  world: WorldPos
+  zIndex: number
+  maskOpacity: number
+}
+
+const WORLD_ORIGIN: WorldPos = { x: 0, y: 0, z: 0 }
+
+export function getStageWorldState({
+  mode,
+  compOrder,
+  mid,
+  focusedIndex,
+  escape,
+}: {
+  mode: StudioViewMode
+  compOrder: number
+  mid: number
+  focusedIndex: number
+  escape: boolean
+}): StageWorldState {
+  const direction = (compOrder - mid) > 0 ? 1 : -1
+  const theta = ((compOrder - mid) * 20 + direction * focusedIndex * 2)
+    / 180 * Math.PI
+
+  const world: WorldPos = mode === 'focus'
+    ? {
+      x: escape ? 0 : Math.sin(theta) * 600,
+      y: 0,
+      z: escape ? 0 : -Math.cos(theta) * 600,
+    }
+    : WORLD_ORIGIN
+
+  const zIndex = mode === 'focus'
+    ? (escape ? 100 : Math.ceil(Math.abs(compOrder - mid) * 2))
+    : 0
+
+  const maskOpacity = mode === 'focus'
+    ? (escape ? 0 : 1 - Math.abs(theta * 2 / Math.PI) * 0.6)
+    : 0
+
+  return {
+    world,
+    zIndex,
+    maskOpacity: maskOpacity * 0.5,
+  }
+}

--- a/luna/packages/luna-studio/tsconfig.build.json
+++ b/luna/packages/luna-studio/tsconfig.build.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "sourceMap": true,
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts"],
+  "exclude": ["**/*.test.ts", "**/__tests__/**"],
+  "references": [
+    { "path": "../luna-core/tsconfig.build.json" },
+    { "path": "../luna-stage/tsconfig.build.json" },
+  ],
+}

--- a/luna/packages/luna-studio/tsconfig.json
+++ b/luna/packages/luna-studio/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "./",
+    "noEmit": true,
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts", "rslib.config.ts"],
+}

--- a/luna/packages/luna-studio/turbo.json
+++ b/luna/packages/luna-studio/turbo.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["@lynx-js/luna-core#build", "@lynx-js/luna-stage#build"],
+      "inputs": [
+        "package.json",
+        "src/**",
+        "rslib.config.ts",
+        "tsconfig.build.json",
+        "../../tsconfig.json"
+      ],
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/luna/tsconfig.json
+++ b/luna/tsconfig.json
@@ -42,5 +42,8 @@
     {
       "path": "./packages/luna-stage/tsconfig.build.json",
     },
+    {
+      "path": "./packages/luna-studio/tsconfig.build.json",
+    },
   ],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -991,6 +991,40 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@24.12.4)(jsdom@25.0.1)(terser@5.47.1)
 
+  luna/packages/luna-studio:
+    dependencies:
+      '@lynx-js/luna-core':
+        specifier: workspace:*
+        version: link:../luna-core
+      '@lynx-js/luna-stage':
+        specifier: workspace:*
+        version: link:../luna-stage
+    devDependencies:
+      '@lynx-js/web-core':
+        specifier: 'catalog:'
+        version: 0.23.0(@lynx-js/css-serializer@0.1.7)(@lynx-js/lynx-core@0.1.4)(tslib@2.8.1)
+      '@rsbuild/plugin-react':
+        specifier: 'catalog:'
+        version: 2.1.0(@rsbuild/core@2.1.8(core-js@3.47.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))
+      '@rslib/core':
+        specifier: 'catalog:'
+        version: 0.23.2(core-js@3.47.0)(typescript@5.9.3)
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.28
+      motion:
+        specifier: 'catalog:'
+        version: 12.42.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react:
+        specifier: 'catalog:'
+        version: 18.3.1
+      react-dom:
+        specifier: 'catalog:'
+        version: 18.3.1(react@18.3.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   luna/packages/luna-styles:
     devDependencies:
       '@lynx-js/luna-core':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1024,6 +1024,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@24.12.4)(jsdom@25.0.1)(terser@5.47.1)
 
   luna/packages/luna-styles:
     devDependencies:


### PR DESCRIPTION
Add @lynx-js/luna-studio as a source-built LUNA package in lynx-ui.

Wire the package to local luna-core and luna-stage workspace dependencies, preserve the public choreography exports and peer dependency contract, and add the initial release changeset.

Ref #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Add `@lynx-js/luna-studio` source-built package to `lynx-ui` workspace.

- Define package metadata, ESM entry points, workspace dependencies, and peer dependency ranges.
- Configure `rslib`, TypeScript, and Turbo builds.
- Export `Choreography` with compare and focus modes, layout resolution, theme styling, and interaction routing.
- Export `StudioLynxStage` with `onLynxRuntimeCall` integration.
- Define choreography, studio layout, stage, theme, and view-mode types.
- Provide layout resolution and focus-key indexing with validation.
- Provide `getStageWorldState` for focus-based positioning, z-index, and mask opacity.
- Add Vitest coverage for `getStageWorldState`.
- Document package usage, exports, layout models, callbacks, and scope.
- Include the initial release changeset referencing issue `#238`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->