### PR TITLE
fix(examples): standardize pressed states on ui-active

### DIFF
--- a/.changeset/calm-buttons-press.md
+++ b/.changeset/calm-buttons-press.md
@@ -1,0 +1,10 @@
+---
+"@lynx-example/lynx-ui-button": patch
+"@lynx-example/lynx-ui-dialog": patch
+"@lynx-example/lynx-ui-list": patch
+"@lynx-example/lynx-ui-radio-group": patch
+"@lynx-example/lynx-ui-slider": patch
+"@lynx-js/skill-lynx-ui": patch
+---
+
+Use lynx-ui `ui-active` variants for pressed-state styling across examples.

--- a/apps/examples/Button/Basic/index.css
+++ b/apps/examples/Button/Basic/index.css
@@ -18,8 +18,7 @@
   gap: 6px;
 }
 
-/* Keep :active pseudo-class selector for lynx web active-state compatibility. */
-.button.active, .button.ui-active, .button:active {
+.button.active, .button.ui-active {
   background-color: var(--primary-2);
 }
 

--- a/apps/examples/Dialog/DifferentAnimation/index.css
+++ b/apps/examples/Dialog/DifferentAnimation/index.css
@@ -18,7 +18,7 @@
   color: white;
 }
 
-.dialog-trigger:active {
+.dialog-trigger.ui-active {
   background-color: rgb(51, 51, 51);
 }
 

--- a/apps/examples/Dialog/DynamicallyChangeLevel/index.css
+++ b/apps/examples/Dialog/DynamicallyChangeLevel/index.css
@@ -18,7 +18,7 @@
   color: white;
 }
 
-.dialog-trigger:active {
+.dialog-trigger.ui-active {
   background-color: rgb(51, 51, 51);
 }
 

--- a/apps/examples/Dialog/ForceMount/index.css
+++ b/apps/examples/Dialog/ForceMount/index.css
@@ -18,7 +18,7 @@
   color: white;
 }
 
-.dialog-trigger:active {
+.dialog-trigger.ui-active {
   background-color: rgb(51, 51, 51);
 }
 

--- a/apps/examples/Dialog/ForceMountUIVariants/index.css
+++ b/apps/examples/Dialog/ForceMountUIVariants/index.css
@@ -18,7 +18,7 @@
   color: white;
 }
 
-.dialog-trigger:active {
+.dialog-trigger.ui-active {
   background-color: rgb(51, 51, 51);
 }
 

--- a/apps/examples/Dialog/InScrollView/index.css
+++ b/apps/examples/Dialog/InScrollView/index.css
@@ -24,7 +24,7 @@
   color: white;
 }
 
-.dialog-trigger:active {
+.dialog-trigger.ui-active {
   background-color: rgb(51, 51, 51);
 }
 

--- a/apps/examples/Dialog/MultipleDialogLevel/index.css
+++ b/apps/examples/Dialog/MultipleDialogLevel/index.css
@@ -21,7 +21,7 @@
   color: white;
 }
 
-.dialog-trigger:active {
+.dialog-trigger.ui-active {
   background-color: rgb(51, 51, 51);
 }
 

--- a/apps/examples/Dialog/Uncontrolled/index.css
+++ b/apps/examples/Dialog/Uncontrolled/index.css
@@ -18,7 +18,7 @@
   color: white;
 }
 
