### PR TITLE
refactor(css): namespace component class names

### DIFF
--- a/.changeset/quiet-wolves-smile.md
+++ b/.changeset/quiet-wolves-smile.md
@@ -1,0 +1,8 @@
+---
+'@lynx-js/lynx-ui-feed-list': patch
+'@lynx-js/lynx-ui-lazy-component': patch
+'@lynx-js/lynx-ui-popover': patch
+'@lynx-js/lynx-ui-swiper': patch
+---
+
+Namespace built-in CSS class names to prevent collisions with application styles.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,7 @@ This library follows the **Headless** pattern, focusing on logic, state manageme
 
 - Use `clsx` for conditional class names.
 - Follow the existing pattern of separating styles into `.css` files or using Tailwind if configured in the specific package.
+- Component classes must use the `.lynx-ui-<package>__<lowercase-kebab-name>` namespace. Do not add generic global selectors such as `.container` or `.text`.
 - Respect the L.U.N.A design tokens.
 
 ### Main Thread Script (MTS)

--- a/packages/lynx-ui-feed-list/src/index.tsx
+++ b/packages/lynx-ui-feed-list/src/index.tsx
@@ -117,7 +117,7 @@ function FeedListImpl(props: FeedListProps, ref: ForwardedRef<FeedListRef>) {
     refreshHeader = (
       <view
         id={`${listId}-refreshHeaderWrapper`}
-        class='vertical-start-wrapper'
+        class='lynx-ui-feed-list__vertical-start-wrapper'
         main-thread:bindlayoutchange={(e) => {
           'main thread'
           useRefreshAndBounceProps?.onRefreshHeaderLayoutUpdated(e)
@@ -144,9 +144,9 @@ function FeedListImpl(props: FeedListProps, ref: ForwardedRef<FeedListRef>) {
           id={`${listId}-upperBounceWrapper`}
           class={horizontal
             ? (enableRTL
-              ? 'horizontal-start-wrapper-rtl'
-              : 'horizontal-start-wrapper')
-            : 'vertical-start-wrapper'}
+              ? 'lynx-ui-feed-list__horizontal-start-wrapper-rtl'
+              : 'lynx-ui-feed-list__horizontal-start-wrapper')
+            : 'lynx-ui-feed-list__vertical-start-wrapper'}
         >
           {bounceableProps.upperBounceItem}
         </view>
@@ -158,9 +158,9 @@ function FeedListImpl(props: FeedListProps, ref: ForwardedRef<FeedListRef>) {
           id={`${listId}-lowerBounceWrapper`}
           class={horizontal
             ? (enableRTL
-              ? 'horizontal-end-wrapper-rtl'
-              : 'horizontal-end-wrapper')
-            : 'vertical-end-wrapper'}
+              ? 'lynx-ui-feed-list__horizontal-end-wrapper-rtl'
+              : 'lynx-ui-feed-list__horizontal-end-wrapper')
+            : 'lynx-ui-feed-list__vertical-end-wrapper'}
         >
           {bounceableProps.lowerBounceItem}
         </view>

--- a/packages/lynx-ui-feed-list/src/styles.css
+++ b/packages/lynx-ui-feed-list/src/styles.css
@@ -1,39 +1,39 @@
-.horizontal-start-wrapper {
+.lynx-ui-feed-list__horizontal-start-wrapper {
   position: absolute;
   right: 100%;
   height: 100%;
   width: max-content;
 }
 
-.horizontal-start-wrapper-rtl {
+.lynx-ui-feed-list__horizontal-start-wrapper-rtl {
   position: absolute;
   left: 100%;
   height: 100%;
   width: max-content;
 }
 
-.vertical-start-wrapper {
+.lynx-ui-feed-list__vertical-start-wrapper {
   position: absolute;
   bottom: 100%;
   width: 100%;
   height: max-content;
 }
 
-.horizontal-end-wrapper {
+.lynx-ui-feed-list__horizontal-end-wrapper {
   position: absolute;
   left: 100%;
   height: 100%;
   width: max-content;
 }
 
-.horizontal-end-wrapper-rtl {
+.lynx-ui-feed-list__horizontal-end-wrapper-rtl {
   position: absolute;
   right: 100%;
   height: 100%;
   width: max-content;
 }
 
-.vertical-end-wrapper {
+.lynx-ui-feed-list__vertical-end-wrapper {
   position: absolute;
   top: 100%;
   width: 100%;

--- a/packages/lynx-ui-lazy-component/src/index.tsx
+++ b/packages/lynx-ui-lazy-component/src/index.tsx
@@ -107,7 +107,7 @@ function LazyComponentImpl(
     return (
       <view
         id='component'
-        className='min'
+        className='lynx-ui-lazy-component__min'
         flatten={false}
         exposure-screen-margin-top={top}
         exposure-screen-margin-bottom={bottom}
@@ -131,7 +131,7 @@ function LazyComponentImpl(
     return show ? children : (
       <view
         id='component'
-        className='min'
+        className='lynx-ui-lazy-component__min'
         flatten={false}
         exposure-screen-margin-top={top}
         exposure-screen-margin-bottom={bottom}

--- a/packages/lynx-ui-lazy-component/src/styles.css
+++ b/packages/lynx-ui-lazy-component/src/styles.css
@@ -1,4 +1,4 @@
-.min {
+.lynx-ui-lazy-component__min {
   min-height: 1px;
   min-width: 1px;
 }

--- a/packages/lynx-ui-popover/src/Popover.tsx
+++ b/packages/lynx-ui-popover/src/Popover.tsx
@@ -375,7 +375,7 @@ export const PopoverBackdrop = (props: PopoverBackdropProps) => {
 
   return (
     <Button
-      className={`popover-backdrop ${presenceClassName}`}
+      className={`lynx-ui-popover__backdrop ${presenceClassName}`}
       style={style}
       onClick={handleTap}
       disabled={busy}

--- a/packages/lynx-ui-popover/src/style.css
+++ b/packages/lynx-ui-popover/src/style.css
@@ -1,4 +1,4 @@
-.popover-backdrop {
+.lynx-ui-popover__backdrop {
   position: fixed;
   width: 100vw;
   height: 100vh;

--- a/packages/lynx-ui-swiper/src/Swiper/index.tsx
+++ b/packages/lynx-ui-swiper/src/Swiper/index.tsx
@@ -358,7 +358,7 @@ const Swiper = forwardRef(
     return (
       <SwiperContext.Provider value={contextValue}>
         <view
-          class='swiper-root'
+          class='lynx-ui-swiper__root'
           style={{
             ...style,
             width: `${containerWidth}px`,
@@ -370,7 +370,7 @@ const Swiper = forwardRef(
           block-native-event={blockNativeEvent}
         >
           <view
-            class='swiper-track'
+            class='lynx-ui-swiper__track'
             style={containerStyle}
             ref={setContainerRef}
             main-thread:ref={containerRef}

--- a/packages/lynx-ui-swiper/src/Swiper/styles.css
+++ b/packages/lynx-ui-swiper/src/Swiper/styles.css
@@ -1,4 +1,4 @@
-.swiper-root {
+.lynx-ui-swiper__root {
   display: linear;
   linear-orientation: horizontal;
   width: 100%;
@@ -6,14 +6,14 @@
   overflow: hidden;
 }
 
-.swiper-track {
+.lynx-ui-swiper__track {
   display: linear;
   linear-orientation: horizontal;
   width: 100%;
   height: 100%;
 }
 
-.bounce-start-item {
+.lynx-ui-swiper__bounce-start {
   position: absolute;
   left: 0;
   transform: translate(-100%);
@@ -21,7 +21,7 @@
   width: max-content;
 }
 
-.bounce-start-item-RTL {
+.lynx-ui-swiper__bounce-start-rtl {
   position: absolute;
   inset-inline-start: 0;
   transform: translate(100%);
@@ -29,14 +29,14 @@
   width: max-content;
 }
 
-.bounce-end-item {
+.lynx-ui-swiper__bounce-end {
   position: absolute;
   left: 100%;
   height: 100%;
   width: max-content;
 }
 
-.bounce-end-item-RTL {
+.lynx-ui-swiper__bounce-end-rtl {
   position: absolute;
   inset-inline-start: 100%;
   height: 100%;

--- a/packages/lynx-ui-swiper/src/SwiperItem/index.tsx
+++ b/packages/lynx-ui-swiper/src/SwiperItem/index.tsx
@@ -202,7 +202,7 @@ const SwiperItem = (
 
   return (
     <view
-      class='swiper-item'
+      class='lynx-ui-swiper__item'
       style={containerStyle}
       main-thread:ref={setRef}
       overlap={overlap}

--- a/packages/lynx-ui-swiper/src/hooks/useBounceView.tsx
+++ b/packages/lynx-ui-swiper/src/hooks/useBounceView.tsx
@@ -27,7 +27,11 @@ function useBounceView({
 }) {
   const bounceStartView = startBounceItem
     ? (
-      <view class={RTL ? 'bounce-start-item-RTL' : 'bounce-start-item'}>
+      <view
+        class={RTL
+          ? 'lynx-ui-swiper__bounce-start-rtl'
+          : 'lynx-ui-swiper__bounce-start'}
+      >
         {startBounceItem}
       </view>
     )
@@ -38,7 +42,11 @@ function useBounceView({
 
   const bounceEndView = endBounceItem && shouldShowEndBounce
     ? (
-      <view class={RTL ? 'bounce-end-item-RTL' : 'bounce-end-item'}>
+      <view
+        class={RTL
+          ? 'lynx-ui-swiper__bounce-end-rtl'
+          : 'lynx-ui-swiper__bounce-end'}
+      >
         {endBounceItem}
       </view>
     )

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -5,6 +5,21 @@ module.exports = {
     '**/dist/**',
     '**/node_modules/**',
   ],
+  overrides: [
+    {
+      files: ['packages/lynx-ui-*/src/**/*.css'],
+      rules: {
+        'selector-class-pattern': [
+          '^lynx-ui-[a-z0-9-]+(?:__(?:[a-z0-9]+(?:-[a-z0-9]+)*)(?:--(?:[a-z0-9]+(?:-[a-z0-9]+)*))?)?$',
+          {
+            message:
+              'Component classes must use the `lynx-ui-<package>__<lowercase-kebab-name>` namespace.',
+            resolveNestedSelectors: true,
+          },
+        ],
+      },
+    },
+  ],
   plugins: [
     path.resolve(__dirname, './tools/stylelint/luna-known-css-vars.mjs'),
   ],


### PR DESCRIPTION
Namespace component-owned CSS classes to prevent bundled library styles from overriding application classes with common names.

- updates FeedList, LazyComponent, Popover, and Swiper selectors and runtime references
- enforces package-specific CSS namespaces in style checks
- adds patch changesets for affected packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Namespace component-owned CSS classes across FeedList, LazyComponent, Popover, and Swiper.
- Align RTL variants with the `--rtl` modifier convention.
- Enforce `lynx-ui` CSS namespaces with Stylelint rules.
- Document the component CSS naming standard.
- Mark affected packages for patch releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->