### PR TITLE
ci: gate new publishable packages on npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,12 @@ jobs:
         run: pnpm check:changesets
       - name: Changeset Check
         run: pnpm changeset status --since=origin/main || echo "::warning::Changeset check failed, but continuing execution."
+      - name: New Publishable Package Check
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+        run: |
+          pnpm test:new-packages
+          pnpm check:new-packages --base "$BASE_SHA"
 
   check-skills:
     name: Check Skills

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check:luna-vars": "stylelint --allow-empty-input --config ./stylelint.config.cjs \"apps/**/*.css\" \"packages/**/*.css\" \"luna/examples/**/*.css\"",
     "check:manypkg": "pnpm dlx @manypkg/cli check",
     "check:mdx": "node tools/scripts/check-mdx-top-level-esm.mjs",
+    "check:new-packages": "node tools/scripts/check-new-publishable-packages.mjs",
     "check:sherif": "pnpm dlx sherif@latest",
     "check:skills-eval-definitions": "pnpm --filter @lynx-js/skill-lynx-ui check:eval-definitions",
     "check:skills-references": "pnpm --filter @lynx-js/skill-lynx-ui check:references",
@@ -37,6 +38,7 @@
     "prepare": "husky",
     "spell": "cspell lint --config cspell.jsonc --gitignore --no-progress --no-must-find-files --show-suggestions **",
     "test": "vitest",
