### PR TITLE
feat(luna): add design system token playground

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -308,6 +308,7 @@ export default tseslint.config(
   },
   {
     files: [
+      'luna/examples/luna-design-system/src/**/*.{js,mjs,cjs,jsx,ts,tsx}',
       'luna/examples/luna-showcase-studio/src/**/*.{js,mjs,cjs,jsx,ts,tsx}',
       'luna/examples/luna-stage-basic/src/**/*.{js,mjs,cjs,jsx,ts,tsx}',
       'luna/examples/luna-stage-motion/src/**/*.{js,mjs,cjs,jsx,ts,tsx}',
@@ -321,6 +322,9 @@ export default tseslint.config(
         },
         jsxPragma: null,
       },
+    },
+    rules: {
+      'n/no-unsupported-features/node-builtins': 'off',
     },
   },
   // Vitest-related

--- a/luna/examples/luna-design-system/README.md
+++ b/luna/examples/luna-design-system/README.md
@@ -1,0 +1,37 @@
+# L.U.N.A Design System
+
+This Web/React app is the starting point for validating design-system token
+mapping, theme customization, and generated UI output against LUNA semantic
+tokens.
+
+## Routes
+
+The app uses React Router with `BrowserRouter`. Rsbuild serves `index.html` for
+unknown development paths through `server.historyApiFallback`; production
+hosting must apply the same fallback for client routes.
+
+| Path | Status | Responsibility |
+| --- | --- | --- |
+| `/tokens` | Implemented | Compare the LUNA semantic token values from two themes. |
+| `/themes` | Planned | Theme composition and customization work. |
+| `/components` | Planned | Component-level design-system validation. |
+| `/interop/:system` | Planned | External design-system mapping and conversion. |
+
+Keep route components under `src/pages/`, route-level shared layouts under
+`src/layouts/`, presentational components under `src/components/`, and source
+token or mapping data under `src/data/`. Add a route only when its page is
+ready to be rendered.
+
+## Development
+
+Start the Rsbuild development server from the repository root:
+
+```bash
+pnpm --filter @lynx-js/example-luna-design-system dev
+```
+
+Create a production build:
+
+```bash
+pnpm turbo build --filter @lynx-js/example-luna-design-system
+```

--- a/luna/examples/luna-design-system/package.json
+++ b/luna/examples/luna-design-system/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@lynx-js/example-luna-design-system",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Web playground for L.U.N.A design system interoperability",
+  "homepage": "https://github.com/lynx-family/lynx-ui/tree/main/luna/examples/luna-design-system#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-ui.git",
+    "directory": "luna/examples/luna-design-system"
+  },
+  "license": "Apache-2.0",
+  "author": "The Lynx Authors",
+  "type": "module",
+  "scripts": {
+    "build": "rsbuild --config ./rsbuild.config.ts build",
+    "dev": "rsbuild --config ./rsbuild.config.ts dev --open",
+    "preview": "rsbuild --config ./rsbuild.config.ts preview"
+  },
+  "dependencies": {
+    "@lynx-js/luna-core": "workspace:*",
+    "@lynx-js/luna-styles": "workspace:*",
+    "@lynx-js/luna-tokens": "workspace:*",
+    "lucide-react": "0.546.0",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-router-dom": "^7.18.2"
+  },
+  "devDependencies": {
+    "@lynx-js/luna-tailwind": "workspace:*",
+    "@rsbuild/core": "catalog:",
+    "@rsbuild/plugin-react": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "rsbuild-plugin-tailwindcss": "catalog:tailwind",
+    "tailwindcss": "catalog:tailwind",
+    "typescript": "catalog:"
+  }
+}

--- a/luna/examples/luna-design-system/rsbuild.config.ts
+++ b/luna/examples/luna-design-system/rsbuild.config.ts
@@ -1,0 +1,26 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from '@rsbuild/core'
+import { pluginReact } from '@rsbuild/plugin-react'
+import { pluginTailwindCSS } from 'rsbuild-plugin-tailwindcss'
+
+export default defineConfig({
+  plugins: [
+    pluginReact(),
+    pluginTailwindCSS({ config: 'tailwind.config.ts' }),
+  ],
+  html: {
+    title: 'L.U.N.A Design System',
+  },
+  server: {
+    historyApiFallback: true,
+  },
+  dev: {
+    client: {
+      overlay: false,
+    },
+    writeToDisk: false,
+  },
+})

