### PR TITLE
fix(tooling): use npm registry for package bootstrap

### DIFF
--- a/tools/scripts/bootstrap-package.mjs
+++ b/tools/scripts/bootstrap-package.mjs
@@ -250,8 +250,11 @@ function printNextSteps(outDir) {
   const outRelPath = path.relative(repoRoot, outDir)
 
   console.log('Next steps:')
+  console.log('  npm login --registry=https://registry.npmjs.org/')
   console.log(`  cd ${outRelPath}`)
-  console.log('  npm publish --access public --tag oidc-bootstrap')
+  console.log(
+    '  npm publish --access public --tag oidc-bootstrap --registry=https://registry.npmjs.org/',
+  )
   console.log()
   console.log('After publish:')
   console.log(

--- a/tools/scripts/check-new-publishable-packages.mjs
+++ b/tools/scripts/check-new-publishable-packages.mjs
@@ -262,8 +262,11 @@ async function main() {
     }
     console.error(`  Bootstrap with: pnpm bootstrap:package ${pkg.path}`)
     console.error(`  Then publish placeholder:`)
+    console.error(`    npm login --registry=https://registry.npmjs.org/`)
     console.error(`    cd ${outputDir}`)
-    console.error(`    npm publish --access public --tag oidc-bootstrap`)
+    console.error(
+      `    npm publish --access public --tag oidc-bootstrap --registry=https://registry.npmjs.org/`,
+    )
     console.error(`  Then configure Trusted Publisher (OIDC):`)
     console.error(`    ${getNpmAccessUrl(pkg.name)}`)
   }


### PR DESCRIPTION
Prompt maintainers to log in before publishing bootstrap packages. Specify the public npm registry explicitly for both login and publish commands to avoid inherited internal registry configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Require npm login before publishing bootstrap packages.
- Publish bootstrap packages through the public npm registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->