### PR TITLE
ci: scope pkg.pr.new previews to changeset releases

### DIFF
--- a/.github/scripts/list-changeset-packages.cjs
+++ b/.github/scripts/list-changeset-packages.cjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+const { execSync } = require('node:child_process')
+const { readFileSync } = require('node:fs')
+
+const statusFile = process.argv[2] || '.changeset-status.json'
+const data = JSON.parse(readFileSync(statusFile, 'utf8'))
+const releases = Array.isArray(data.releases) ? data.releases : []
+
+const affected = new Set(
+  releases
+    .filter((release) => release?.type && release.type !== 'none')
+    .map((release) => release.name)
+    .filter(Boolean),
+)
+
+if (affected.size > 0) {
+  const workspace = JSON.parse(
+    execSync('pnpm --recursive list --json --depth=-1', {
+      encoding: 'utf8',
+    }),
+  )
+
+  if (!Array.isArray(workspace)) {
+    throw new TypeError('Expected pnpm recursive list to return an array')
+  }
+
+  for (const pkg of workspace) {
+    if (!pkg.name || pkg.private) {
+      continue
+    }
+
+    if (!affected.has(pkg.name)) {
+      continue
+    }
+
+    process.stdout.write(`${pkg.path}\n`)
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,20 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=32768
       - name: Pack Package Artifacts
         if: inputs.upload-package-artifacts
-        run: tar -czf package-artifacts.tgz packages/*/dist
+        run: |
+          PACKAGE_ARTIFACTS=()
+          for dir in packages/*/dist luna/packages/*/dist; do
+            if [ -d "$dir" ]; then
+              PACKAGE_ARTIFACTS+=("$dir")
+            fi
+          done
+
+          if [ "${#PACKAGE_ARTIFACTS[@]}" -eq 0 ]; then
+            echo "No package dist artifacts found." >&2
+            exit 1
+          fi
+
+          tar -czf package-artifacts.tgz "${PACKAGE_ARTIFACTS[@]}"
       - name: Upload Package Artifacts
         if: inputs.upload-package-artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -2,11 +2,8 @@ name: pkg.pr.new
 
 on:
   pull_request:
-  push:
     branches:
-      - "**"
-    tags:
-      - "!**"
+      - main
 
 permissions: {}
 
@@ -40,6 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
@@ -56,10 +54,34 @@ jobs:
           name: package-artifacts-${{ github.sha }}
       - name: Extract Package Artifacts
         run: tar -xzf package-artifacts.tgz
+      - name: Collect Packages with Changesets
+        id: changeset
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        shell: bash
+        run: |
+          pnpm changeset status --since="$BASE_SHA" --output .changeset-status.json
+          PACKAGE_DIRS="$(node .github/scripts/list-changeset-packages.cjs .changeset-status.json | tr '\n' ' ')"
+          if [ -z "$(echo "$PACKAGE_DIRS" | tr -d '[:space:]')" ]; then
+            echo "No publishable packages affected by changesets; skipping pkg.pr.new publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Publishing the following package directories to pkg.pr.new:"
+          printf '  %s\n' $PACKAGE_DIRS
+          {
+            echo "skip=false"
+            echo "package-dirs<<EOF"
+            echo "$PACKAGE_DIRS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       - name: Publish Preview Packages
+        if: steps.changeset.outputs.skip == 'false'
+        env:
+          PACKAGE_DIRS: ${{ steps.changeset.outputs.package-dirs }}
         run: >
           pnpm exec pkg-pr-new publish
           --pnpm
           --commentWithSha
           --packageManager=pnpm
-          './packages/*'
+          $PACKAGE_DIRS


### PR DESCRIPTION
## Summary

Publish pkg.pr.new previews only for publishable workspace packages
affected by the current PR's Changesets releases.

This also adds preview artifact support for packages under
`luna/packages/*` and limits preview publishing to pull requests targeting
`main`.

## Motivation

The existing workflow passed `./packages/*` directly to pkg.pr.new. This
published every package under `packages/*` for every preview, regardless
of which packages were affected by the PR's changesets.

It also excluded packages under `luna/packages/*`.

The workflow additionally ran on every branch push, including `main`.
This duplicated PR runs for feature branches and performed unnecessary
builds on `main`, where the release workflow already handles publishing.

## Changes

- Restrict the pkg.pr.new workflow to pull requests targeting `main`.
- Remove the branch push trigger.
- Use the pull request's base SHA as the Changesets comparison reference,
  avoiding a dependency on remote-tracking refs while keeping the preview
  scoped to the effective PR changes.
- Run `changeset status --since` to obtain the releases calculated by
  Changesets.
- Add `.github/scripts/list-changeset-packages.cjs` to:
  - ignore releases without an actual version bump;
  - exclude private workspace packages;
  - map package names to workspace directories using `pnpm m ls`;
  - support both `packages/*` and `luna/packages/*`.
- Skip publishing when no publishable package is affected.
- Pass concrete package directories to `pkg-pr-new publish` instead of a
  hard-coded glob.
- Run package collection with an explicit Bash shell so pipeline failures
  propagate instead of being masked by `tr`.
- Log the selected package directories.
- Include existing `packages/*/dist` and `luna/packages/*/dist`
  directories in the package artifact archive.

## Resulting Behavior

pkg.pr.new previews now run only when:

- the event is a pull request targeting `main`;
- the build succeeds;
- Changesets reports at least one release with an actual version bump;
- the release maps to a non-private workspace package.

The workflow does not run for pushes, merge groups, or pull requests
targeting branches other than `main`.

New commits pushed to an existing PR update the preview through the pull
request `synchronize` event.

If package discovery fails, the workflow fails instead of treating the
failed pipeline as an empty package set. A successful empty result
continues to skip publishing intentionally.

## Changesets Behavior

The selected package set comes from the `releases` field produced by
Changesets. This intentionally respects the repository's `linked` and
`fixed` package configuration.

Changesets receives the PR event's base SHA directly. Since the checked
out `HEAD` is the PR merge ref, Changesets resolves the effective PR
boundary without depending on `origin/main` or moving the comparison back
to the branch divergence point.

If a package change causes its linked or fixed group to receive version
bumps, all publishable packages in that release group are included in the
preview.

Private packages and releases with `type: "none"` are excluded.

## Verification

- Verified package-name-to-workspace-path mapping with representative
  Changesets status data.
- Ran `changeset status --since` with a concrete base SHA.
- Verified package discovery failures propagate through the pipeline.
- Verified an empty package result still follows the skip path.
- Ran ESLint and Biome checks for the new script.
- Ran dprint and CSpell checks for the workflow files.
- Ran `git diff --check`.
- Ran the full workspace build with `pnpm turbo build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Publish eligible Changesets packages affected by pull requests targeting `main`.
- Discover publishable packages under `packages/*` and `luna/packages/*`.
- Skip publishing when no package requires a version bump.
- Archive existing distribution directories from both workspace locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->