--- a/luna/examples/luna-design-system/src/App.css
+++ b/luna/examples/luna-design-system/src/App.css
@@ -1,0 +1,46 @@
+@import "@lynx-js/luna-styles/index.css";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  html,
+  body,
+  #root {
+    min-height: 100%;
+  }
+
+  html,
+  body {
+    background-color: var(--canvas);
+    color: var(--content);
+  }
+}
+
+@layer utilities {
+  .scrollbar-subtle {
+    scrollbar-color: var(--content-faint) transparent;
+    scrollbar-width: thin;
+  }
+
+  .scrollbar-subtle::-webkit-scrollbar {
+    height: 8px;
+    width: 8px;
+  }
+
+  .scrollbar-subtle::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .scrollbar-subtle::-webkit-scrollbar-thumb {
+    background-clip: padding-box;
+    background-color: var(--content-faint);
+    border: 2px solid transparent;
+    border-radius: 9999px;
+  }
+
+  .scrollbar-subtle:hover::-webkit-scrollbar-thumb {
+    background-color: var(--content-subtle);
+  }
+}

--- a/luna/examples/luna-design-system/src/App.tsx
+++ b/luna/examples/luna-design-system/src/App.tsx
@@ -1,0 +1,21 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { Navigate, Route, Routes } from 'react-router-dom'
+
+import { AppLayout } from './layouts/AppLayout'
+import { TokensPage } from './pages/TokensPage'
+
+function App() {
+  return (
+    <Routes>
+      <Route element={<AppLayout />}>
+        <Route element={<TokensPage />} path='/tokens' />
+      </Route>
+      <Route element={<Navigate replace to='/tokens' />} path='*' />
+    </Routes>
+  )
+}
+
+export default App

--- a/luna/examples/luna-design-system/src/components/PageHeader.tsx
+++ b/luna/examples/luna-design-system/src/components/PageHeader.tsx
@@ -1,0 +1,22 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+interface PageHeaderProps {
+  detail: string
+  title: string
+}
+
+function PageHeader({ detail, title }: PageHeaderProps) {
+  return (
+    <header className='flex flex-col gap-6 border-b border-line pb-6 sm:flex-row sm:items-end sm:justify-between'>
+      <div className='flex flex-col gap-2'>
+        <p className='m-0 text-sm text-content-muted'>L.U.N.A</p>
+        <h1 className='m-0 text-3xl font-normal'>{title}</h1>
+      </div>
+      <p className='m-0 text-sm text-content-muted'>{detail}</p>
+    </header>
+  )
+}
+
+export { PageHeader }

