### PR TITLE
fix(examples): refine Sortable scroll boundary examples

### DIFF
--- a/.changeset/tidy-sortables-scroll.md
+++ b/.changeset/tidy-sortables-scroll.md
@@ -1,0 +1,6 @@
+---
+"@lynx-example/lynx-ui-sortable": patch
+---
+
+Refine the scroll boundary and disabled item examples with semantic LUNA
+styling, safe-area spacing, and clearer behavior guidance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,9 @@ Examples should prefer importing public APIs from `@lynx-js/lynx-ui` instead of 
 
 When adding a new example under `apps/examples/<Component>/<UseCase>/`, ALWAYS register it in that component's sibling `lynx.config.mjs`. If the entry is missing, the example will not appear in the example app.
 
+When adding examples for an existing component, follow that component's established example patterns; for a new component, use examples from components with similar behavior and layouts as references.
+
+
 ### 3.1 Example Theming With LUNA
 
 Examples should use the in-repo LUNA theme foundation by default instead of ad-hoc hard-coded colors.
@@ -90,9 +93,9 @@ Examples should use the in-repo LUNA theme foundation by default instead of ad-h
 - Prefer semantic LUNA tokens over literal color values.
 - When you need the exact token names or meanings, look them up in the in-repo `luna/` workspace and the imported LUNA styles source used by the example.
 - Use token semantics rather than visual guesses. Choose surface, content, accent, backdrop, divider, or gradient roles based on purpose, then resolve the exact token from the source of truth in `luna/`.
-- Put styles and local CSS variables shared by multiple examples for one component in `apps/examples/<Component>/shared/base.css`, then import that base stylesheet from each example stylesheet.
+- Put styles and local CSS variables shared by multiple examples under `apps/examples/<Component>/shared/`, using `base.css` for broadly reused foundations and purpose-specific filenames for subsets; each shared stylesheet must import `@lynx-js/luna-styles/index.css` directly.
 - Define repeated literal colors once as semantically named local CSS variables, such as `--negative`, instead of duplicating the literal across example styles. Register shared files that declare non-LUNA variables in `extraTokenFiles` in `stylelint.config.cjs`.
-- Give scrollable example content enough top padding to clear device safe areas such as the iPhone Dynamic Island.
+- Give every example page root enough top padding to keep its first visible content clear of device safe-area overlays such as the iPhone Dynamic Island, whether or not the example itself scrolls.
 - After adding or editing demo CSS, run `pnpm check:luna-vars` from `lynx-ui-open-source` to verify every referenced CSS variable is known.
 - Fix every `check:luna-vars` violation before handing off or submitting the demo change.
 - When an example needs RTL support, set `direction: rtl` on the outer container and let descendants inherit it through CSS instead of duplicating directional styles on every node.

--- a/apps/examples/Sortable/DisableItems/index.css
+++ b/apps/examples/Sortable/DisableItems/index.css
@@ -1,141 +1,87 @@
+@import "@lynx-js/luna-styles/index.css";
+
 @import "../shared/base.css";
 @import "../shared/palette.css";
