### PR TITLE
feat(scroll-view): enable native bounces on new architecture

### DIFF
--- a/.changeset/native-scroll-view-bounces.md
+++ b/.changeset/native-scroll-view-bounces.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/lynx-ui-scroll-view': minor
+---
+
+Add an `enableNewArch` option that defaults to `true` on Lynx SDK 4.3 and newer, and uses native scroll-view bounces across Android, iOS, and Harmony while preserving custom bounce items, threshold callbacks, stable overscroll alignment, and radius-aware clipping.

--- a/apps/examples/ScrollView/NativeUseBounces/index.css
+++ b/apps/examples/ScrollView/NativeUseBounces/index.css
@@ -1,0 +1,136 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.demo-container {
+  width: 100%;
+  height: 100%;
+  padding: 36px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: var(--canvas);
+}
+
+.header {
+  width: 100%;
+  margin-bottom: 20px;
+}
+
+.title {
+  color: var(--content);
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.description {
+  color: var(--content-subtle);
+  font-size: 14px;
+  margin-top: 6px;
+}
+
+.metrics {
+  width: 100%;
+  margin-top: 14px;
+  padding: 12px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 8px;
+  border-radius: 12px;
+  background-color: var(--paper);
+}
+
+.metric {
+  color: var(--content-subtle);
+  font-size: 12px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  background-color: var(--canvas);
+}
+
+.metric--event {
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.scroll-view {
+  background-color: var(--paper);
+}
+
+.scroll-content {
+  width: 100%;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: linear-gradient(
+    180deg,
+    var(--gradient-a),
+    var(--gradient-b),
+    var(--gradient-c),
+    var(--gradient-d)
+  );
+}
+
+.card {
+  width: 100%;
+  height: 88px;
+  padding: 14px 18px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  border-radius: 16px;
+  background-color: var(--canvas);
+}
+
+.card__index {
+  width: 52px;
+  color: var(--primary);
+  font-size: 32px;
+  font-weight: 700;
+}
+
+.card__copy {
+  display: flex;
+  flex-direction: column;
+}
+
+.card__title {
+  color: var(--content);
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.card__subtitle {
+  color: var(--content-subtle);
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+.bounce-item {
+  width: 100%;
+  height: 96px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.bounce-item--upper {
+  background-color: var(--primary);
+}
+
+.bounce-item--lower {
+  background-color: var(--primary-2);
+}
+
+.bounce-item__label {
+  color: var(--gradient-content);
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.bounce-item__hint {
+  color: var(--gradient-content);
+  font-size: 12px;
+  margin-top: 4px;
+}

--- a/apps/examples/ScrollView/NativeUseBounces/index.tsx
+++ b/apps/examples/ScrollView/NativeUseBounces/index.tsx
@@ -1,0 +1,155 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from '@lynx-js/react'
+
+import { ScrollView } from '@lynx-js/lynx-ui'
+import type { ScrollEvent } from '@lynx-js/types'
+
+import './index.css'
+
+const VIEWPORT_HEIGHT = 420
+const TRIGGER_DISTANCE = 48
+const ITEMS = Array.from({ length: 12 }, (_, index) => index + 1)
+
+interface Metrics {
+  bounceCount: number
+  lastBounce: 'none' | 'upper' | 'lower'
+  maxLowerDistance: number
+  maxUpperDistance: number
+  minScrollTop: number
+  scrollHeight: number
+  scrollTop: number
+}
+
+function BounceItem(props: {
+  direction: 'upper' | 'lower'
+  label: string
+}) {
+  const { direction, label } = props
+  return (
+    <view className={`bounce-item bounce-item--${direction}`}>
+      <text className='bounce-item__label'>{label}</text>
+      <text className='bounce-item__hint'>Threshold: 48px</text>
+    </view>
+  )
+}
+
+function formatMetric(value: number) {
+  return Number.isFinite(value) ? value.toFixed(1) : '--'
+}
+
+function App() {
+  const [metrics, setMetrics] = useState<Metrics>({
+    bounceCount: 0,
+    lastBounce: 'none',
+    maxLowerDistance: 0,
+    maxUpperDistance: 0,
+    minScrollTop: 0,
+    scrollHeight: 0,
+    scrollTop: 0,
+  })
+
+  const handleScroll = (event: ScrollEvent) => {
+    const { scrollHeight, scrollTop } = event.detail
+    const upperDistance = Math.max(0, -scrollTop)
+    const lowerDistance = Math.max(0, scrollTop - scrollHeight)
+
+    setMetrics(previous => ({
+      ...previous,
+      maxLowerDistance: Math.max(
+        previous.maxLowerDistance,
+        lowerDistance,
+      ),
+      maxUpperDistance: Math.max(
+        previous.maxUpperDistance,
+        upperDistance,
+      ),
+      minScrollTop: Math.min(previous.minScrollTop, scrollTop),
+      scrollHeight,
+      scrollTop,
+    }))
+  }
+
+  return (
+    <view className='demo-container lunaris-dark'>
+      <view className='header'>
+        <text className='title'>Native useBounces</text>
+        <text className='description'>
+          Pull beyond both edges and watch bindscroll metrics.
+        </text>
+        <view className='metrics'>
+          <text className='metric'>
+            {`scrollTop: ${formatMetric(metrics.scrollTop)}`}
+          </text>
+          <text className='metric'>
+            {`min scrollTop: ${formatMetric(metrics.minScrollTop)}`}
+          </text>
+          <text className='metric'>
+            {`max upper: ${formatMetric(metrics.maxUpperDistance)}`}
+          </text>
+          <text className='metric'>
+            {`max lower: ${formatMetric(metrics.maxLowerDistance)}`}
+          </text>
+          <text className='metric'>
+            {`scrollHeight: ${formatMetric(metrics.scrollHeight)}`}
+          </text>
+          <text className='metric metric--event'>
+            {`bounce event: ${metrics.lastBounce} (${metrics.bounceCount})`}
+          </text>
+        </view>
+      </view>
+
+      <ScrollView
+        enableNewArch={true}
+        scrollOrientation='vertical'
+        className='scroll-view'
+        style={{
+          width: '100%',
+          height: `${VIEWPORT_HEIGHT}px`,
+          borderRadius: '20px',
+        }}
+        onScroll={handleScroll}
+        bounceableOptions={{
+          enableBounces: true,
+          alwaysBouncing: true,
+          singleSidedBounce: 'both',
+          startBounceTriggerDistance: TRIGGER_DISTANCE,
+          endBounceTriggerDistance: TRIGGER_DISTANCE,
+          upperBounceItem: (
+            <BounceItem direction='upper' label='Native upper bounce' />
+          ),
+          lowerBounceItem: (
+            <BounceItem direction='lower' label='Native lower bounce' />
+          ),
+          onScrollToBounces: ({ direction }) => {
+            setMetrics(previous => ({
+              ...previous,
+              bounceCount: previous.bounceCount + 1,
+              lastBounce: direction,
+            }))
+          },
+        }}
+      >
+        <view className='scroll-content'>
+          {ITEMS.map(item => (
+            <view className='card' key={`native-bounce-card-${item}`}>
+              <text className='card__index'>{`${item}`}</text>
+              <view className='card__copy'>
+                <text className='card__title'>Native ScrollView</text>
+                <text className='card__subtitle'>
+                  scroll-view-new-arch=true
+                </text>
+              </view>
+            </view>
+          ))}
+        </view>
+      </ScrollView>
+    </view>
+  )
+}
+
+root.render(<App />)
+
+export default App

--- a/apps/examples/ScrollView/lynx.config.mjs
+++ b/apps/examples/ScrollView/lynx.config.mjs
@@ -9,6 +9,7 @@ const defaultConfig = exampleConfig({
   ScrollViewBounces: './Bounces/index.tsx',
   ScrollViewBouncesRTL: './BouncesRTL/index.tsx',
   ScrollViewInnerFlex: './InnerFlex/index.tsx',
+  ScrollViewNativeUseBounces: './NativeUseBounces/index.tsx',
   ScrollViewScrollBy: './ScrollBy/index.tsx',
   ScrollViewZIndex: './ZIndex/index.tsx',
 }, { needWeb: false })

--- a/packages/lynx-ui-scroll-view/SKILL.md
+++ b/packages/lynx-ui-scroll-view/SKILL.md
@@ -5,6 +5,7 @@
 ## 1. Core Capabilities
 
 - **Vertical and Horizontal Scrolling**: Supports vertical (`scrollOrientation = 'vertical'`) and horizontal (`scrollOrientation = 'horizontal'`) scrolling.
+- **Native Scroll Architecture**: `enableNewArch` defaults to `true` on Lynx SDK 4.3 and newer and to `false` on earlier versions. The new architecture uses native bounces across Android, iOS, and Harmony; set the prop explicitly to override the SDK-based default.
 - **BounceableOptions**: Supports edge rubber-band and bounce effects, configurable via:
   - `enableBounces`: enable/disable edge bounce
   - `singleSidedBounce`: select bounce side (`'upper' | 'lower' | 'both'`)

--- a/packages/lynx-ui-scroll-view/__tests__/bounceWrapperUtils.test.ts
+++ b/packages/lynx-ui-scroll-view/__tests__/bounceWrapperUtils.test.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, it } from 'vitest'
+
+import { getBounceWrapperStyle } from '../src/bounceWrapperUtils'
+
+describe('bounce wrapper style', () => {
+  it('copies the scroll view radius to the vertical clipping wrapper', () => {
+    expect(getBounceWrapperStyle({
+      width: '100%',
+      height: '420px',
+      borderRadius: '20px',
+      backgroundColor: 'red',
+    }, false)).toMatchObject({
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+      width: '100%',
+      height: '420px',
+      borderRadius: '20px',
+    })
+  })
+
+  it('copies individual radii to the horizontal clipping wrapper', () => {
+    expect(getBounceWrapperStyle({
+      width: '320px',
+      height: '100%',
+      borderStartStartRadius: '12px',
+      borderEndEndRadius: '18px',
+    }, true)).toMatchObject({
+      overflow: 'hidden',
+      width: '320px',
+      height: '100%',
+      borderStartStartRadius: '12px',
+      borderEndEndRadius: '18px',
+    })
+  })
+})

--- a/packages/lynx-ui-scroll-view/__tests__/nativeBounceUtils.test.ts
+++ b/packages/lynx-ui-scroll-view/__tests__/nativeBounceUtils.test.ts
@@ -1,0 +1,46 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, it } from 'vitest'
+
+import { getNativeBounceMetricsMT } from '../src/hooks/nativeBounceUtils'
+
+describe('native bounce metrics', () => {
+  it('keeps the upper bounce distance while the native offset is negative', () => {
+    expect(getNativeBounceMetricsMT(-16.7, 1216, 640, true, true)).toEqual({
+      maxScrollOffset: 576,
+      upperDistance: 16.7,
+      lowerDistance: 0,
+    })
+  })
+
+  it('keeps the lower bounce distance past the maximum scroll offset', () => {
+    expect(getNativeBounceMetricsMT(610, 1216, 640, true, true)).toEqual({
+      maxScrollOffset: 576,
+      upperDistance: 0,
+      lowerDistance: 34,
+    })
+  })
+
+  it('returns no bounce distance inside the scrollable range', () => {
+    expect(getNativeBounceMetricsMT(240, 1216, 640, true, true)).toEqual({
+      maxScrollOffset: 576,
+      upperDistance: 0,
+      lowerDistance: 0,
+    })
+  })
+
+  it('respects disabled bounce directions', () => {
+    expect(getNativeBounceMetricsMT(-20, 1216, 640, false, true)).toEqual({
+      maxScrollOffset: 576,
+      upperDistance: 0,
+      lowerDistance: 0,
+    })
+    expect(getNativeBounceMetricsMT(600, 1216, 640, true, false)).toEqual({
+      maxScrollOffset: 576,
+      upperDistance: 0,
+      lowerDistance: 0,
+    })
+  })
+})

--- a/packages/lynx-ui-scroll-view/docs/APIReference.mdx
+++ b/packages/lynx-ui-scroll-view/docs/APIReference.mdx
@@ -144,6 +144,92 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "docTypeFallback": null
   },
   {
+    "name": "enableNewArch",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Enable the native "
+      },
+      {
+        "kind": "code",
+        "text": "`<scroll-view>`"
+      },
+      {
+        "kind": "text",
+        "text": " new architecture. When enabled, "
+      },
+      {
+        "kind": "code",
+        "text": "`bounceableOptions`"
+      },
+      {
+        "kind": "text",
+        "text": " uses native bounces on Android, iOS, and Harmony. Defaults to "
+      },
+      {
+        "kind": "code",
+        "text": "`true`"
+      },
+      {
+        "kind": "text",
+        "text": " on Lynx SDK 4.3 and newer, and "
+      },
+      {
+        "kind": "code",
+        "text": "`false`"
+      },
+      {
+        "kind": "text",
+        "text": " on earlier versions."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "启用原生 "
+      },
+      {
+        "kind": "code",
+        "text": "`<scroll-view>`"
+      },
+      {
+        "kind": "text",
+        "text": " 新架构。启用后，"
+      },
+      {
+        "kind": "code",
+        "text": "`bounceableOptions`"
+      },
+      {
+        "kind": "text",
+        "text": " 会在 Android、iOS 和 Harmony 上使用原生回弹。Lynx SDK 4.3 及以上版本默认为 "
+      },
+      {
+        "kind": "code",
+        "text": "`true`"
+      },
+      {
+        "kind": "text",
+        "text": "，更早版本默认为 "
+      },
+      {
+        "kind": "code",
+        "text": "`false`"
+      },
+      {
+        "kind": "text",
+        "text": "。"
+      }
+    ],
+    "defaultValue": "true on Lynx SDK >= 4.3; false otherwise",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
     "name": "enableRTL",
     "type": "boolean",
     "summary": [
@@ -846,7 +932,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "docTypeFallback": null
   }
 ]}/>