+    "test:new-packages": "node --test tools/scripts/check-new-publishable-packages.test.mjs",
     "version:packages": "pnpm ensure:skills-changeset && changeset version"
   },
   "nano-staged": {

--- a/tools/scripts/check-new-publishable-packages.mjs
+++ b/tools/scripts/check-new-publishable-packages.mjs
@@ -1,0 +1,276 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { execFile, execFileSync } from 'node:child_process'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+import { parse } from 'yaml'
+
+const execFileAsync = promisify(execFile)
+const repoRoot = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+)
+
+function runGit(args) {
+  return execFileSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+}
+
+function readJson(text, source) {
+  try {
+    return JSON.parse(text)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to parse JSON from ${source}: ${message}`)
+  }
+}
+
+function safeFolderName(packageName) {
+  return String(packageName).replace(/^@/u, '').replaceAll('/', '__')
+}
+
+function getNpmAccessUrl(packageName) {
+  return `https://www.npmjs.com/package/${String(packageName)}/access`
+}
+
+function globToRegExp(glob) {
+  // Workspace patterns only need directory matching, so keep this conversion
+  // intentionally limited to the glob tokens used by pnpm-workspace.yaml.
+  let pattern = '^'
+
+  for (let index = 0; index < glob.length; index += 1) {
+    const character = glob[index]
+
+    if (character === '*' && glob[index + 1] === '*') {
+      if (glob[index + 2] === '/') {
+        pattern += '(?:.*/)?'
+        index += 2
+      } else {
+        pattern += '.*'
+        index += 1
+      }
+    } else if (character === '*') {
+      pattern += '[^/]*'
+    } else if (character === '?') {
+      pattern += '[^/]'
+    } else {
+      pattern += character.replace(/[\\^$.*+?()[\]{}|]/gu, '\\$&')
+    }
+  }
+
+  return new RegExp(`${pattern}$`, 'u')
+}
+
+function isWorkspacePackage(manifestPath, workspacePatterns) {
+  if (manifestPath === 'package.json') {
+    return true
+  }
+
+  const packageDirectory = path.posix.dirname(manifestPath)
+  const includes = workspacePatterns.filter(pattern => !pattern.startsWith('!'))
+  const excludes = workspacePatterns
+    .filter(pattern => pattern.startsWith('!'))
+    .map(pattern => pattern.slice(1))
+
+  return includes.some(pattern => globToRegExp(pattern).test(packageDirectory))
+    && !excludes.some(pattern => globToRegExp(pattern).test(packageDirectory))
+}
+
+function getPublishablePackageNamesAtRef(ref) {
+  // Rebuild the workspace package set from the base commit instead of the
+  // checked-out files, which may already contain new or renamed packages.
+  const workspaceText = runGit(['show', `${ref}:pnpm-workspace.yaml`])
+  const workspace = parse(workspaceText)
+  const workspacePatterns = workspace?.packages
+
+  if (!Array.isArray(workspacePatterns)) {
+    throw new TypeError(
+      `Expected "packages" to be an array in pnpm-workspace.yaml at ${ref}`,
+    )
+  }
+
+  const manifestPaths = runGit(['ls-tree', '-r', '--name-only', ref])
+    .split('\n')
+    .filter(filePath =>
+      filePath.endsWith('/package.json') || filePath === 'package.json'
+    )
+    .filter(filePath => isWorkspacePackage(filePath, workspacePatterns))
+
+  const packageNames = new Set()
+
+  for (const manifestPath of manifestPaths) {
+    const manifest = readJson(
+      runGit(['show', `${ref}:${manifestPath}`]),
+      `${ref}:${manifestPath}`,
+    )
+
+    if (manifest.private === true) {
+      continue
+    }
+
+    if (typeof manifest.name !== 'string' || manifest.name.length === 0) {
+      throw new TypeError(`Missing package name in ${ref}:${manifestPath}`)
+    }
+
+    packageNames.add(manifest.name)
+  }
+
+  return packageNames
+}
+
+function getCurrentPublishablePackages() {
+  // Let pnpm resolve the current workspace so this stays aligned with its
+  // package discovery behavior.
+  const output = execFileSync(
+    'pnpm',
+    ['--recursive', 'list', '--json', '--depth=-1'],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    },
+  )
+  const workspace = readJson(output, 'pnpm recursive list')
+
+  if (!Array.isArray(workspace)) {
+    throw new TypeError('Expected pnpm recursive list to return an array')
+  }
+
+  return workspace
+    .filter(pkg => pkg.private !== true)
+    .map(pkg => {
+      if (typeof pkg.name !== 'string' || pkg.name.length === 0) {
+        throw new TypeError(`Missing package name for workspace at ${pkg.path}`)
+      }
+
+      return {
+        name: pkg.name,
+        path: path.relative(repoRoot, pkg.path),
+      }
+    })
+}
+
+export function getNewPublishablePackages(currentPackages, basePackageNames) {
+  return currentPackages.filter(pkg => !basePackageNames.has(pkg.name))
+}
+
+export function parsePublishedVersions(output, packageName) {
+  const versions = readJson(output, `npm view ${packageName} versions`)
+
+  if (Array.isArray(versions)) {
+    return versions.filter(version =>
+      typeof version === 'string' && version.length > 0
+    )
+  }
+
+  return typeof versions === 'string' && versions.length > 0 ? [versions] : []
+}
+
+async function getPublishedVersions(packageName) {
+  // Query all versions because a bootstrap release may only have a custom
+  // dist-tag and therefore no "latest" version.
+  const { stdout } = await execFileAsync(
+    'npm',
+    ['view', packageName, 'versions', '--json'],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    },
+  )
+
+  return parsePublishedVersions(stdout, packageName)
+}
+
+async function checkPublishedPackages(packages) {
+  return Promise.all(
+    packages.map(async pkg => {
+      try {
+        const versions = await getPublishedVersions(pkg.name)
+        return { ...pkg, versions }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        return { ...pkg, error: message, versions: [] }
+      }
+    }),
+  )
+}
+
+function parseArguments(args) {
+  const baseIndex = args.indexOf('--base')
+  const base = baseIndex === -1 ? null : args[baseIndex + 1]
+
+  if (!base) {
+    throw new Error(
+      'Usage: check-new-publishable-packages.mjs --base <git-ref>',
+    )
+  }
+
+  return { base }
+}
+
+async function main() {
+  const { base } = parseArguments(process.argv.slice(2))
+  const basePackageNames = getPublishablePackageNamesAtRef(base)
+  const currentPackages = getCurrentPublishablePackages()
+  // Comparing complete names also detects private-to-public transitions and
+  // scope changes while ignoring directory-only moves.
+  const newPackages = getNewPublishablePackages(
+    currentPackages,
+    basePackageNames,
+  )
+
+  if (newPackages.length === 0) {
+    console.log('No new publishable packages detected.')
+    return
+  }
+
+  console.log('New publishable packages:')
+  for (const pkg of newPackages) {
+    console.log(`- ${pkg.name} (${pkg.path})`)
+  }
+
+  const results = await checkPublishedPackages(newPackages)
+  const unpublishedPackages = results.filter(
+    result => result.versions.length === 0,
+  )
+
+  if (unpublishedPackages.length === 0) {
+    console.log('All new publishable packages already have npm versions.')
+    return
+  }
+
+  console.error()
+  console.error(
+    'The following packages do not have a published npm version or could not be verified:',
+  )
+
+  for (const pkg of unpublishedPackages) {
+    const outputDir = path.join(
+      'tools/bootstrap-package/output',
+      safeFolderName(pkg.name),
+    )
+
+    console.error(`- ${pkg.name} (${pkg.path})`)
+    if (pkg.error) {
+      console.error(`  npm view failed: ${pkg.error}`)
+    }
+    console.error(`  Bootstrap with: pnpm bootstrap:package ${pkg.path}`)
+    console.error(`  Then publish placeholder:`)
+    console.error(`    cd ${outputDir}`)
+    console.error(`    npm publish --access public --tag oidc-bootstrap`)
+    console.error(`  Then configure Trusted Publisher (OIDC):`)
+    console.error(`    ${getNpmAccessUrl(pkg.name)}`)
+  }
+
+  process.exitCode = 1
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main()
+}

