### PR TITLE
test(ci): trigger new publishable package gate (DO NOT merge)

### DIFF
--- a/luna/examples/luna-stage-basic/package.json
+++ b/luna/examples/luna-stage-basic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lynx-example/luna-stage-basic",
   "version": "0.0.0",
-  "private": true,
+  "private": false,
   "license": "Apache-2.0",
   "author": "The Lynx Authors",
   "type": "module",


### PR DESCRIPTION
This commit intentionally makes @lynx-example/luna-stage-basic publishable by switching "private" from true to false in:
- luna/examples/luna-stage-basic/package.json

Purpose: exercise the CI gate "New Publishable Package Check" in .github/workflows/ci.yml that validates newly publishable packages already exist on npm (OIDC bootstrap workflow).

Expected result: CI should fail at the new package gate with a "npm view ... 404" error. Do NOT merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Make `@lynx-example/luna-stage-basic` publishable by setting `"private"` to `false`.
- Exercise the “New Publishable Package Check” CI gate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->