-      
+
 ### Events
 <UIApiTable source={[
   {
@@ -1224,7 +1310,6 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "docTypeFallback": null
   }
 ]}/>
-      
 
 ### BounceableBasicProps
 
@@ -1601,7 +1686,3 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "docTypeFallback": null
   }
 ]}/>
-    
-      
-
-  

--- a/packages/lynx-ui-scroll-view/docs/README.mdx
+++ b/packages/lynx-ui-scroll-view/docs/README.mdx
@@ -11,7 +11,7 @@ import { lynxUiIntros } from '../../lynx-ui-intros';
 
 - Lazy-loading optimized container powered by LazyComponent, designed to reduce first-screen rendering time
 
-- Built-in platform-consistent bounces behavior (iOS/Android alignment)
+- Native bounces across Android, iOS, and Harmony with the new scroll-view architecture
 
 :::info
 

--- a/packages/lynx-ui-scroll-view/docs/README.zh.mdx
+++ b/packages/lynx-ui-scroll-view/docs/README.zh.mdx
@@ -10,7 +10,7 @@ import { lynxUiIntrosZh } from '../../lynx-ui-intros';
 {lynxUiIntrosZh['lynx-ui-scroll-view']}
 
 - 利用 [`LazyComponent`](/lynx-ui/components/lazy-component.html)内置懒加载能力的滚动容器，用于优化首屏耗时；