+@import "../shared/scroll-boundary.css";
 
 .demo-container {
-  width: 100%;
-  height: 100%;
   display: flex;
   flex-direction: column;
-  padding: 24px 16px;
+  row-gap: 12px;
+  width: 100%;
+  height: 100%;
+  padding: 64px 16px 24px;
   z-index: 0;
-}
-
-.outside-panel {
-  width: 100%;
-  height: 112px;
-  flex-shrink: 0;
-  border-radius: 16px;
-  padding: 18px 20px;
-  background-color: rgba(255, 255, 255, 0.12);
-}
-
-.outside-panel--top {
-  margin-bottom: 12px;
-}
-
-.outside-panel--bottom {
-  margin-top: 12px;
-}
-
-.outside-panel-title {
-  font-size: 20px;
-  font-weight: 700;
-  color: #ffffff;
-}
-
-.outside-panel-copy {
-  margin-top: 8px;
-  font-size: 13px;
-  line-height: 18px;
-  color: rgba(255, 255, 255, 0.72);
-}
-
-.scroll-by-actions {
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  margin-bottom: 12px;
-}
-
-.scroll-by-button {
-  flex: 1;
-  height: 40px;
-  border-radius: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: rgba(255, 255, 255, 0.16);
-}
-
-.scroll-by-button--primary {
-  background-color: #ffffff;
-}
-
-.scroll-by-button-text {
-  font-size: 14px;
-  font-weight: 700;
-  color: #ffffff;
-}
-
-.scroll-by-button--primary .scroll-by-button-text {
-  color: #1f2937;
+  background-color: var(--canvas);
 }
 
 .short-scroll-view {
+  flex: 1;
   width: 100%;
-  height: 360px;
-  flex-shrink: 0;
-  border-radius: 18px;
+  min-height: 0;
+  border-radius: 16px;
   border-width: 1px;
-  border-color: rgba(255, 255, 255, 0.22);
-  background-color: rgba(0, 0, 0, 0.16);
+  border-color: var(--line);
   z-index: 0;
+}
+.sortable-root {
+  background-color: var(--canvas-ambient);
 }
 
 .short-sortable-root {
   justify-content: flex-start;
-  min-height: 100%;
-  padding: 16px 12px;
   height: max-content;
+  min-height: 100%;
+  padding: 24px 40px 32px;
 }
 
 .sortable-item {
   display: flex;
   flex-direction: column;
-  height: 92px;
-  padding-bottom: 10px;
   flex-shrink: 0;
+  height: 100px;
+  padding-bottom: 12px;
   background-color: transparent;
 }
 
 .sortable-item-surface {
   display: flex;
   flex-direction: row;
-  justify-content: end;
   align-items: center;
+  justify-content: end;
   width: 100%;
-  height: 82px;
-  border-radius: 14px;
+  height: 88px;
+  border-radius: 16px;
   overflow: hidden;
 }
 
 .sortable-item-surface--locked {
   opacity: 0.55;
   border-width: 1px;
-  border-color: rgba(255, 255, 255, 0.45);
+  border-color: var(--line);
 }
 
 .sortable-item-content {
   display: flex;
   flex: 1;
   flex-direction: column;
+  row-gap: 4px;
   justify-content: center;
-  padding-left: 18px;
+  padding-left: 20px;
 }
 
 .sortable-item-title {
-  font-size: 17px;
+  font-size: 18px;
   font-weight: 700;
 }
 
 .sortable-item-subtitle {
-  margin-top: 5px;
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.72);
+  font-size: 13px;
+  font-weight: 500;
 }
 
 .sortable-item-area {
-  width: 76px;
+  width: 88px;
 }
 
 .sortable-item-area--locked {
@@ -143,9 +89,13 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.28);
+  background-color: var(--backdrop);
 }
 
 .drag-here-text--locked {
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--content);
+}
+
+.drag-here-text {
+  font-size: 10px;
 }

--- a/apps/examples/Sortable/DisableItems/index.tsx
+++ b/apps/examples/Sortable/DisableItems/index.tsx
@@ -6,7 +6,12 @@ import { root, useCallback, useMemo, useState } from '@lynx-js/react'
 
 import './index.css'
 
-import { SortableItem, SortableItemArea, SortableRoot } from '@lynx-js/lynx-ui'
+import {
+  Button,
+  SortableItem,
+  SortableItemArea,
+  SortableRoot,
+} from '@lynx-js/lynx-ui'
 import type { SortableData } from '@lynx-js/lynx-ui'
 
 import type { SortableDemoItem } from '../shared/data'