--- a/luna/examples/luna-design-system/src/components/tokens/ThemeSelect.tsx
+++ b/luna/examples/luna-design-system/src/components/tokens/ThemeSelect.tsx
@@ -1,0 +1,32 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { themeTokens } from '../../data/tokens'
+
+interface ThemeSelectProps {
+  label: string
+  onChange: (value: string) => void
+  value: string
+}
+
+function ThemeSelect({ label, onChange, value }: ThemeSelectProps) {
+  return (
+    <label className='flex flex-col gap-2 text-sm text-content-muted'>
+      {label}
+      <select
+        className='h-10 border border-line bg-paper px-3 text-base text-content focus:border-line focus:outline-none'
+        onChange={event => onChange(event.target.value)}
+        value={value}
+      >
+        {themeTokens.map(theme => (
+          <option key={theme.key} value={theme.key}>
+            {theme.key}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+export { ThemeSelect }

--- a/luna/examples/luna-design-system/src/components/tokens/TokenComparisonTable.tsx
+++ b/luna/examples/luna-design-system/src/components/tokens/TokenComparisonTable.tsx
@@ -1,0 +1,137 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { LunaThemeTokens } from '@lynx-js/luna-core'
+import { Check, Copy } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+import { colorTokenIds } from '../../data/tokens'
+
+interface TokenComparisonTableProps {
+  leftTheme: LunaThemeTokens
+  rightTheme: LunaThemeTokens
+}
+
+function TokenComparisonTable({
+  leftTheme,
+  rightTheme,
+}: TokenComparisonTableProps) {
+  return (
+    <div className='scrollbar-subtle overflow-x-auto border border-line'>
+      <div className='min-w-[720px]'>
+        <div className='grid grid-cols-[minmax(11rem,1fr)_minmax(15rem,1fr)_minmax(15rem,1fr)] border-b border-line bg-paper-clear'>
+          <div className='px-4 py-3 text-sm text-content-muted'>Token</div>
+          <ThemeColumnHeading themeKey={leftTheme.key} />
+          <ThemeColumnHeading themeKey={rightTheme.key} />
+        </div>
+
+        {colorTokenIds.map(tokenId => (
+          <div
+            className='grid grid-cols-[minmax(11rem,1fr)_minmax(15rem,1fr)_minmax(15rem,1fr)] border-b border-line last:border-b-0'
+            key={tokenId}
+          >
+            <div className='flex items-center px-4 py-3 font-mono text-sm'>
+              --{tokenId}
+            </div>
+            <TokenValue value={leftTheme.colors[tokenId]} />
+            <TokenValue value={rightTheme.colors[tokenId]} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ThemeColumnHeading({ themeKey }: { themeKey: string }) {
+  return (
+    <div className='border-l border-line px-4 py-3 text-sm'>{themeKey}</div>
+  )
+}
+
+function TokenValue({ value }: { value: string }) {
+  const [copyStatus, setCopyStatus] = useState<
+    'copied' | 'failed' | 'idle'
+  >('idle')
+
+  useEffect(() => {
+    if (copyStatus === 'idle') {
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setCopyStatus('idle')
+    }, 1500)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [copyStatus])
+
+  async function copyValue() {
+    try {
+      await window.navigator.clipboard.writeText(value)
+      setCopyStatus('copied')
+    } catch {
+      setCopyStatus('failed')
+    }
+  }
+
+  const copyLabel = getCopyLabel(copyStatus, value)
+
+  return (
+    <div className='flex items-center gap-3 border-l border-line px-4 py-3'>
+      <button
+        aria-label={copyLabel}
+        className='group relative size-7 shrink-0 border border-line p-0 transition-transform hover:scale-110 hover:border-content focus-visible:border-content focus-visible:outline focus-visible:outline-1 focus-visible:outline-content focus-visible:outline-offset-2'
+        onClick={() => {
+          void copyValue()
+        }}
+        style={{ backgroundColor: value }}
+        title={copyLabel}
+      >
+        <Copy
+          aria-hidden
+          className='absolute inset-0 m-auto text-content-muted opacity-0 transition-opacity group-hover:opacity-80'
+          size={15}
+          strokeWidth={2}
+        />
+      </button>
+      <code className='text-sm text-content-muted'>{value}</code>
+      {copyStatus === 'copied'
+        ? (
+          <span
+            aria-live='polite'
+            className='inline-flex items-center gap-1 text-xs text-content'
+          >
+            <Check aria-hidden size={14} strokeWidth={2} />
+            Copied
+          </span>
+        )
+        : null}
+      {copyStatus === 'failed'
+        ? (
+          <span aria-live='polite' className='text-xs text-content'>
+            Copy failed
+          </span>
+        )
+        : null}
+    </div>
+  )
+}
+
+function getCopyLabel(
+  copyStatus: 'copied' | 'failed' | 'idle',
+  value: string,
+) {
+  if (copyStatus === 'copied') {
+    return 'Copied'
+  }
+  if (copyStatus === 'failed') {
+    return 'Copy failed'
+  }
+
+  return `Copy ${value}`
+}
+
+export { TokenComparisonTable }

--- a/luna/examples/luna-design-system/src/data/tokens.ts
+++ b/luna/examples/luna-design-system/src/data/tokens.ts
@@ -1,0 +1,23 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { LUNA_COLOR_IDS } from '@lynx-js/luna-core'
+import type { LunaColorId, LunaThemeTokens } from '@lynx-js/luna-core'
+import {
+  lunaDarkTokens,
+  lunaLightTokens,
+  lunarisDarkTokens,
+  lunarisLightTokens,
+} from '@lynx-js/luna-tokens'
+
+export const themeTokens: readonly LunaThemeTokens[] = [
+  lunaLightTokens,
+  lunaDarkTokens,
+  lunarisLightTokens,
+  lunarisDarkTokens,
+]
+
+export const colorTokenIds: readonly LunaColorId[] = LUNA_COLOR_IDS
+
+export const colorTokenCount = colorTokenIds.length

--- a/luna/examples/luna-design-system/src/env.d.ts
+++ b/luna/examples/luna-design-system/src/env.d.ts
@@ -1,0 +1,5 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/// <reference types="@rsbuild/core/types" />

--- a/luna/examples/luna-design-system/src/index.tsx
+++ b/luna/examples/luna-design-system/src/index.tsx
@@ -1,0 +1,25 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+
+import App from './App'
+import './App.css'
+
+const ROOT_THEME_CLASS_NAME = 'lunaris-dark'
+const rootElement = document.getElementById('root')
+
+document.documentElement.classList.add(ROOT_THEME_CLASS_NAME)
+
+if (rootElement) {
+  ReactDOM.createRoot(rootElement).render(
+    <React.StrictMode>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </React.StrictMode>,
+  )
+}

--- a/luna/examples/luna-design-system/src/layouts/AppLayout.tsx
+++ b/luna/examples/luna-design-system/src/layouts/AppLayout.tsx
@@ -1,0 +1,17 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { Outlet } from 'react-router-dom'
+
+function AppLayout() {
+  return (
+    <main className='min-h-screen bg-canvas text-content'>
+      <div className='mx-auto max-w-6xl px-5 py-8 sm:px-8 sm:py-12'>
+        <Outlet />
+      </div>
+    </main>
+  )
+}
+
+export { AppLayout }

--- a/luna/examples/luna-design-system/src/pages/TokensPage.tsx
+++ b/luna/examples/luna-design-system/src/pages/TokensPage.tsx
@@ -1,0 +1,50 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { useState } from 'react'
+
+import { PageHeader } from '../components/PageHeader'
+import { ThemeSelect } from '../components/tokens/ThemeSelect'
+import { TokenComparisonTable } from '../components/tokens/TokenComparisonTable'
+import { colorTokenCount, themeTokens } from '../data/tokens'
+
+const DEFAULT_LEFT_THEME = 'luna-dark'
+const DEFAULT_RIGHT_THEME = 'lunaris-dark'
+
+function TokensPage() {
+  const [leftThemeKey, setLeftThemeKey] = useState(DEFAULT_LEFT_THEME)
+  const [rightThemeKey, setRightThemeKey] = useState(DEFAULT_RIGHT_THEME)
+  const leftTheme = themeTokens.find(theme => theme.key === leftThemeKey)
+  const rightTheme = themeTokens.find(theme => theme.key === rightThemeKey)
+
+  if (leftTheme === undefined || rightTheme === undefined) {
+    throw new Error('Selected token theme is unavailable.')
+  }
+
+  return (
+    <div className='flex flex-col gap-10'>
+      <PageHeader
+        detail={`${colorTokenCount} semantic colors`}
+        title='Color Tokens'
+      />
+      <section aria-label='Theme comparison' className='flex flex-col gap-5'>
+        <div className='flex flex-wrap gap-4'>
+          <ThemeSelect
+            label='Left theme'
+            onChange={setLeftThemeKey}
+            value={leftThemeKey}
+          />
+          <ThemeSelect
+            label='Right theme'
+            onChange={setRightThemeKey}
+            value={rightThemeKey}
+          />
+        </div>
+        <TokenComparisonTable leftTheme={leftTheme} rightTheme={rightTheme} />
+      </section>
+    </div>
+  )
+}
+
+export { TokensPage }

--- a/luna/examples/luna-design-system/tailwind.config.ts
+++ b/luna/examples/luna-design-system/tailwind.config.ts
@@ -1,0 +1,13 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { createLunaPreset } from '@lynx-js/luna-tailwind'
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./src/**/*.{html,js,ts,jsx,tsx,mdx}'],
+  presets: [createLunaPreset({ leafPreset: false })],
+}
+
+export default config

--- a/luna/examples/luna-design-system/tsconfig.json
+++ b/luna/examples/luna-design-system/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "moduleDetection": "force",
+    "noUncheckedSideEffectImports": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+  },
+  "include": [
+    "src",
+    "rsbuild.config.ts",
+    "tailwind.config.ts",
+  ],
+  "references": [
+    { "path": "../../packages/luna-core/tsconfig.build.json" },
+    { "path": "../../packages/luna-tailwind/tsconfig.build.json" },
+    { "path": "../../packages/luna-tokens/tsconfig.build.json" },
+  ],
+}

--- a/luna/examples/luna-design-system/turbo.json
+++ b/luna/examples/luna-design-system/turbo.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": [
+        "@lynx-js/luna-core#build",
+        "@lynx-js/luna-styles#build",
+        "@lynx-js/luna-tailwind#build",
+        "@lynx-js/luna-tokens#build"
+      ],
+      "inputs": [
+        "package.json",
+        "src/**",
+        "rsbuild.config.ts",
+        "tailwind.config.ts",
+        "tsconfig.json",
+        "../../tsconfig.json"
+      ],
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/luna/tsconfig.json
+++ b/luna/tsconfig.json
@@ -25,6 +25,9 @@
   "files": [],
   "references": [
     {
+      "path": "./examples/luna-design-system",
+    },
+    {
       "path": "./examples/luna-showcase-catalog/tsconfig.build.json",
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -828,6 +828,55 @@ importers:
         specifier: catalog:tailwind
         version: 3.4.17
 
+  luna/examples/luna-design-system:
+    dependencies:
+      '@lynx-js/luna-core':
+        specifier: workspace:*
+        version: link:../../packages/luna-core
+      '@lynx-js/luna-styles':
+        specifier: workspace:*
+        version: link:../../packages/luna-styles
+      '@lynx-js/luna-tokens':
+        specifier: workspace:*
+        version: link:../../packages/luna-tokens
+      lucide-react:
+        specifier: 0.546.0
+        version: 0.546.0(react@18.3.1)
+      react:
+        specifier: 'catalog:'
+        version: 18.3.1
+      react-dom:
+        specifier: 'catalog:'
+        version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: ^7.18.2
+        version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    devDependencies:
+      '@lynx-js/luna-tailwind':
+        specifier: workspace:*
+        version: link:../../packages/luna-tailwind
+      '@rsbuild/core':
+        specifier: 'catalog:'
+        version: 2.1.0(core-js@3.47.0)
+      '@rsbuild/plugin-react':
+        specifier: 'catalog:'
+        version: 2.1.0(@rsbuild/core@2.1.0(core-js@3.47.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 18.3.7(@types/react@18.3.28)
+      rsbuild-plugin-tailwindcss:
+        specifier: catalog:tailwind
+        version: 0.2.4(@rsbuild/core@2.1.0(core-js@3.47.0))(tailwindcss@3.4.17)
+      tailwindcss:
+        specifier: catalog:tailwind
+        version: 3.4.17
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   luna/examples/luna-showcase-catalog:
     devDependencies:
       '@rslib/core':
@@ -4576,6 +4625,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
 
@@ -6578,6 +6631,23 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@7.18.2:
+    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.18.2:
+    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react-stately@3.49.0:
     resolution: {integrity: sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==}
     peerDependencies:
@@ -6793,6 +6863,9 @@ packages:
   serialize-javascript@7.0.7:
     resolution: {integrity: sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==}
     engines: {node: '>=20.0.0'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -10054,6 +10127,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.1.1: {}
+
   copy-to-clipboard@3.3.3:
     dependencies:
       toggle-selection: 1.0.6
@@ -12261,6 +12336,20 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-router-dom@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  react-router@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      cookie: 1.1.1
+      react: 18.3.1
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+
   react-stately@3.49.0(react@18.3.1):
     dependencies:
       '@internationalized/date': 3.12.3
@@ -12544,6 +12633,8 @@ snapshots:
   semver@7.8.5: {}
 
   serialize-javascript@7.0.7: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
Add a dedicated Rsbuild Web example under luna/examples/luna-design-system so design-system interop work can be explored without coupling it to the existing stage and showcase examples.

The first route focuses on comparing LUNA semantic color tokens across built-in themes. It adds a shared layout, BrowserRouter wiring, token data sourced from @lynx-js/luna-tokens, copyable swatches, and small-screen horizontal scrolling behavior that fits the LUNA theme.

Also wire the example into workspace TypeScript, ESLint browser globals, and lockfile dependencies so it builds cleanly with the rest of the repository.

<img width="940" height="1600" alt="color_tokens" src="https://github.com/user-attachments/assets/7428d676-150e-456b-8f8e-6caae0e1be2a" />