-- 内置双端对齐的 bounces 能力。
+- 新版 scroll-view 架构在 Android、iOS 和 Harmony 上提供原生 bounces 能力。
 
 :::info
 

--- a/packages/lynx-ui-scroll-view/docs/useBounce.mdx
+++ b/packages/lynx-ui-scroll-view/docs/useBounce.mdx
@@ -41,7 +41,9 @@ First, let's treat this hook as a black box that receives component settings and
 
 ### Scroll Simulation
 
-We use `MTS` and `transform` to simulate bounce effects:
+With `enableNewArch`, `ScrollView` uses native bounces on Android, iOS, and Harmony while retaining custom bounce items and `onScrollToBounces` threshold callbacks.
+
+On the legacy architecture, non-`iOSBounces` modes use `MTS` and `transform` to simulate bounce effects:
 
 1. Locate nodes via `lynx.querySelector`:
 
@@ -60,6 +62,10 @@ useBounces divides scrolling into three phases:
 3. Bounce-back effect
 
 ### Using `bounceableOptions`
+
+#### `enableNewArch`
+
+`ScrollView` enables the native `<scroll-view>` new architecture by default on Lynx SDK 4.3 and newer, and keeps the legacy architecture on earlier versions. Set `enableNewArch` explicitly to override this version-based default.
 
 #### `onScrollToBounces` with distance thresholds
 

