### PR TITLE
fix(build): exclude test artifacts from lynx-ui package outputs

### DIFF
--- a/.changeset/clean-common-test-output.md
+++ b/.changeset/clean-common-test-output.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/lynx-ui-common": patch
+"@lynx-js/lynx-ui-sheet": patch
+---
+
+Exclude test modules from compiled package output.

--- a/packages/lynx-ui-button/tsconfig.json
+++ b/packages/lynx-ui-button/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-checkbox/tsconfig.json
+++ b/packages/lynx-ui-checkbox/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-common/tsconfig.json
+++ b/packages/lynx-ui-common/tsconfig.json
@@ -8,5 +8,7 @@
   ],
   "exclude": [
     "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
   ],
 }

--- a/packages/lynx-ui-dialog/tsconfig.json
+++ b/packages/lynx-ui-dialog/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-draggable/tsconfig.json
+++ b/packages/lynx-ui-draggable/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-feed-list/tsconfig.json
+++ b/packages/lynx-ui-feed-list/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-form/tsconfig.json
+++ b/packages/lynx-ui-form/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-input/tsconfig.json
+++ b/packages/lynx-ui-input/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-lazy-component/tsconfig.json
+++ b/packages/lynx-ui-lazy-component/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-list/tsconfig.json
+++ b/packages/lynx-ui-list/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-overlay/tsconfig.json
+++ b/packages/lynx-ui-overlay/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-popover/tsconfig.json
+++ b/packages/lynx-ui-popover/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-presence/tsconfig.json
+++ b/packages/lynx-ui-presence/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-radio-group/tsconfig.json
+++ b/packages/lynx-ui-radio-group/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-scroll-view/tsconfig.json
+++ b/packages/lynx-ui-scroll-view/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-sheet/tsconfig.json
+++ b/packages/lynx-ui-sheet/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-slider/tsconfig.json
+++ b/packages/lynx-ui-slider/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-sortable/tsconfig.json
+++ b/packages/lynx-ui-sortable/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-swipe-action/tsconfig.json
+++ b/packages/lynx-ui-swipe-action/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-swiper/tsconfig.json
+++ b/packages/lynx-ui-swiper/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui-switch/tsconfig.json
+++ b/packages/lynx-ui-switch/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/packages/lynx-ui/tsconfig.json
+++ b/packages/lynx-ui/tsconfig.json
@@ -6,4 +6,9 @@
   "include": [
     "src",
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
 }

--- a/tools/configs/rslib.base.ts
+++ b/tools/configs/rslib.base.ts
@@ -13,6 +13,11 @@ export const baseConfig: RslibConfig = {
       },
     }),
   ],
+  source: {
+    entry: {
+      index: ['src/**', '!src/**/*.test.*', '!src/**/__tests__/**'],
+    },
+  },
   lib: [
     {
       bundle: false,


### PR DESCRIPTION
## Context

Some lynx-ui packages use Rslib in bundleless mode through a shared base
configuration. In that mode, the build pipeline was effectively scanning
`src/**` as source input, which meant colocated test files could be treated
as build entries unless they were filtered explicitly.

That behavior already showed up in real package outputs: test artifacts were
being emitted from `@lynx-js/lynx-ui-common`, and `@lynx-js/lynx-ui-sheet`
also exposed the same underlying problem.

## Problem

The repository had two different output paths that needed to agree on what
counts as publishable source:

1. Bundleless JS/JSX output controlled by Rslib source entry resolution
2. Declaration output controlled by TypeScript config

Before this change, those two layers were not aligned. As a result:

- compiled `.test.jsx` files could leak into `dist/`
- `.test.d.ts` files could still be generated even after JS entry filtering
- the fix would have to be repeated package-by-package unless moved into the
  shared build layer

## Approach

This PR fixes the issue at the architectural boundary where it originates.

### Shared build filtering

The shared `tools/configs/rslib.base.ts` config now excludes test files and
`__tests__` directories from bundleless source entry resolution. This makes
the default build behavior match the intended publishable source surface for
all packages that inherit the base config.

### Declaration filtering

Package `tsconfig.json` files are aligned with the same exclusion patterns so
TypeScript declaration generation does not emit test declarations.

### Scope of release impact

Although the shared configuration now protects all packages, the observed
published-output change in this PR affects `@lynx-js/lynx-ui-common` and
`@lynx-js/lynx-ui-sheet`, which are the packages included in the changeset.

## Why this shape

The main goal here is not just to remove a few accidental files, but to make
the build contract consistent:

- source entry discovery should ignore tests
- declaration generation should ignore tests
- packages should inherit the same default behavior instead of carrying local
  one-off fixes

That keeps the fix durable as more colocated tests are added over time.

## Validation

- Rebuilt `@lynx-js/lynx-ui-common`
- Rebuilt `@lynx-js/lynx-ui-sheet`
- Verified test artifacts no longer appear in `dist/`
- Ran `pnpm turbo build`
- Ran `NODE_OPTIONS=--max-old-space-size=8192 pnpm check:all`

## Result

Published package outputs no longer include internal test build artifacts, and
the default bundleless build behavior is now consistent across lynx-ui
packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Exclude test files and `__tests__` directories from `lynx-ui` TypeScript builds.
- Exclude test modules from Rslib bundleless build entries and declaration output.
- Add patch changesets for `@lynx-js/lynx-ui-common` and `@lynx-js/lynx-ui-sheet`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->