@@ -61,10 +66,12 @@ export function App() {
               <text className={`sortable-item-title drag-here-text--${tone}`}>
                 {`Row ${numericId + 1}`}
               </text>
-              <text className='sortable-item-subtitle'>
+              <text
+                className={`sortable-item-subtitle sortable-item-subtitle--${tone}`}
+              >
                 {isLocked
-                  ? 'Locked · cannot be dragged or displaced'
-                  : 'Drag handle on the right to reorder'}
+                  ? 'Locked in this position'
+                  : 'Drag to reorder around locked rows'}
               </text>
             </view>
             {isLocked
@@ -78,7 +85,7 @@ export function App() {
               : (
                 <SortableItemArea className='sortable-item-area'>
                   <text className={`drag-here-text drag-here-text--${tone}`}>
-                    Drag
+                    Drag Here
                   </text>
                 </SortableItemArea>
               )}
@@ -100,28 +107,32 @@ export function App() {
   }, [])
 
   return (
-    <view className='demo-container lunaris-dark luna-gradient-berry'>
-      <view className='outside-panel outside-panel--top'>
-        <text className='outside-panel-title'>Locked rows demo</text>
-        <text className='outside-panel-copy'>
-          Rows 1, 6, 8 and 12 are locked. They never move and are never
-          displaced, but other rows can freely cross over them while sorting.
+    <view className='demo-container lunaris-light'>
+      <view className='scroll-boundary-info'>
+        <text className='scroll-boundary-info-title'>Locked Items</text>
+        <text className='scroll-boundary-info-description'>
+          Rows 1, 6, 8, 11, and 12 stay fixed while unlocked rows move around
+          them.
         </text>
       </view>
 
-      <view className='scroll-by-actions'>
-        <view
-          className='scroll-by-button'
-          main-thread:bindtap={handleScrollUpTap}
+      <view className='scroll-controls'>
+        <Button
+          className='scroll-control-button'
+          buttonProps={{
+            'main-thread:bindtap': handleScrollUpTap,
+          }}
         >
-          <text className='scroll-by-button-text'>Scroll Up</text>
-        </view>
-        <view
-          className='scroll-by-button scroll-by-button--primary'
-          main-thread:bindtap={handleScrollDownTap}
+          <text className='scroll-control-label'>Scroll Up</text>
+        </Button>
+        <Button
+          className='scroll-control-button scroll-control-button--primary'
+          buttonProps={{
+            'main-thread:bindtap': handleScrollDownTap,
+          }}
         >
-          <text className='scroll-by-button-text'>Scroll Down</text>
-        </view>
+          <text className='scroll-control-label'>Scroll Down</text>
+        </Button>
       </view>
 
       <SortableRoot
@@ -138,12 +149,11 @@ export function App() {
         {renderSortableItem}
       </SortableRoot>
 
-      <view className='outside-panel outside-panel--bottom'>
-        <text className='outside-panel-title'>Behavior</text>
-        <text className='outside-panel-copy'>
-          Locked rows always keep their absolute positions. Other rows are
-          reordered around them, sliding past at a higher speed so the gap stays
-          in sync with the dragged item.
+      <view className='scroll-boundary-info'>
+        <text className='scroll-boundary-info-title'>Sorting Behavior</text>
+        <text className='scroll-boundary-info-description'>
+          Drag an unlocked row across a locked row. The locked row stays in
+          place while unlocked rows reorder around it.
         </text>
       </view>
     </view>

--- a/apps/examples/Sortable/ScrollableBoundary/index.css
+++ b/apps/examples/Sortable/ScrollableBoundary/index.css
@@ -2,99 +2,56 @@
 
 @import "../shared/base.css";
 @import "../shared/palette.css";
+@import "../shared/scroll-boundary.css";
 
 .demo-container {
-  width: 100%;
-  height: 100%;
   display: flex;
   flex-direction: column;
-  padding-top: 48px;
-  padding-bottom: 48px;
-  padding-right: 16px;
-  padding-left: 16px;
+  width: 100%;
+  height: 100%;
+  padding: 64px 16px 48px 16px;
   z-index: 0;
+  background-color: var(--canvas);
 }
 
 .scroll-view {
-  width: 100%;
   flex: 1;
+  width: 100%;
   z-index: 0;
+  border-radius: 16px;
+  border-color: var(--line);
+  border-width: 1px;
+}
+
+.sortable-root {
+  background-color: var(--canvas-ambient);
 }
 
 .scrollable-boundary-root {
   justify-content: flex-start;
-  min-height: 100%;
-  padding-top: 24px;
-  padding-bottom: 32px;
-  border-radius: 16px;
   height: max-content;
+  min-height: 100%;
+  padding: 24px 40px 32px;
 }
 
-.demo-header {
-  width: 100%;
-  padding: 20px 24px;
-  border-radius: 16px;
-  background-color: rgba(255, 255, 255, 0.12);
-}
-
-.demo-title {
-  font-size: 22px;
-  font-weight: 700;
-  color: #ffffff;
-}
-
-.demo-description {
-  margin-top: 8px;
-  font-size: 14px;
-  line-height: 20px;
-  color: rgba(255, 255, 255, 0.72);
-}
-
-.scroll-by-actions {
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  margin-bottom: 16px;
-}
-
-.scroll-by-button {
-  flex: 1;
-  height: 44px;
-  border-radius: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: rgba(255, 255, 255, 0.16);
-}
-
-.scroll-by-button--primary {
-  background-color: #ffffff;
-}
-
-.scroll-by-button-text {
-  font-size: 14px;
-  font-weight: 700;
-  color: #ffffff;
-}
-
-.scroll-by-button--primary .scroll-by-button-text {
-  color: #1f2937;
+.scroll-controls {
+  margin-bottom: 24px;
 }
 
 .sortable-item {
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   height: 100px;
   padding-bottom: 12px;
-  flex-shrink: 0;
   background-color: transparent;
 }
 
 .sortable-item-surface {
   display: flex;
   flex-direction: row;
-  justify-content: end;
   align-items: center;
+  justify-content: end;
   width: 100%;
   height: 88px;
   border-radius: 16px;
@@ -105,6 +62,7 @@
   display: flex;
   flex: 1;
   flex-direction: column;
+  row-gap: 4px;
   justify-content: center;
   padding-left: 20px;
 }
@@ -115,11 +73,14 @@
 }
 
 .sortable-item-subtitle {
-  margin-top: 6px;
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.72);
+  font-size: 13px;
+  font-weight: 500;
 }
 
 .sortable-item-area {
   width: 88px;
+}
+
+.drag-here-text {
+  font-size: 10px;
 }

--- a/apps/examples/Sortable/ScrollableBoundary/index.tsx
+++ b/apps/examples/Sortable/ScrollableBoundary/index.tsx
@@ -6,7 +6,12 @@ import { root, useCallback, useState } from '@lynx-js/react'
 
 import './index.css'
 
-import { SortableItem, SortableItemArea, SortableRoot } from '@lynx-js/lynx-ui'
+import {
+  Button,
+  SortableItem,
+  SortableItemArea,
+  SortableRoot,
+} from '@lynx-js/lynx-ui'
 import type { SortableData } from '@lynx-js/lynx-ui'
 
 import type { SortableDemoItem } from '../shared/data'
@@ -51,7 +56,9 @@ export function App() {
               <text className={`sortable-item-title drag-here-text--${tone}`}>
                 {`Option ${numericId + 1}`}
               </text>
-              <text className='sortable-item-subtitle'>
+              <text
+                className={`sortable-item-subtitle sortable-item-subtitle--${tone}`}
+              >
                 Drag near the edge
               </text>
             </view>
@@ -68,26 +75,30 @@ export function App() {
   )
 
   return (
-    <view className='demo-container lunaris-dark luna-gradient-berry'>
-      <view className='scroll-by-actions'>
-        <view
-          className='scroll-by-button'
-          main-thread:bindtap={() => {
-            'main thread'
-            scrollBoundaryBy(-160)
+    <view className='demo-container lunaris-dark'>
+      <view className='scroll-controls'>
+        <Button
+          className='scroll-control-button'
+          buttonProps={{
+            'main-thread:bindtap': () => {
+              'main thread'
+              scrollBoundaryBy(-160)
+            },
           }}
         >
-          <text className='scroll-by-button-text'>Scroll Up</text>
-        </view>
-        <view
-          className='scroll-by-button scroll-by-button--primary'
-          main-thread:bindtap={() => {
-            'main thread'
-            scrollBoundaryBy(160)
+          <text className='scroll-control-label'>Scroll Up</text>
+        </Button>
+        <Button
+          className='scroll-control-button scroll-control-button--primary'
+          buttonProps={{
+            'main-thread:bindtap': () => {
+              'main thread'
+              scrollBoundaryBy(160)
+            },
           }}
         >
-          <text className='scroll-by-button-text'>Scroll Down</text>
-        </view>
+          <text className='scroll-control-label'>Scroll Down</text>
+        </Button>
       </view>
       <SortableRoot
         data={data}

--- a/apps/examples/Sortable/ShortScrollView/index.css
+++ b/apps/examples/Sortable/ShortScrollView/index.css
@@ -1,111 +1,59 @@
+@import "@lynx-js/luna-styles/index.css";
+
 @import "../shared/base.css";
 @import "../shared/palette.css";
+@import "../shared/scroll-boundary.css";
 
 .demo-container {
-  width: 100%;
-  height: 100%;
   display: flex;
   flex-direction: column;
-  padding: 24px 16px;
+  row-gap: 12px;
+  width: 100%;
+  height: 100%;
+  padding: 64px 16px 24px;
   z-index: 0;
-}
-
-.outside-panel {
-  width: 100%;
-  height: 112px;
-  flex-shrink: 0;
-  border-radius: 16px;
-  padding: 18px 20px;
-  background-color: rgba(255, 255, 255, 0.12);
-}
-
-.outside-panel--top {
-  margin-bottom: 12px;
-}
-
-.outside-panel--bottom {
-  margin-top: 12px;
-}
-
-.outside-panel-title {
-  font-size: 20px;
-  font-weight: 700;
-  color: #ffffff;
-}
-
-.outside-panel-copy {
-  margin-top: 8px;
-  font-size: 13px;
-  line-height: 18px;
-  color: rgba(255, 255, 255, 0.72);
-}
-
-.scroll-by-actions {
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  margin-bottom: 12px;
-}
-
-.scroll-by-button {
-  flex: 1;
-  height: 40px;
-  border-radius: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: rgba(255, 255, 255, 0.16);
-}
-
-.scroll-by-button--primary {
-  background-color: #ffffff;
-}
-
-.scroll-by-button-text {
-  font-size: 14px;
-  font-weight: 700;
-  color: #ffffff;
-}
-
-.scroll-by-button--primary .scroll-by-button-text {
-  color: #1f2937;
+  background-color: var(--canvas);
 }
 
 .short-scroll-view {
+  flex: 1;
   width: 100%;
-  height: 360px;
-  flex-shrink: 0;
-  border-radius: 18px;
+  min-height: 0;
+  border-radius: 16px;
   border-width: 1px;
-  border-color: rgba(255, 255, 255, 0.22);
-  background-color: rgba(0, 0, 0, 0.16);
+  border-color: var(--line);
+  background-color: var(--canvas-ambient);
   z-index: 0;
+}
+
+.sortable-root {
+  background-color: var(--canvas-ambient);
 }
 
 .short-sortable-root {
   justify-content: flex-start;
-  min-height: 100%;
-  padding: 16px 12px;
   height: max-content;
+  min-height: 100%;
+  padding: 24px 40px 32px;
 }
 
 .sortable-item {
   display: flex;
   flex-direction: column;
-  height: 92px;
-  padding-bottom: 10px;
   flex-shrink: 0;
+  height: 100px;
+  padding-bottom: 12px;
   background-color: transparent;
 }
 
 .sortable-item-surface {
   display: flex;
   flex-direction: row;
-  justify-content: end;
   align-items: center;
+  justify-content: end;
   width: 100%;
-  height: 82px;
-  border-radius: 14px;
+  height: 88px;
+  border-radius: 16px;
   overflow: hidden;
 }
 
@@ -113,21 +61,25 @@
   display: flex;
   flex: 1;
   flex-direction: column;
+  row-gap: 4px;
   justify-content: center;
-  padding-left: 18px;
+  padding-left: 20px;
 }
 
 .sortable-item-title {
-  font-size: 17px;
+  font-size: 18px;
   font-weight: 700;
 }
 
 .sortable-item-subtitle {
-  margin-top: 5px;
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.72);
+  font-size: 13px;
+  font-weight: 500;
 }
 
 .sortable-item-area {
-  width: 76px;
+  width: 88px;
+}
+
+.drag-here-text {
+  font-size: 10px;
 }

--- a/apps/examples/Sortable/ShortScrollView/index.tsx
+++ b/apps/examples/Sortable/ShortScrollView/index.tsx
@@ -6,7 +6,12 @@ import { root, useCallback, useState } from '@lynx-js/react'
 
 import './index.css'
 
-import { SortableItem, SortableItemArea, SortableRoot } from '@lynx-js/lynx-ui'
+import {
+  Button,
+  SortableItem,
+  SortableItemArea,
+  SortableRoot,
+} from '@lynx-js/lynx-ui'
 import type { SortableData } from '@lynx-js/lynx-ui'
 
 import type { SortableDemoItem } from '../shared/data'
@@ -51,13 +56,15 @@ export function App() {
               <text className={`sortable-item-title drag-here-text--${tone}`}>
                 {`Row ${numericId + 1}`}
               </text>
-              <text className='sortable-item-subtitle'>
-                Middle scroll-view boundary
+              <text
+                className={`sortable-item-subtitle sortable-item-subtitle--${tone}`}
+              >
+                Drag within this short scroll area
               </text>
             </view>
             <SortableItemArea className='sortable-item-area'>
               <text className={`drag-here-text drag-here-text--${tone}`}>
-                Drag
+                Drag Here
               </text>
             </SortableItemArea>
           </view>
@@ -78,28 +85,33 @@ export function App() {
   }, [])
 
   return (
-    <view className='demo-container lunaris-dark luna-gradient-berry'>
-      <view className='outside-panel outside-panel--top'>
-        <text className='outside-panel-title'>Content Above</text>
-        <text className='outside-panel-copy'>
-          The sortable scroll-view below is intentionally shorter than the
-          screen.
+    <view className='demo-container lunaris-dark'>
+      <view className='scroll-boundary-info'>
+        <text className='scroll-boundary-info-title'>
+          Above the Scroll Boundary
+        </text>
+        <text className='scroll-boundary-info-description'>
+          This panel sits outside the sortable scroll area below.
         </text>
       </view>
 
-      <view className='scroll-by-actions'>
-        <view
-          className='scroll-by-button'
-          main-thread:bindtap={handleScrollUpTap}
+      <view className='scroll-controls'>
+        <Button
+          className='scroll-control-button'
+          buttonProps={{
+            'main-thread:bindtap': handleScrollUpTap,
+          }}
         >
-          <text className='scroll-by-button-text'>Scroll Up</text>
-        </view>
-        <view
-          className='scroll-by-button scroll-by-button--primary'
-          main-thread:bindtap={handleScrollDownTap}
+          <text className='scroll-control-label'>Scroll Up</text>
+        </Button>
+        <Button
+          className='scroll-control-button scroll-control-button--primary'
+          buttonProps={{
+            'main-thread:bindtap': handleScrollDownTap,
+          }}
         >
-          <text className='scroll-by-button-text'>Scroll Down</text>
-        </view>
+          <text className='scroll-control-label'>Scroll Down</text>
+        </Button>
       </view>
 
       <SortableRoot
@@ -116,10 +128,12 @@ export function App() {
         {renderSortableItem}
       </SortableRoot>
 
-      <view className='outside-panel outside-panel--bottom'>
-        <text className='outside-panel-title'>Content Below</text>
-        <text className='outside-panel-copy'>
-          Dragging near the panel edge should not react to this outside area.
+      <view className='scroll-boundary-info'>
+        <text className='scroll-boundary-info-title'>
+          Below the Scroll Boundary
+        </text>
+        <text className='scroll-boundary-info-description'>
+          Dragging near this panel should not trigger sortable auto-scroll.
         </text>
       </view>
     </view>

--- a/apps/examples/Sortable/shared/data.ts
+++ b/apps/examples/Sortable/shared/data.ts
@@ -12,8 +12,10 @@ export interface SortableDemoItem {
 }
 
 export function getToneByIndex(i: number): Tone {
-  if (i > 0 && i < 4) return 'primary'
-  if (i > 3) return 'secondary'
+  const paletteIndex = i % 6
+
+  if (paletteIndex > 0 && paletteIndex < 4) return 'primary'
+  if (paletteIndex > 3) return 'secondary'
   return 'neutral'
 }
 

--- a/apps/examples/Sortable/shared/palette.css
+++ b/apps/examples/Sortable/shared/palette.css
@@ -35,3 +35,15 @@
 .drag-here-text--secondary {
   color: var(--secondary-content);
 }
+
+.sortable-item-subtitle--neutral {
+  color: var(--neutral-content-faded);
+}
+
+.sortable-item-subtitle--primary {
+  color: var(--primary-content-faded);
+}
+
+.sortable-item-subtitle--secondary {
+  color: var(--secondary-content-faded);
+}

--- a/apps/examples/Sortable/shared/scroll-boundary.css
+++ b/apps/examples/Sortable/shared/scroll-boundary.css
@@ -1,0 +1,65 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.scroll-boundary-info {
+  display: flex;
+  flex-direction: column;
+  row-gap: 8px;
+  flex-shrink: 0;
+  width: 100%;
+  height: 112px;
+  padding: 18px 20px;
+  border-radius: 16px;
+  background-color: var(--paper);
+}
+
+.scroll-boundary-info-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--content);
+}
+
+.scroll-boundary-info-description {
+  font-size: 13px;
+  line-height: 18px;
+  color: var(--content-muted);
+}
+
+.scroll-controls {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  column-gap: 12px;
+  padding: 0 24px;
+}
+
+.scroll-control-button {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  height: 44px;
+  border-radius: 999px;
+  background-color: var(--neutral);
+}
+
+.scroll-control-button.ui-active {
+  background-color: var(--neutral-2);
+}
+
+.scroll-control-button--primary {
+  background-color: var(--primary);
+}
+
+.scroll-control-button--primary.ui-active {
+  background-color: var(--primary-2);
+}
+
+.scroll-control-label {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--neutral-content);
+}
+
+.scroll-control-button--primary .scroll-control-label {
+  color: var(--primary-content);
+}


### PR DESCRIPTION
## Context

The Sortable scroll-boundary examples used ad-hoc colors, inconsistent layouts,
and unclear behavior descriptions. Some page content could also overlap device
safe-area overlays.

## Architecture

- Replace literal colors with semantic LUNA tokens.
- Use Button state variants for scroll controls.
- Align row sizing and palette-aware foreground colors across examples.
- Keep palette tones synchronized with the six-color cycle.
- Clarify scroll-boundary and locked-item behavior.
- Document safe-area spacing requirements for all example page roots.

## Regression

The existing SortableRoot boundaries, main-thread scroll handlers, sorting
behavior, and locked item keys remain unchanged.

## Result

ScrollableBoundary, ShortScrollView, and DisableItems now share a consistent
visual language and provide clearer behavioral guidance. A patch changeset is
included for `@lynx-example/lynx-ui-sortable`.

## Validation

- `pnpm check:luna-vars`
- Biome, Stylelint, CSpell, and commit hooks
- `pnpm changeset status`
- `pnpm turbo build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Refine Sortable scroll-boundary examples with semantic LUNA tokens and palette-aware colors.
- Use `Button` state variants for scroll controls.
- Clarify scroll-boundary and locked-item behavior.
- Align row sizing, spacing, and safe-area requirements.
- Synchronize palette tones with the six-color cycle.
- Add a patch changeset for `@lynx-example/lynx-ui-sortable`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->