--- a/packages/lynx-ui-scroll-view/docs/useBounce.zh.mdx
+++ b/packages/lynx-ui-scroll-view/docs/useBounce.zh.mdx
@@ -28,7 +28,9 @@ import { Go } from '@lynx-ui/index';
 
 ## 如何形成滚动
 
-我们在这里使用了 `MTS` 调用 `transform` 来模拟弹性效果。
+启用 `enableNewArch` 后，`ScrollView` 会在 Android、iOS 和 Harmony 上使用原生回弹，同时保留自定义回弹内容和 `onScrollToBounces` 阈值回调。
+
+在旧架构中，非 `iOSBounces` 模式使用 `MTS` 调用 `transform` 来模拟弹性效果。
 
 1. 使用 `id`，通过 `lynx.querySelector` 找到节点。
 
@@ -45,6 +47,10 @@ useBounces 将滚动曲线分为了三段：
 3. 回弹效果
 
 ## bounceableOptions 的各属性如何使用？
+
+### `enableNewArch`
+
+Lynx SDK 4.3 及以上版本中，`ScrollView` 默认启用原生 `<scroll-view>` 新架构；更早的版本默认保留旧架构。可以显式设置 `enableNewArch`，覆盖这一基于 SDK 版本的默认行为。
 
 ### `onScrollToBounces` 事件和 `startBounceTriggerDistance`/`endBounceTriggerDistance`
 

--- a/packages/lynx-ui-scroll-view/src/ScrollViewWithBouncesHook.tsx
+++ b/packages/lynx-ui-scroll-view/src/ScrollViewWithBouncesHook.tsx
@@ -10,7 +10,9 @@ import type {
   ScrollViewProps as ScrollViewElementProps,
 } from '@lynx-js/types'
 
+import { getBounceWrapperStyle } from './bounceWrapperUtils'
 import { useBounce } from './hooks/useBounce'
