### PR TITLE
test: wire root vitest workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,7 +264,9 @@ This project uses **Biome** for linting and formatting, and **dprint** for Markd
 
 - Use **Vitest** for unit testing.
 - Test files should be located alongside source files or in a `__tests__` directory (follow existing pattern).
-- Run tests: `pnpm test`
+- Run tests: `pnpm test`. The root command uses `vitest.workspace.json` to collect package-level Vitest configs.
+- When adding tests for a package, add or update that package's `vitest.config.ts` so root `pnpm test` includes it.
+- Add a package-level `test` script only when that package has tests or intentionally delegates to an external test config.
 
 ## Contribution Rules
 

--- a/luna/packages/luna-studio/tsconfig.build.json
+++ b/luna/packages/luna-studio/tsconfig.build.json
@@ -11,7 +11,13 @@
     "sourceMap": true,
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts"],
-  "exclude": ["**/*.test.ts", "**/__tests__/**"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**",
+  ],
   "references": [
     { "path": "../luna-core/tsconfig.build.json" },
     { "path": "../luna-stage/tsconfig.build.json" },

--- a/luna/packages/luna-studio/vitest.config.ts
+++ b/luna/packages/luna-studio/vitest.config.ts
@@ -1,0 +1,13 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from 'vitest/config'
+
+const config = defineConfig({
+  test: {
+    name: 'luna-studio',
+  },
+})
+
+export default config

--- a/packages/lynx-ui-sheet/vitest.config.ts
+++ b/packages/lynx-ui-sheet/vitest.config.ts
@@ -1,0 +1,13 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from 'vitest/config'
+
+const config = defineConfig({
+  test: {
+    name: 'lynx-ui-sheet',
+  },
+})
+
+export default config

--- a/packages/lynx-ui-swiper/vitest.config.ts
+++ b/packages/lynx-ui-swiper/vitest.config.ts
@@ -1,0 +1,13 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from 'vitest/config'
+
+const config = defineConfig({
+  test: {
+    name: 'lynx-ui-swiper',
+  },
+})
+
+export default config

--- a/vitest.workspace.json
+++ b/vitest.workspace.json
@@ -1,1 +1,6 @@
-["packages/**/vitest.config.ts", "apps/examples/vitest.config.ts"]
+[
+  "packages/**/vitest.config.ts",
+  "luna/packages/**/vitest.config.ts",
+  "apps/examples/vitest.config.ts",
+  "tools/skill-lynx-ui/vitest.config.ts"
+]


### PR DESCRIPTION
Register package-level Vitest projects so the root test command includes existing suites across lynx-ui packages, luna packages, and skill tests.

Add missing Vitest configs for packages that already have tests, extend the workspace project list to cover existing luna configs such as luna-stage, and document the root test convention in AGENTS.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Register lynx-ui, luna, and skill test suites in the root Vitest workspace.
- Define package-level Vitest configurations for `luna-studio`, `lynx-ui-sheet`, and `lynx-ui-swiper`.
- Document root Vitest conventions and exclude test files from the Luna Studio build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->