### PR TITLE
chore(luna-examples): align private luna examples package scope

### DIFF
--- a/luna/examples/luna-stage-basic/package.json
+++ b/luna/examples/luna-stage-basic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lynx-example/luna-stage-basic",
+  "name": "@lynx-js/example-luna-stage-basic",
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",

--- a/luna/examples/luna-stage-motion/package.json
+++ b/luna/examples/luna-stage-motion/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lynx-example/luna-stage-motion",
+  "name": "@lynx-js/example-luna-stage-motion",
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",

--- a/luna/examples/luna-theme-provider/README.md
+++ b/luna/examples/luna-theme-provider/README.md
@@ -17,11 +17,11 @@ through `globalProps` so the example can switch the active theme variant.
 Run the development server from the repository root:
 
 ```bash
-pnpm --filter @lynx-example/luna-theme-provider dev
+pnpm --filter @lynx-js/example-luna-theme-provider dev
 ```
 
 Build the example:
 
 ```bash
-pnpm --filter @lynx-example/luna-theme-provider build
+pnpm --filter @lynx-js/example-luna-theme-provider build
 ```

--- a/luna/examples/luna-theme-provider/package.json
+++ b/luna/examples/luna-theme-provider/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lynx-example/luna-theme-provider",
+  "name": "@lynx-js/example-luna-theme-provider",
   "version": "0.0.0",
   "private": true,
   "description": "Example app demonstrating LUNA theme provider usage in lynx-ui",


### PR DESCRIPTION
# Context

Core L.U.N.A migrations are complete and the follow-up in-repo showcases already use `@lynx-js/example-luna-*`.

The `@lynx-example` scope is shared by public Lynx examples, not only `lynx-ui` examples. Future public L.U.N.A examples may still use `@lynx-example/luna-*` when they are intentionally published.

The `lynx-stack` repository currently uses the `@lynx-js/example-*` naming convention for in-repo private examples. This change applies the same convention to private `luna/examples` packages in `lynx-ui`.

## Architecture

This is a metadata-only rename of the remaining private `luna/examples` packages still using `@lynx-example/luna-*`.

It also updates the `luna-theme-provider` README filter commands.

There is no runtime logic change.

## Regression

Suggested checks:

```bash
pnpm --filter @lynx-js/example-luna-theme-provider dev
pnpm --filter @lynx-js/example-luna-stage-basic dev
pnpm --filter @lynx-js/example-luna-stage-motion dev
```

## Result

Private `luna/examples` package naming is consistent with the migration follow-up showcase scheme and with `lynx-stack` private example naming.

Scope ownership is clearer:

- `@lynx-js/example-luna-*` for private in-repo L.U.N.A examples and showcases
- `@lynx-example/*` for public Lynx examples, including future public L.U.N.A examples when intentionally published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Rename private L.U.N.A example packages to the `@lynx-js/example-luna-*` scope.
- Update `luna-theme-provider` README filter commands to use the new package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->