+import { useNativeBounce } from './hooks/useNativeBounce'
 import type {
   BounceableBasicProps,
   ScrollViewProps,
@@ -26,6 +28,7 @@ function ScrollViewWithBouncesHook(
     bounceableOptions?: BounceableBasicProps
     debugLog?: boolean
     enableRTL?: boolean
+    nativeBounces?: boolean
     sticky?: ReactElement
   },
   _ref: ForwardedRef<ScrollViewRef>,
@@ -37,6 +40,7 @@ function ScrollViewWithBouncesHook(
     elementProps,
     debugLog = false,
     enableRTL = false,
+    nativeBounces = false,
   } = props
   // @ts-expect-error Compatible with older versions
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -45,6 +49,7 @@ function ScrollViewWithBouncesHook(
     ?? elementProps['scroll-y'] === false
   const scrollViewId = elementProps.id
   const { style } = elementProps as { style: CSSProperties }
+  const bounceWrapperStyle = getBounceWrapperStyle(style, Boolean(horizontal))
   // Initialize bounceableProps
   let enableBounce = false
   let bounceableProps: BounceableBasicProps = { enableBounces: false }
@@ -73,6 +78,16 @@ function ScrollViewWithBouncesHook(
     id: scrollViewId,
     scrollOrientation: horizontal ? 'horizontal' : 'vertical',
   })
+  const nativeBounceMTSProps = useNativeBounce({
+    bounceableOptions: bounceableProps,
+    debugLog,
+    enableRTL,
+    id: scrollViewId,
+    scrollOrientation: horizontal ? 'horizontal' : 'vertical',
+  })
+  const activeBounceMTSProps = nativeBounces
+    ? nativeBounceMTSProps
+    : bounceMTSProps
   if (enableBounce) {
     if (bounceableProps.upperBounceItem) {
       startBounceView = (
@@ -108,7 +123,7 @@ function ScrollViewWithBouncesHook(
         </view>
       )
     }
-    upperExposureView = (
+    upperExposureView = !nativeBounces && (
       <view
         style={`display: flex; flex-direction: column; overflow:hidden; height: ${
           horizontal ? '100%' : '1ppx'
@@ -121,7 +136,7 @@ function ScrollViewWithBouncesHook(
         main-thread:gesture={elementProps['main-thread:gesture']}
       />
     )
-    lowerExposureView = (
+    lowerExposureView = !nativeBounces && (
       <view
         style={`display: flex; flex-direction: column; overflow:hidden; height: ${
           horizontal ? '100%' : '1ppx'
@@ -139,15 +154,14 @@ function ScrollViewWithBouncesHook(
   return (
     <view
       id={`${scrollViewId}-BounceWrapper`}
-      style={`display: flex; flex-direction: column; overflow:hidden; height: ${
-        horizontal ? '100%' : `${style?.height}`
-      }; width: ${horizontal ? `${style?.width}` : '100%'};`}
+      flatten={false}
+      style={bounceWrapperStyle}
       main-thread:gesture={elementProps['main-thread:gesture']}
     >
       <scroll-view
         {...elementProps}
-        {...bounceMTSProps}
-        bounces={false}
+        {...activeBounceMTSProps}
+        bounces={nativeBounces}
         ios-enable-simultaneous-touch={true}
         // This is a workaround for using RL3.0-ver 0.110.1 and SDK-ver <=3.4. It will force the scroll-view to update after the BTS is ready and flush the 'name' prop along with __AddEvents. Otherwise, a pure __AddEvents will be discarded by the engine and won't trigger the flush of the prop_bundle. As a result, all events will be lost.
         // We do not use __MAIN_THREAD__ here to maintain compatibility with the old version of @lynx-js/react.

--- a/packages/lynx-ui-scroll-view/src/bounceWrapperUtils.ts
+++ b/packages/lynx-ui-scroll-view/src/bounceWrapperUtils.ts
@@ -1,0 +1,27 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { CSSProperties } from '@lynx-js/types'
+
+export function getBounceWrapperStyle(
+  style: CSSProperties | undefined,
+  horizontal: boolean,
+): CSSProperties {
+  return {
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    height: horizontal ? '100%' : style?.height,
+    width: horizontal ? style?.width : '100%',
+    borderRadius: style?.borderRadius,
+    borderTopLeftRadius: style?.borderTopLeftRadius,
+    borderTopRightRadius: style?.borderTopRightRadius,
+    borderBottomLeftRadius: style?.borderBottomLeftRadius,
+    borderBottomRightRadius: style?.borderBottomRightRadius,
+    borderStartStartRadius: style?.borderStartStartRadius,
+    borderStartEndRadius: style?.borderStartEndRadius,
+    borderEndStartRadius: style?.borderEndStartRadius,
+    borderEndEndRadius: style?.borderEndEndRadius,
+  }
+}

--- a/packages/lynx-ui-scroll-view/src/hooks/nativeBounceUtils.ts
+++ b/packages/lynx-ui-scroll-view/src/hooks/nativeBounceUtils.ts
@@ -1,0 +1,28 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Older ReactLynx versions incorrectly tree-shake files that only contain
+// main thread functions, so this file must also contain a BTS function.
+export function nativeBounceUtilsDummyBTS(): void {
+  // Intentionally empty
+}
+
+export function getNativeBounceMetricsMT(
+  offset: number,
+  scrollSize: number,
+  viewportSize: number,
+  enableUpper: boolean,
+  enableLower: boolean,
+) {
+  'main thread'
+  const maxScrollOffset = Math.max(0, scrollSize - viewportSize)
+
+  return {
+    maxScrollOffset,
+    upperDistance: enableUpper ? Math.max(0, -offset) : 0,
+    lowerDistance: enableLower
+      ? Math.max(0, offset - maxScrollOffset)
+      : 0,
+  }
+}

--- a/packages/lynx-ui-scroll-view/src/hooks/useNativeBounce.tsx
+++ b/packages/lynx-ui-scroll-view/src/hooks/useNativeBounce.tsx
@@ -1,0 +1,192 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { runOnBackground, useMainThreadRef } from '@lynx-js/react'
+
+import { mtsLog, selectorMT } from '@lynx-js/lynx-ui-common'
+import type { CommonEvent, ScrollEvent } from '@lynx-js/types'
+
+import type { BounceableBasicProps, scrollToBouncesInfo } from '../types'
+import { getNativeBounceMetricsMT } from './nativeBounceUtils'
+
+interface UseNativeBounceOptions {
+  bounceableOptions: BounceableBasicProps
+  debugLog?: boolean
+  enableRTL?: boolean
+  id?: string
+  scrollOrientation: 'vertical' | 'horizontal'
+}
+
+interface NativeBounceHandlers {
+  'main-thread:bindlayoutchange': (event: CommonEvent) => void
+  'main-thread:bindscroll': (event: ScrollEvent) => void
+  'main-thread:bindscrollend': (event: ScrollEvent) => void
+}
+
+export function useNativeBounce(
+  options: UseNativeBounceOptions,
+): NativeBounceHandlers {
+  const containerID = options.id ?? 'bounceableContainer'
+  const isVertical = options.scrollOrientation === 'vertical'
+  const enableRTL = options.enableRTL ?? false
+  const debugLogEnabled = Boolean(options.debugLog)
+  const height = useMainThreadRef(
+    options.bounceableOptions.estimatedHeight ?? 0,
+  )
+  const width = useMainThreadRef(
+    options.bounceableOptions.estimatedWidth ?? 0,
+  )
+  const maxUpperDistance = useMainThreadRef(0)
+  const maxLowerDistance = useMainThreadRef(0)
+  const lastBounceDirection = useMainThreadRef<'upper' | 'lower' | null>(null)
+
+  const singleSidedBounce = options.bounceableOptions.singleSidedBounce
+    ?? 'both'
+  const enableUpper = singleSidedBounce === 'upper'
+    || singleSidedBounce === 'both'
+    || singleSidedBounce === 'iOSBounces'
+  const enableLower = singleSidedBounce === 'lower'
+    || singleSidedBounce === 'both'
+    || singleSidedBounce === 'iOSBounces'
+
+  function setBounceViewOffset(upperDistance: number, lowerDistance: number) {
+    'main thread'
+    if (isVertical) {
+      selectorMT(`${containerID}-upperBounceWrapper`)?.setStyleProperty(
+        'transform',
+        `translateY(${upperDistance}px)`,
+      )
+      selectorMT(`${containerID}-lowerBounceWrapper`)?.setStyleProperty(
+        'transform',
+        `translateY(${-lowerDistance}px)`,
+      )
+    } else {
+      const direction = enableRTL ? -1 : 1
+      selectorMT(`${containerID}-upperBounceWrapper`)?.setStyleProperty(
+        'transform',
+        `translateX(${direction * upperDistance}px)`,
+      )
+      selectorMT(`${containerID}-lowerBounceWrapper`)?.setStyleProperty(
+        'transform',
+        `translateX(${-direction * lowerDistance}px)`,
+      )
+    }
+  }
+
+  function onScrollToBouncesJS(info: scrollToBouncesInfo) {
+    options.bounceableOptions.onScrollToBounces?.(info)
+  }
+
+  function nativeBounceLayoutChange(event: CommonEvent) {
+    'main thread'
+    const isAndroid = SystemInfo.platform === 'Android'
+    // @ts-expect-error Expected
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    height.current = (isAndroid ? event.params?.height : event.detail?.height)
+      ?? 0
+    // @ts-expect-error Expected
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    width.current = (isAndroid ? event.params?.width : event.detail?.width) ?? 0
+
+    mtsLog(
+      debugLogEnabled,
+      `[lynx-ui-scroll-view][useNativeBounce] layout change, height: ${height.current}, width: ${width.current}`,
+    )
+  }
+
+  function nativeBounceScroll(event: ScrollEvent) {
+    'main thread'
+    const offset = isVertical
+      ? event.detail.scrollTop
+      : event.detail.scrollLeft
+    const scrollSize = isVertical
+      ? event.detail.scrollHeight
+      : event.detail.scrollWidth
+    const viewportSize = isVertical ? height.current : width.current
+    const {
+      maxScrollOffset,
+      upperDistance,
+      lowerDistance,
+    } = getNativeBounceMetricsMT(
+      offset,
+      scrollSize,
+      viewportSize,
+      enableUpper,
+      enableLower,
+    )
+
+    mtsLog(
+      debugLogEnabled,
+      `[lynx-ui-scroll-view][useNativeBounce] scroll, offset: ${offset}, scrollSize: ${scrollSize}, viewportSize: ${viewportSize}, maxScrollOffset: ${maxScrollOffset}, upperDistance: ${upperDistance}, lowerDistance: ${lowerDistance}`,
+    )
+
+    setBounceViewOffset(upperDistance, lowerDistance)
+
+    if (upperDistance > 0) {
+      maxUpperDistance.current = Math.max(
+        maxUpperDistance.current,
+        upperDistance,
+      )
+      lastBounceDirection.current = 'upper'
+    } else if (lowerDistance > 0) {
+      maxLowerDistance.current = Math.max(
+        maxLowerDistance.current,
+        lowerDistance,
+      )
+      lastBounceDirection.current = 'lower'
+    }
+  }
+
+  function nativeBounceScrollEnd(event: ScrollEvent) {
+    'main thread'
+    const offset = isVertical
+      ? event.detail.scrollTop
+      : event.detail.scrollLeft
+    const scrollSize = isVertical
+      ? event.detail.scrollHeight
+      : event.detail.scrollWidth
+    const viewportSize = isVertical ? height.current : width.current
+    const { upperDistance, lowerDistance } = getNativeBounceMetricsMT(
+      offset,
+      scrollSize,
+      viewportSize,
+      enableUpper,
+      enableLower,
+    )
+
+    setBounceViewOffset(upperDistance, lowerDistance)
+
+    const direction = lastBounceDirection.current
+    const triggerDistance = direction === 'upper'
+      ? (options.bounceableOptions.startBounceTriggerDistance ?? 0)
+      : (options.bounceableOptions.endBounceTriggerDistance ?? 0)
+    const maxDistance = direction === 'upper'
+      ? maxUpperDistance.current
+      : maxLowerDistance.current
+
+    mtsLog(
+      debugLogEnabled,
+      `[lynx-ui-scroll-view][useNativeBounce] scroll end, offset: ${offset}, upperDistance: ${upperDistance}, lowerDistance: ${lowerDistance}, direction: ${
+        String(direction)
+      }, maxUpperDistance: ${maxUpperDistance.current}, maxLowerDistance: ${maxLowerDistance.current}, triggerDistance: ${triggerDistance}`,
+    )
+
+    if (
+      direction !== null
+      && maxDistance > triggerDistance
+    ) {
+      runOnBackground(onScrollToBouncesJS)({ direction })
+    }
+
+    maxUpperDistance.current = 0
+    maxLowerDistance.current = 0
+    lastBounceDirection.current = null
+  }
+
+  return {
+    'main-thread:bindlayoutchange': nativeBounceLayoutChange,
+    'main-thread:bindscroll': nativeBounceScroll,
+    'main-thread:bindscrollend': nativeBounceScrollEnd,
+  }
+}

--- a/packages/lynx-ui-scroll-view/src/index.tsx
+++ b/packages/lynx-ui-scroll-view/src/index.tsx
@@ -13,6 +13,7 @@ import {
   LayoutEventsMapping,
   ScrollEventsMapping,
   TouchEventsMapping,
+  nativeLynxSDKVersionLessThan,
   useRegisteredEvents,
 } from '@lynx-js/lynx-ui-common'
 import { LazyComponent } from '@lynx-js/lynx-ui-lazy-component'
@@ -83,6 +84,7 @@ function ScrollViewImpl(
     },
     enableScroll = true,
     enableScrollMonitor = false,
+    enableNewArch: enableNewArchProp,
     scrollMonitorTag,
     sticky,
     scrollPropagationBehavior = 'native',
@@ -94,6 +96,8 @@ function ScrollViewImpl(
     androidTouchSlop,
     'main-thread:gesture': gesture,
   } = props
+  const enableNewArch = enableNewArchProp
+    ?? !nativeLynxSDKVersionLessThan('4.3')
   // generates binding events dynamically
   const scrollViewRegisteredEvents = useRef<Record<string, string>>({
     ...ScrollEventsMapping,
@@ -139,9 +143,12 @@ function ScrollViewImpl(
     bounceableProps.validAnimationVersion =
       bounceableOptions.validAnimationVersion ?? true
   }
-  // Only when the enableBounces is true and singleSidedBounce is set to 'iOSBounces' will it use default bounces effect on iOS.
-  const platformBounces = enableBounce
-    && bounceableProps?.singleSidedBounce === 'iOSBounces'
+  // The new architecture provides native bounces on every platform. On the
+  // legacy architecture, native bounces are only used for iOSBounces.
+  const nativeBounces = enableBounce
+    && (enableNewArch
+      ? bounceableProps.singleSidedBounce !== 'none'
+      : bounceableProps.singleSidedBounce === 'iOSBounces')
 
   const shouldEnableNested = () => {
     if (
@@ -185,6 +192,8 @@ function ScrollViewImpl(
   type ExtendedScrollViewElementProps = ScrollViewElementProps & {
     'scroll-x': boolean
     'scroll-y': boolean
+    'scroll-orientation'?: 'horizontal' | 'vertical'
+    'scroll-view-new-arch'?: boolean
   }
   const elementProps: ExtendedScrollViewElementProps & {
     'enable-scroll-monitor': boolean
@@ -208,6 +217,10 @@ function ScrollViewImpl(
     'id': scrollviewId,
     'scroll-x': isHorizontal(),
     'scroll-y': !isHorizontal(),
+    ...(enableNewArch && {
+      'scroll-orientation': isHorizontal() ? 'horizontal' : 'vertical',
+      'scroll-view-new-arch': true,
+    }),
     'enable-scroll-monitor': enableScrollMonitor,
     'scroll-monitor-tag': scrollMonitorTag,
     'main-thread:gesture': gesture,
@@ -224,7 +237,7 @@ function ScrollViewImpl(
     'enable-new-nested': true,
     'className': className,
     'style': normalizedStyle,
-    'bounces': platformBounces,
+    'bounces': nativeBounces,
     'enable-scroll': enableScroll,
     ...(androidTouchSlop !== undefined
       && { 'android-touch-slop': androidTouchSlop }),
@@ -237,7 +250,32 @@ function ScrollViewImpl(
     ...registerEvents,
   }
 
-  if (
+  if (enableNewArch) {
+    if (
+      nativeBounces
+      && (bounceableProps.upperBounceItem
+        || bounceableProps.lowerBounceItem
+        || bounceableProps.onScrollToBounces)
+    ) {
+      return (
+        <ScrollViewWithBouncesHook
+          elementProps={elementProps}
+          bounceableOptions={bounceableProps}
+          debugLog={debugLog}
+          enableRTL={enableRTL}
+          nativeBounces={true}
+          sticky={sticky}
+        >
+          {renderChildren(children, normalizedLazyOptions)}
+        </ScrollViewWithBouncesHook>
+      )
+    }
+    return (
+      <ScrollViewBasic elementProps={elementProps} sticky={sticky}>
+        {renderChildren(children, normalizedLazyOptions)}
+      </ScrollViewBasic>
+    )
+  } else if (
     enableBounce
     && bounceableProps.singleSidedBounce !== 'iOSBounces'
     && bounceableProps.singleSidedBounce !== 'none'

--- a/packages/lynx-ui-scroll-view/src/types/index.docs.ts
+++ b/packages/lynx-ui-scroll-view/src/types/index.docs.ts
@@ -179,6 +179,15 @@ export interface ScrollViewProps
    */
   enableScrollMonitor?: boolean
   /**
+   * Enable the native `<scroll-view>` new architecture. When enabled, `bounceableOptions` uses native bounces on Android, iOS, and Harmony. Defaults to `true` on Lynx SDK 4.3 and newer, and `false` on earlier versions.
+   * @zh 启用原生 `<scroll-view>` 新架构。启用后，`bounceableOptions` 会在 Android、iOS 和 Harmony 上使用原生回弹。Lynx SDK 4.3 及以上版本默认为 `true`，更早版本默认为 `false`。
+   * @defaultValue `true on Lynx SDK >= 4.3; false otherwise`
+   * @Android
+   * @iOS
+   * @Harmony
+   */
+  enableNewArch?: boolean
+  /**
    * The tag for scroll monitor.
    * @zh 滚动监控的标签。
    * @defaultValue false

--- a/packages/lynx-ui-scroll-view/vitest.config.ts
+++ b/packages/lynx-ui-scroll-view/vitest.config.ts
@@ -1,0 +1,13 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from 'vitest/config'
+
+const config = defineConfig({
+  test: {
+    name: 'lynx-ui-scroll-view',
+  },
+})
+
+export default config


### PR DESCRIPTION
## Summary

- Default ScrollView to the new architecture on Lynx SDK 4.3 and later.
- Use native bounces on Android, iOS, and HarmonyOS when the new architecture is active.
- Preserve custom upper/lower bounce items and threshold callbacks in the native bounce path.
- Add a runnable `NativeUseBounces` example and a changeset.

## Why

The new-architecture `scroll-view` provides native bounce behavior on all three platforms. The previous compatibility path either used simulated MTS bounce behavior or only enabled native bounce on iOS, and it did not keep `bounceableOptions` items and callbacks working in the native path.

## Implementation

- An explicit `enableNewArch` prop takes precedence; otherwise Lynx SDK 4.3+ defaults it to `true`.
- Lower overscroll is calculated from content size minus viewport size.
- Native scroll distances drive the upper/lower bounce item transforms, and threshold callbacks are reported on scroll end.

## Validation

- `pnpm turbo build` (56/56 tasks)
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm check:all`
- `pnpm check:exports`
- `pnpm check:luna-vars`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Enable native `ScrollView` bounce behavior across Android, iOS, and HarmonyOS for the new architecture.
- Default `enableNewArch` to `true` on Lynx SDK 4.3 and later.
- Preserve custom bounce items, threshold callbacks, overscroll alignment, and radius-aware clipping.
- Implement native bounce metrics and scroll handlers with Vitest coverage.
- Add the runnable `NativeUseBounces` example and changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->