### PR TITLE
ci: reject changesets for private packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
           pnpm dlx sherif@latest
       - name: Changeset Target Check
         run: pnpm check:changesets
+      - name: Changeset Private Target Check
+        run: |
+          pnpm test:changesets-private
+          pnpm check:changesets-private
       - name: Changeset Check
         run: pnpm changeset status --since=origin/main || echo "::warning::Changeset check failed, but continuing execution."
       - name: New Publishable Package Check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,7 @@ This project uses **Biome** for linting and formatting, and **dprint** for Markd
 ## Contribution Rules
 
 1. **Changesets**: All changes that affect package versions must include a changeset (`pnpm changeset`).
+   Changesets must not target workspace packages with `"private": true`. Remove private package entries before submission, or make the package publishable when it must be versioned and tagged.
 2. **Toolchain Updates**: Keep `.nvmrc`, `package.json` `engines`/`packageManager`, `pnpm-lock.yaml`, and GitHub Actions `actions/setup-node` versions aligned when changing Node.js or pnpm.
 3. **Pull Request Titles**: Pull request titles **MUST** use a Conventional Commits style prefix that starts the title, such as `fix(swiper): preserve release velocity on Android`.
    Do not prepend labels like `[codex]` before the release type, because the semantic PR check parses the type from the beginning of the title.

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "build": "turbo build",
     "changeset": "changeset",
     "check": "pnpm run check:luna-vars && biome check --write --no-errors-on-unmatched --files-ignore-unknown=true && eslint . --cache --cache-strategy content && dprint check",
-    "check:all": "pnpm run check && pnpm run check:mdx && pnpm run check:exports && pnpm run check:changed && pnpm run check:changesets && pnpm run check:manypkg && pnpm run check:sherif",
+    "check:all": "pnpm run check && pnpm run check:mdx && pnpm run check:exports && pnpm run check:changed && pnpm run check:changesets && pnpm run check:changesets-private && pnpm run check:manypkg && pnpm run check:sherif",
     "check:changed": "sh tools/checkChanged/checkChanged.sh",
     "check:changesets": "node tools/scripts/check-changeset-targets.mjs",
+    "check:changesets-private": "node tools/scripts/check-changeset-private-targets.mjs",
     "check:exports": "node tools/scripts/check-aggregate-exports.mjs",
     "check:luna-vars": "stylelint --allow-empty-input --config ./stylelint.config.cjs \"apps/**/*.css\" \"packages/**/*.css\" \"luna/examples/**/*.css\"",
     "check:manypkg": "pnpm dlx @manypkg/cli check",
@@ -38,6 +39,7 @@
     "prepare": "husky",
     "spell": "cspell lint --config cspell.jsonc --gitignore --no-progress --no-must-find-files --show-suggestions **",
     "test": "vitest",
+    "test:changesets-private": "node --test tools/scripts/check-changeset-private-targets.test.mjs",
     "test:new-packages": "node --test tools/scripts/check-new-publishable-packages.test.mjs",
     "version:packages": "pnpm ensure:skills-changeset && changeset version"
   },
@@ -68,6 +70,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@changesets/cli": "2.28.1",
+    "@changesets/parse": "0.4.3",
     "@cspell/eslint-plugin": "^8.17.1",
     "@eslint/js": "^9.17.0",
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@changesets/cli':
         specifier: 2.28.1
         version: 2.28.1
+      '@changesets/parse':
+        specifier: 0.4.3
+        version: 0.4.3
       '@cspell/eslint-plugin':
         specifier: ^8.17.1
         version: 8.19.4(eslint@9.39.4(jiti@2.7.0))