-.dialog-trigger:active {
+.dialog-trigger.ui-active {
   background-color: rgb(51, 51, 51);
 }
 

--- a/apps/examples/Dialog/Uncontrolled/index.tsx
+++ b/apps/examples/Dialog/Uncontrolled/index.tsx
@@ -37,10 +37,8 @@ function App() {
         ) => {
           return (
             <>
-              <DialogTrigger>
-                <view className='dialog-trigger'>
-                  <text className='dialog-trigger-text'>open</text>
-                </view>
+              <DialogTrigger className='dialog-trigger'>
+                <text className='dialog-trigger-text'>open</text>
               </DialogTrigger>
               <DialogView
                 className={clsx('dialog-viewport', { 'closed': closed })}

--- a/apps/examples/List/Basic/index.css
+++ b/apps/examples/List/Basic/index.css
@@ -51,7 +51,7 @@
   transition: opacity 0.2s ease-in-out;
 }
 
-.button:active {
+.button.ui-active {
   opacity: 0.5;
 }
 

--- a/apps/examples/RadioGroup/Disabled/index.css
+++ b/apps/examples/RadioGroup/Disabled/index.css
@@ -140,8 +140,7 @@
   background-color: var(--primary);
 }
 
-/* Keep :active pseudo-class selector for lynx web active-state compatibility. */
-.button.ui-active, .button:active {
+.button.ui-active {
   background-color: var(--primary-2);
 }
 

--- a/apps/examples/Slider/shared/OptionChipRow/index.css
+++ b/apps/examples/Slider/shared/OptionChipRow/index.css
@@ -20,8 +20,7 @@
   transition: background-color 100ms ease-out;
 }
 
-.option-chip.ui-active,
-.option-chip:active {
+.option-chip.ui-active {
   background-color: var(--paper);
 }
 
@@ -29,8 +28,7 @@
   background-color: var(--primary);
 }
 
-.option-chip--selected.ui-active,
-.option-chip--selected:active {
+.option-chip--selected.ui-active {
   background-color: var(--primary-2);
 }
 

--- a/luna/examples/luna-stage-basic/package.json
+++ b/luna/examples/luna-stage-basic/package.json
@@ -19,7 +19,10 @@
     "react-dom": "catalog:"
   },
   "devDependencies": {
+    "@lynx-example/lynx-ui-button": "workspace:*",
     "@lynx-example/lynx-ui-popover": "workspace:*",
+    "@lynx-example/lynx-ui-radio-group": "workspace:*",
+    "@lynx-example/lynx-ui-slider": "workspace:*",
     "@lynx-example/lynx-ui-switch": "workspace:*",
     "@rsbuild/core": "catalog:",
     "@rsbuild/plugin-react": "catalog:",

--- a/luna/examples/luna-stage-basic/rsbuild.config.ts
+++ b/luna/examples/luna-stage-basic/rsbuild.config.ts
@@ -43,6 +43,36 @@ const config: RsbuildConfig = defineConfig({
         copyOnBuild: true,
       },
       {
+        name: path.join(
+          __dirname,
+          './node_modules',
+          '@lynx-example/lynx-ui-button',
+          'dist',
+        ),
+        watch: true,
+        copyOnBuild: true,
+      },
+      {
+        name: path.join(
+          __dirname,
+          './node_modules',
+          '@lynx-example/lynx-ui-radio-group',
+          'dist',
+        ),
+        watch: true,
+        copyOnBuild: true,
+      },
+      {
+        name: path.join(
+          __dirname,
+          './node_modules',
+          '@lynx-example/lynx-ui-slider',
+          'dist',
+        ),
+        watch: true,
+        copyOnBuild: true,
+      },
+      {
         name: 'public',
         watch: true,
         copyOnBuild: true,

--- a/luna/examples/luna-stage-basic/src/demos/index.tsx
+++ b/luna/examples/luna-stage-basic/src/demos/index.tsx
@@ -7,7 +7,13 @@ import { LynxStage } from '@lynx-js/luna-stage/lynx'
 
 import './index.css'
 
-const demos = ['PopoverBasic', 'SwitchBasic']
+const demos = [
+  'PopoverBasic',
+  'SwitchBasic',
+  'ButtonBasic',
+  'RadioGroupBasic',
+  'SliderDynamicWidth',
+]
 
 export default function Demo() {
   return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -974,9 +974,18 @@ importers:
         specifier: 'catalog:'
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@lynx-example/lynx-ui-button':
+        specifier: workspace:*
+        version: link:../../../apps/examples/Button
       '@lynx-example/lynx-ui-popover':
         specifier: workspace:*
         version: link:../../../apps/examples/Popover
+      '@lynx-example/lynx-ui-radio-group':
+        specifier: workspace:*
+        version: link:../../../apps/examples/RadioGroup
+      '@lynx-example/lynx-ui-slider':
+        specifier: workspace:*
+        version: link:../../../apps/examples/Slider
       '@lynx-example/lynx-ui-switch':
         specifier: workspace:*
         version: link:../../../apps/examples/Switch


### PR DESCRIPTION
## Motivation

lynx-ui now exposes pressed state consistently through the `ui-active`
variant on Lynx and web. The older example-level `:active` fallbacks are no
longer needed and make the pressed-state contract less clear.

## Changes

- Replaced legacy `:active` pressed-state selectors with `ui-active` in
  Button, Dialog, List, RadioGroup, and Slider examples
- Kept `.active` selectors where they represent explicit render-prop state or
  selected state rather than pressed-state fallback
- Moved the Uncontrolled Dialog trigger styling onto the `DialogTrigger` root
  so it receives the injected `ui-active` state
- Expanded `luna-stage-basic` to preview Button, RadioGroup, and Slider
  examples through Lynx web while validating the related pressed-state changes
- Added patch changesets for the affected example packages and
  `@lynx-js/skill-lynx-ui`

## Validation

- Verified no legacy `:active` pressed-state selectors remain under
  `apps/examples`
- Previewed the related examples through `luna-stage-basic`
- Ran affected example package builds
- Ran `pnpm check:luna-vars`
- Ran `pnpm check:changesets`
- Ran `pnpm check:changesets-private`
- Ran `pnpm turbo build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Replace legacy `:active` selectors with `ui-active` variants across Button, Dialog, List, RadioGroup, and Slider examples.
- Move Uncontrolled Dialog trigger styling to the `DialogTrigger` root.
- Preserve `.active` for explicit render-prop and selected states.
- Expand `luna-stage-basic` with `lynx-ui` Button, RadioGroup, and Slider demos.
- Add patch changesets for affected example packages and `@lynx-js/skill-lynx-ui`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->