--- a/tools/scripts/check-new-publishable-packages.test.mjs
+++ b/tools/scripts/check-new-publishable-packages.test.mjs
@@ -1,0 +1,69 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import {
+  getNewPublishablePackages,
+  parsePublishedVersions,
+} from './check-new-publishable-packages.mjs'
+
+describe('getNewPublishablePackages', () => {
+  it('ignores a package moved without changing its name', () => {
+    const currentPackages = [
+      { name: '@lynx-js/example', path: 'new/example' },
+    ]
+    const basePackageNames = new Set(['@lynx-js/example'])
+
+    assert.deepEqual(
+      getNewPublishablePackages(currentPackages, basePackageNames),
+      [],
+    )
+  })
+
+  it('detects a package that changes from private to public', () => {
+    const currentPackages = [
+      { name: '@lynx-js/example', path: 'packages/example' },
+    ]
+
+    assert.deepEqual(
+      getNewPublishablePackages(currentPackages, new Set()),
+      currentPackages,
+    )
+  })
+
+  it('detects a package name or scope change', () => {
+    const currentPackages = [{ name: 'example', path: 'packages/example' }]
+    const basePackageNames = new Set(['@lynx-js/example'])
+
+    assert.deepEqual(
+      getNewPublishablePackages(currentPackages, basePackageNames),
+      currentPackages,
+    )
+  })
+})
+
+describe('parsePublishedVersions', () => {
+  it('accepts multiple published versions', () => {
+    assert.deepEqual(
+      parsePublishedVersions('["0.0.0","1.0.0"]', '@lynx-js/example'),
+      ['0.0.0', '1.0.0'],
+    )
+  })
+
+  it('accepts a single version response', () => {
+    assert.deepEqual(
+      parsePublishedVersions('"0.0.0"', '@lynx-js/example'),
+      ['0.0.0'],
+    )
+  })
+
+  it('rejects an empty versions response', () => {
+    assert.deepEqual(
+      parsePublishedVersions('[]', '@lynx-js/example'),
+      [],
+    )
+  })
+})


### PR DESCRIPTION
## Motivation

lynx-ui uses npm Trusted Publishing (OIDC) for automated releases. npm requires a package to already exist on the registry before a Trusted Publisher configuration can be added for that package.

When a new publishable workspace package (or a package that transitions from `private: true` → public) lands in `main` without being pre-published at least once, the next release run can fail when trying to publish that new package via OIDC.

This failure has an outsized blast radius because the release workflow is orchestrated by `changesets/action`: once the publish step fails, the workflow cannot proceed to downstream steps (tagging, GitHub Release creation, release notes, etc.). In practice, a single new package missing a bootstrap publish / OIDC setup can cause the entire release to fail.

## What’s in this PR

- Adds a CI gate that detects newly publishable (non-private) workspace packages by comparing the PR base SHA to the current workspace package set.
- For each newly publishable package, verifies that the package already has at least one published version on npm (via `npm view <name> versions --json`).
- Adds unit tests for the package-diff logic and npm versions parsing.

## Why this approach

- Works for:
  - brand new packages
  - `private` → public transitions
  - package renames / scope changes
- Avoids false positives for directory-only moves (name unchanged).
- Checks `versions` instead of `version` to avoid missing packages that don’t have a `latest` dist-tag yet (e.g. bootstrap/tagged releases).

## How to verify

- CI runs:
  - `pnpm test:new-packages`
  - `pnpm check:new-packages --base "$BASE_SHA"`
  
## How to resolve

- If CI fails with "new publishable package has no published npm versions", bootstrap-publish the package first:

  - Run: `pnpm bootstrap:package <package-dir>`
  - Publish the placeholder package from the generated output directory with a non-latest tag (e.g. `oidc-bootstrap`)
  - Then configure npm Trusted Publishing (OIDC) for that package before enabling automated releases

- See also: `AGENTS.md` "Publishing" section.

## Follow-ups / Notes

- This gate ensures new packages are bootstrap-published before landing.
- OIDC Trusted Publisher configuration remains a one-time manual step per package on npm (or via `npm trust`), but this PR prevents accidental merges that would later break the automated release pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Gate CI on newly publishable workspace packages.
- Detect new, public, renamed, or scope-changed packages and verify published npm versions.
- Test package detection and npm version parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->