--- a/tools/scripts/check-changeset-private-targets.mjs
+++ b/tools/scripts/check-changeset-private-targets.mjs
@@ -1,0 +1,129 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+import parseChangeset from '@changesets/parse'
+
+const repoRoot = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+)
+const changesetDir = path.join(repoRoot, '.changeset')
+
+function readJson(text, source) {
+  try {
+    return JSON.parse(text)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to parse JSON from ${source}: ${message}`)
+  }
+}
+
+function getChangesetFiles() {
+  // README.md documents Changesets itself and is not a release declaration.
+  return fs
+    .readdirSync(changesetDir)
+    .filter(
+      fileName =>
+        fileName.endsWith('.md') && fileName.toLowerCase() !== 'readme.md',
+    )
+    .map(fileName => path.join(changesetDir, fileName))
+    .sort()
+}
+
+export function getChangesetPackageNames(changesetText) {
+  return parseChangeset(changesetText).releases.map(release => release.name)
+}
+
+export function getPrivateWorkspacePackageNames(workspace) {
+  if (!Array.isArray(workspace)) {
+    throw new TypeError('Expected pnpm recursive list to return an array')
+  }
+
+  const packageNames = new Set()
+
+  for (const pkg of workspace) {
+    if (pkg?.private !== true) {
+      continue
+    }
+
+    if (typeof pkg.name !== 'string' || pkg.name.length === 0) {
+      throw new TypeError(`Missing package name for workspace at ${pkg?.path}`)
+    }
+
+    packageNames.add(pkg.name)
+  }
+
+  return packageNames
+}
+
+function getWorkspacePrivatePackageNames() {
+  // Let pnpm resolve workspace membership so this check follows the same
+  // package discovery rules as the rest of the repository tooling.
+  const output = execFileSync(
+    'pnpm',
+    ['--recursive', 'list', '--json', '--depth=-1'],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    },
+  )
+
+  return getPrivateWorkspacePackageNames(
+    readJson(output, 'pnpm recursive list'),
+  )
+}
+
+function formatFilePath(filePath) {
+  return path.relative(repoRoot, filePath)
+}
+
+export function checkChangesets(privatePackageNames, changesets) {
+  // Compare complete package names so scoped and unscoped packages remain
+  // distinct and only current private workspace packages are rejected.
+  return changesets
+    .map(({ filePath, text }) => ({
+      filePath,
+      privateTargets: getChangesetPackageNames(text).filter(name =>
+        privatePackageNames.has(name)
+      ),
+    }))
+    .filter(entry => entry.privateTargets.length > 0)
+}
+
+function main() {
+  const privatePackageNames = getWorkspacePrivatePackageNames()
+  const changesets = getChangesetFiles().map(filePath => ({
+    filePath,
+    text: fs.readFileSync(filePath, 'utf8'),
+  }))
+  const failures = checkChangesets(privatePackageNames, changesets)
+
+  if (failures.length === 0) {
+    console.log('Changeset private target check passed.')
+    return
+  }
+
+  console.error('Changesets must not target private workspace packages.')
+  console.error(
+    'Remove the private package entries or make the package publishable before adding a changeset.',
+  )
+  console.error()
+
+  for (const failure of failures) {
+    console.error(`- ${formatFilePath(failure.filePath)}`)
+    console.error(`  Private targets: ${failure.privateTargets.join(', ')}`)
+  }
+
+  process.exitCode = 1
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main()
+}

--- a/tools/scripts/check-changeset-private-targets.test.mjs
+++ b/tools/scripts/check-changeset-private-targets.test.mjs
@@ -1,0 +1,136 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  checkChangesets,
+  getChangesetPackageNames,
+  getPrivateWorkspacePackageNames,
+} from './check-changeset-private-targets.mjs'
+
+test('getChangesetPackageNames parses quoted targets', () => {
+  const text = `---
+"@lynx-js/lynx-ui": patch
+'@lynx-js/luna-stage': minor
+---
+
+body
+`
+
+  assert.deepEqual(getChangesetPackageNames(text), [
+    '@lynx-js/lynx-ui',
+    '@lynx-js/luna-stage',
+  ])
+})
+
+test('getChangesetPackageNames rejects non-frontmatter files', () => {
+  assert.throws(
+    () => getChangesetPackageNames('no frontmatter\n'),
+    /could not parse changeset - missing or invalid frontmatter/u,
+  )
+})
+
+test('getPrivateWorkspacePackageNames collects private packages only', () => {
+  const workspace = [
+    { name: '@lynx-js/public', private: false, path: '/repo/packages/public' },
+    { name: '@lynx-js/private', private: true, path: '/repo/packages/private' },
+  ]
+
+  assert.deepEqual(Array.from(getPrivateWorkspacePackageNames(workspace)), [
+    '@lynx-js/private',
+  ])
+})
+
+test('checkChangesets reports only private targets regardless of order', () => {
+  const privatePackageNames = new Set(['@lynx-js/private'])
+  const changesets = [
+    {
+      filePath: '.changeset/private-first.md',
+      text: `---
+"@lynx-js/private": patch
+"@lynx-js/public": minor
+---
+`,
+    },
+    {
+      filePath: '.changeset/public-first.md',
+      text: `---
+"@lynx-js/public": minor
+"@lynx-js/private": patch
+---
+`,
+    },
+  ]
+
+  assert.deepEqual(checkChangesets(privatePackageNames, changesets), [
+    {
+      filePath: '.changeset/private-first.md',
+      privateTargets: ['@lynx-js/private'],
+    },
+    {
+      filePath: '.changeset/public-first.md',
+      privateTargets: ['@lynx-js/private'],
+    },
+  ])
+})
+
+test('checkChangesets reports every private target', () => {
+  const privatePackageNames = new Set([
+    '@lynx-js/private-a',
+    '@lynx-js/private-b',
+  ])
+  const changesets = [
+    {
+      filePath: '.changeset/two-private-packages.md',
+      text: `---
+"@lynx-js/private-a": patch
+"@lynx-js/public": minor
+"@lynx-js/private-b": major
+---
+`,
+    },
+  ]
+
+  assert.deepEqual(checkChangesets(privatePackageNames, changesets), [
+    {
+      filePath: '.changeset/two-private-packages.md',
+      privateTargets: ['@lynx-js/private-a', '@lynx-js/private-b'],
+    },
+  ])
+})
+
+test('checkChangesets reports private targets from YAML flow mappings', () => {
+  const privatePackageNames = new Set(['@lynx-js/private'])
+  const changesets = [
+    {
+      filePath: '.changeset/flow-mapping.md',
+      text: `---
+{ "@lynx-js/private": patch }
+---
+`,
+    },
+  ]
+
+  assert.deepEqual(checkChangesets(privatePackageNames, changesets), [
+    {
+      filePath: '.changeset/flow-mapping.md',
+      privateTargets: ['@lynx-js/private'],
+    },
+  ])
+})
+
+test('getPrivateWorkspacePackageNames rejects unnamed private packages', () => {
+  assert.throws(
+    () =>
+      getPrivateWorkspacePackageNames([
+        { private: true, path: '/repo/packages/private' },
+      ]),
+    {
+      name: 'TypeError',
+      message: 'Missing package name for workspace at /repo/packages/private',
+    },
+  )
+})


### PR DESCRIPTION
## Motivation

Private workspace packages are excluded from Changesets versioning and tagging. Changesets targeting these packages therefore create misleading release metadata that cannot result in a release.

This PR adds a CI gate to reject these invalid changesets before they are merged.

## Changes

- Collect private package names from the current pnpm workspace.
- Scan `.changeset/*.md` frontmatter for private package targets.
- Report the affected changeset files and private package names.
- Run the policy check through `check:all` and PR CI.
- Extract the policy decision into a pure helper for deterministic testing.
- Add tests covering:
  - mixed public and private targets
  - target ordering
  - multiple private targets
  - invalid private workspace metadata

## Verification

- `pnpm test:changesets-private`
- `pnpm check:changesets-private`
- `pnpm check:all`
- `pnpm turbo build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Enforce a policy that rejects Changesets targeting private workspace packages.
- Report affected Changeset files and private package names.
- Integrate validation with `check:all` and PR CI.
- Test target ordering, multiple targets, and invalid workspace metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->