### PR TITLE
perf(sortable): render only active drag overlay

### DIFF
--- a/.changeset/optimize-sortable-active-overlay.md
+++ b/.changeset/optimize-sortable-active-overlay.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/lynx-ui-sortable': patch
+---
+
+Render only the active Sortable drag overlay instead of mounting a hidden overlay for every item.

--- a/apps/examples/Sortable/Performance90/README.md
+++ b/apps/examples/Sortable/Performance90/README.md
@@ -1,0 +1,36 @@
+# Sortable 90-item performance demo
+
+<!-- cspell:ignore pftrace -->
+
+这个示例用 90 个固定高度、包含多层文本节点的卡片复现长列表拖拽和边缘自动滚动场景。
+
+## 采集方法
+
+使用支持 Lynx trace 的 Android `local_test` 或 iOS Profile 包：
+
+```bash
+agent-lynx list-clients
+agent-lynx trace start --client <client-id>
+
+# 打开 SortablePerformance90，拖住列表项手柄，在底部边缘保持约 8 秒后松手。
+
+agent-lynx trace end --client <client-id>
+agent-lynx trace read-data \
+  --client <client-id> \
+  --stream <stream-id> \
+  --output ./sortable-90.pftrace
+agent-lynx trace event-summary ./sortable-90.pftrace --json
+agent-lynx trace query ./sortable-90.pftrace \
+  --sql-file ./Performance90/trace-evidence.sql
+```
+
+示例在 trace 中写入以下事件：
+
+- `Sortable90::mounted`：首屏提交完成。
+- `Sortable90::dragGesture`：完整拖拽区间。
+- `Sortable90::dragStart`：拖拽开始，带 item 数和 render callback 调用次数。
+- `Sortable90::sortCommit`：松手提交，带发生位置变化的 item 数。
+
+重点检查主线程大于 16 ms 的任务、JS 线程大于 30 ms 的任务，以及 `ReactLynx::render`、`ReactLynx::diff`、`ReactLynx::commit` 和 `ReactLynx::patch` 的耗时。
+
+当前 overlay 策略的预期值：初次挂载时 `renderItemCalls=90`，开始拖拽后只为当前项目追加一次渲染，因此本次拖拽提交前应为 `renderItemCallsBeforeCommit=91`。非拖拽态 overlay 数量为 0，拖拽态为 1。

--- a/apps/examples/Sortable/Performance90/index.css
+++ b/apps/examples/Sortable/Performance90/index.css
@@ -1,0 +1,181 @@
+@import "@lynx-js/luna-styles/index.css";
+
+* {
+  box-sizing: border-box;
+}
+
+.performance-page {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background-color: #f2f4f7;
+}
+
+.performance-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 30px 24px 18px;
+  background-color: #ffffff;
+  border-bottom: 1px solid #e4e7ec;
+}
+
+.performance-title {
+  color: #101828;
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.performance-subtitle {
+  max-width: 520px;
+  margin-top: 6px;
+  color: #667085;
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.performance-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 58px;
+  height: 58px;
+  margin-left: 16px;
+  background-color: #eef4ff;
+  border: 1px solid #c7d7fe;
+  border-radius: 16px;
+}
+
+.performance-badge-value {
+  color: #3538cd;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.performance-badge-label {
+  color: #6172f3;
+  font-size: 9px;
+  font-weight: 600;
+}
+
+.trace-hint {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 10px 24px;
+  background-color: #fffaeb;
+  border-bottom: 1px solid #fedf89;
+}
+
+.trace-hint-dot {
+  margin-right: 8px;
+  color: #f79009;
+  font-size: 9px;
+}
+
+.trace-hint-text {
+  color: #7a2e0e;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.sortable-scroll {
+  width: 100%;
+  flex: 1;
+}
+
+.sortable-list {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 12px 14px 28px;
+}
+
+.order-card {
+  width: 100%;
+  height: 128px;
+  margin-bottom: 10px;
+  background-color: #ffffff;
+  border: 1px solid #e4e7ec;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(16, 24, 40, 0.08);
+}
+
+.order-card-content {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  width: 100%;
+  height: 100%;
+}
+
+.order-card-copy {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  padding: 12px 8px 10px 14px;
+}
+
+.order-eyebrow {
+  color: #667085;
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.order-title {
+  margin-top: 5px;
+  color: #101828;
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 18px;
+}
+
+.order-assignee {
+  margin-top: 7px;
+  color: #344054;
+  font-size: 10px;
+}
+
+.order-code-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-top: 6px;
+}
+
+.order-code {
+  color: #98a2b3;
+  font-size: 9px;
+}
+
+.order-tag {
+  margin-left: 8px;
+  padding: 2px 5px;
+  color: #b54708;
+  font-size: 8px;
+  font-weight: 700;
+  background-color: #fffaeb;
+  border-radius: 4px;
+}
+
+.drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 100%;
+  background-color: #f9fafb;
+  border-left: 1px solid #eaecf0;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
+}
+
+.drag-handle-icon {
+  color: #475467;
+  font-size: 22px;
+  font-weight: 700;
+}

--- a/apps/examples/Sortable/Performance90/index.tsx
+++ b/apps/examples/Sortable/Performance90/index.tsx
@@ -1,0 +1,233 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useCallback, useEffect, useState } from '@lynx-js/react'
+
+import './index.css'
+
+import { SortableItem, SortableItemArea, SortableRoot } from '@lynx-js/lynx-ui'
+import type { SortableData } from '@lynx-js/lynx-ui'
+
+// cspell:ignore Adelia Apotek Bantul Cahyani Daerah Esthi kesehatan Klinik konsultasi Kota layanan pasien Penambahan pusat Puskesmas rehabilitasi Rumah ruang Sakit Senopati serta Sihono Sinduadi Sleman Sudirohusodo Susi Trirenggo Umum warga Yani Yogyakarta
+const ITEM_COUNT = 90
+
+interface OrderItem {
+  id: string
+  region: string
+  title: string
+  assignee: string
+  trackingCode: string
+}
+
+const REGIONS = [
+  'Kab. Bantul, Trirenggo',
+  'Kab. Sleman, Sinduadi',
+  'Kota Yogyakarta',
+]
+
+const LOCATIONS = [
+  'Rumah Sakit Umum Daerah Penambahan Senopati',
+  'Puskesmas Trirenggo dan layanan kesehatan warga',
+  'Klinik Sudirohusodo dan pusat rehabilitasi',
+  'Apotek Bantul serta ruang konsultasi pasien',
+]
+
+const ASSIGNEES = [
+  'Adelia Cahyani',
+  'Sihono Pilot',
+  'Esthi Susi',
+  'Indra Yani',
+]
+
+function createPerformanceData(): SortableData<OrderItem>[] {
+  return Array.from({ length: ITEM_COUNT }, (_, index) => {
+    const position = index + 1
+    const id = String(position).padStart(2, '0')
+
+    return {
+      dataItem: {
+        id,
+        region: REGIONS[index % REGIONS.length],
+        title: `${LOCATIONS[index % LOCATIONS.length]} #${id}`,
+        assignee: ASSIGNEES[index % ASSIGNEES.length],
+        trackingCode: `GTL${String(7_020_000_000 + position * 7_319)}`,
+      },
+      getSortingKey: () => `order-${id}`,
+    }
+  })
+}
+
+let renderItemCalls = 0
+let activeDragFlowId: number | undefined
+
+function isProfiling() {
+  return lynx.performance?.isProfileRecording?.() === true
+}
+
+function markMountedProfile() {
+  if (!isProfiling()) return
+
+  lynx.performance.profileMark('Sortable90::mounted', {
+    args: {
+      dataItems: String(ITEM_COUNT),
+      renderItemCalls: String(renderItemCalls),
+    },
+  })
+}
+
+function startDragProfile() {
+  if (!isProfiling()) return
+
+  activeDragFlowId = lynx.performance.profileFlowId()
+  const option = {
+    flowId: activeDragFlowId,
+    args: {
+      dataItems: String(ITEM_COUNT),
+      renderItemCalls: String(renderItemCalls),
+    },
+  }
+  lynx.performance.profileStart('Sortable90::dragGesture', option)
+  lynx.performance.profileMark('Sortable90::dragStart', option)
+}
+
+function endDragProfile(changedPositions: number) {
+  if (!isProfiling()) return
+
+  lynx.performance.profileMark('Sortable90::sortCommit', {
+    flowId: activeDragFlowId,
+    args: {
+      changedPositions: String(changedPositions),
+      renderItemCallsBeforeCommit: String(renderItemCalls),
+    },
+  })
+  lynx.performance.profileEnd()
+  activeDragFlowId = undefined
+}
+
+function countChangedPositions(
+  previous: SortableData<OrderItem>[],
+  next: SortableData<OrderItem>[],
+) {
+  let changedPositions = 0
+  for (let index = 0; index < next.length; index++) {
+    if (
+      previous[index]?.getSortingKey() !== next[index]?.getSortingKey()
+    ) {
+      changedPositions++
+    }
+  }
+  return changedPositions
+}
+
+interface Sortable90CardProps {
+  item: OrderItem
+}
+
+function Sortable90Card({ item }: Sortable90CardProps) {
+  return (
+    <view className='order-card-content'>
+      <view className='order-card-copy'>
+        <text className='order-eyebrow'>
+          {item.id} · {item.region}
+        </text>
+        <text className='order-title'>{item.title}</text>
+        <text className='order-assignee'>◉ {item.assignee}</text>
+        <view className='order-code-row'>
+          <text className='order-code'>{item.trackingCode}</text>
+          <text className='order-tag'>COD</text>
+        </view>
+      </view>
+      <SortableItemArea className='drag-handle'>
+        <text className='drag-handle-icon'>≡</text>
+      </SortableItemArea>
+    </view>
+  )
+}
+
+Sortable90Card.displayName = 'Sortable90Card'
+
+export function App() {
+  const [data, setData] = useState<SortableData<OrderItem>[]>(
+    createPerformanceData,
+  )
+
+  useEffect(() => {
+    markMountedProfile()
+  }, [])
+
+  const handleSortStart = useCallback(() => {
+    startDragProfile()
+  }, [])
+
+  const handleSortEnd = useCallback(
+    (sortedData: SortableData<OrderItem>[]) => {
+      const changedPositions = countChangedPositions(data, sortedData)
+      endDragProfile(changedPositions)
+      setData(sortedData)
+    },
+    [data],
+  )
+
+  const renderSortableItem = useCallback(
+    (item: SortableData<OrderItem>) => {
+      renderItemCalls++
+      const sortingKey = item.getSortingKey()
+
+      return (
+        <SortableItem
+          key={sortingKey}
+          as='DraggableRoot'
+          className='order-card'
+          sortingKey={sortingKey}
+        >
+          <Sortable90Card item={item.dataItem} />
+        </SortableItem>
+      )
+    },
+    [],
+  )
+
+  return (
+    <view className='performance-page'>
+      <view className='performance-header'>
+        <view>
+          <text className='performance-title'>Sortable 90</text>
+          <text className='performance-subtitle'>
+            Drag the handle and hold near an edge to stress auto-scroll
+          </text>
+        </view>
+        <view className='performance-badge'>
+          <text className='performance-badge-value'>90</text>
+          <text className='performance-badge-label'>items</text>
+        </view>
+      </view>
+
+      <view className='trace-hint'>
+        <text className='trace-hint-dot'>●</text>
+        <text className='trace-hint-text'>
+          Trace markers: Sortable90::dragStart → Sortable90::sortCommit
+        </text>
+      </view>
+
+      <SortableRoot
+        as='ScrollView'
+        data={data}
+        onSortStart={handleSortStart}
+        onSortEnd={handleSortEnd}
+        scrollableClassName='sortable-scroll'
+        scrollableContentClassName='sortable-list'
+        scrollableStickyUpperOffset={24}
+        scrollableStickyLowerOffset={24}
+      >
+        {renderSortableItem}
+      </SortableRoot>
+    </view>
+  )
+}
+
+App.displayName = 'Sortable90PerformanceApp'
+
+export default App
+
+root.render(<App />)

--- a/apps/examples/Sortable/Performance90/trace-evidence.sql
+++ b/apps/examples/Sortable/Performance90/trace-evidence.sql
@@ -1,0 +1,11 @@
+SELECT
+  name,
+  COUNT(*) AS occurrences,
+  ROUND(SUM(dur) / 1000000.0, 2) AS total_ms,
+  ROUND(MAX(dur) / 1000000.0, 2) AS max_ms
+FROM slice
+WHERE name GLOB 'Sortable90::*'
+  OR name GLOB 'ReactLynx::*'
+  OR name IN ('Layout', 'UIOperation', 'ScrollByInternal')
+GROUP BY name
+ORDER BY total_ms DESC, occurrences DESC;

--- a/apps/examples/Sortable/lynx.config.mjs
+++ b/apps/examples/Sortable/lynx.config.mjs
@@ -6,6 +6,7 @@ import { exampleConfig } from '../../../tools/configs/exampleConfig.mjs'
 
 const defaultConfig = exampleConfig({
   SortableBasic: './Basic/index.tsx',
+  SortablePerformance90: './Performance90/index.tsx',
   SortableWithScrollView: './WithScrollView/index.tsx',
   SortableScrollableBoundary: './ScrollableBoundary/index.tsx',
   SortableShortScrollView: './ShortScrollView/index.tsx',

--- a/packages/lynx-ui-sortable/src/Sortable.tsx
+++ b/packages/lynx-ui-sortable/src/Sortable.tsx
@@ -110,14 +110,15 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     enableSorting = true,
   } = props
   const scrollable = as === 'ScrollView'
-  const [isDragging, setIsDragging] = useState(false)
-  const handleInternalSortStart = useCallback(() => {
-    setIsDragging(true)
+  const [activeDragKey, setActiveDragKey] = useState<string | null>(null)
+  const isDragging = activeDragKey !== null
+  const handleInternalSortStart = useCallback((sortingKey: string) => {
+    setActiveDragKey(sortingKey)
     onSortStart?.()
   }, [onSortStart])
   const handleInternalSortEnd = useCallback(
     (sortedData: SortableData<T>[]) => {
-      setIsDragging(false)
+      setActiveDragKey(null)
       onSortEnd(sortedData)
     },
     [onSortEnd],
@@ -143,6 +144,11 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
   )
   const dragOverlayRefMap = useMainThreadRef<
     Record<string, MainThread.Element | null>
+  >(
+    {},
+  )
+  const dragOverlayActivatorRefMap = useMainThreadRef<
+    Record<string, (() => void) | null>
   >(
     {},
   )
@@ -202,7 +208,16 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     key: string,
   ) => {
     'main thread'
-    dragOverlayRefMap.current[key] = refI.current
+    const overlay = refI.current
+    dragOverlayRefMap.current[key] = overlay
+    if (overlay) {
+      dragOverlayActivatorRefMap.current[key]?.()
+    }
+  }, [dragOverlayActivatorRefMap, dragOverlayRefMap])
+
+  const clearDragOverlayRef = useCallback((key: string) => {
+    'main thread'
+    delete dragOverlayRefMap.current[key]
   }, [dragOverlayRefMap])
 
   const { handleDragEnd, handleDragMove, handleDragStart } = useSortable({
@@ -235,6 +250,9 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
       ? scrollableScrollTopRef
       : undefined,
     dragOverlayRefMap: scrollable ? dragOverlayRefMap : undefined,
+    dragOverlayActivatorRefMap: scrollable
+      ? dragOverlayActivatorRefMap
+      : undefined,
     dirtyKeysRef,
     disabledKeysRef,
     scrollableStickyUpperOffset,
@@ -243,6 +261,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     setChildrenRef,
     setChildrenMTSRef,
     setDragOverlayRef,
+    clearDragOverlayRef,
     handleDragEnd,
     handleDragMove,
     handleDragStart,
@@ -259,6 +278,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     scrollableBoundaryUpperEdgeRef,
     scrollableScrollTopRef,
     dragOverlayRefMap,
+    dragOverlayActivatorRefMap,
     dirtyKeysRef,
     disabledKeysRef,
     scrollableStickyLowerOffset,
@@ -267,6 +287,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     setChildrenRef,
     setChildrenMTSRef,
     setDragOverlayRef,
+    clearDragOverlayRef,
     handleDragEnd,
     handleDragMove,
     handleDragStart,
@@ -282,10 +303,16 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
     [data, children],
   )
 
-  const renderedDragOverlayChildren = useMemo(
-    () => data?.map(item => children(item)),
-    [data, children],
-  )
+  const renderedDragOverlayChild = useMemo(() => {
+    if (activeDragKey === null) {
+      return null
+    }
+
+    const activeItem = data?.find(
+      item => item.getSortingKey() === activeDragKey,
+    )
+    return activeItem ? children(activeItem) : null
+  }, [activeDragKey, children, data])
 
   if (scrollable) {
     return (
@@ -328,7 +355,7 @@ export function SortableRoot<T>(props: SortableRootProps<T>) {
         <SortableContext.Provider
           value={sortableDragOverlayContextValue}
         >
-          {renderedDragOverlayChildren}
+          {renderedDragOverlayChild}
         </SortableContext.Provider>
       </>
     )
@@ -363,7 +390,7 @@ export function SortableItem(props: SortableItemProps) {
 
 function SortableDragOverlayItem(props: SortableItemProps) {
   const { className, children, sortingKey } = props
-  const { setDragOverlayRef } = useContext(SortableContext)
+  const { clearDragOverlayRef, setDragOverlayRef } = useContext(SortableContext)
   const overlayRef = useMainThreadRef<MainThread.Element | null>(null)
   const overlayElementId = useMemo(
     () => getSortableDragOverlayElementId(sortingKey),
@@ -383,7 +410,10 @@ function SortableDragOverlayItem(props: SortableItemProps) {
 
   useEffect(() => {
     runOnMainThread(setDragOverlayRef)(overlayRef, sortingKey)
-  }, [overlayRef, setDragOverlayRef, sortingKey])
+    return () => {
+      runOnMainThread(clearDragOverlayRef)(sortingKey)
+    }
+  }, [clearDragOverlayRef, overlayRef, setDragOverlayRef, sortingKey])
 
   return (
     <view
@@ -415,6 +445,7 @@ function SortableInteractiveItem(props: SortableItemProps) {
     scrollableBoundaryLowerEdgeRef,
     scrollableScrollTopRef,
     dragOverlayRefMap,
+    dragOverlayActivatorRefMap,
     dirtyKeysRef,
     disabledKeysRef,
     scrollableStickyUpperOffset,
@@ -752,16 +783,17 @@ function SortableInteractiveItem(props: SortableItemProps) {
 
   const activateDragOverlay = useCallback(() => {
     'main thread'
-    if (!scrollableBoundaryId) {
+    if (!scrollableBoundaryId || latestDragEvent.current === null) {
       return
     }
-
-    hideDragSourceItem()
 
     const overlay = getDragOverlayElement()
     if (!overlay) {
       return
     }
+
+    MTSRef.current?.MTSSetTransform(0, 0)
+    hideDragSourceItem()
 
     const visualTranslateY = getVisualTranslateY()
     const bounds = getVisualBounds(visualTranslateY)
@@ -777,10 +809,12 @@ function SortableInteractiveItem(props: SortableItemProps) {
       transform: `translate(${bounds.left}px, ${bounds.top}px)`,
     })
   }, [
+    MTSRef,
     getDragOverlayElement,
     getVisualBounds,
     getVisualTranslateY,
     hideDragSourceItem,
+    latestDragEvent,
     scrollableBoundaryId,
   ])
 
@@ -788,9 +822,15 @@ function SortableInteractiveItem(props: SortableItemProps) {
     'main thread'
     const visualTranslateY = getVisualTranslateY()
     if (scrollableBoundaryId) {
-      MTSRef.current?.MTSSetTransform(0, 0)
-      console.info('reset local drag visual')
-      updateDragOverlayTransform(visualTranslateY)
+      if (getDragOverlayElement()) {
+        MTSRef.current?.MTSSetTransform(0, 0)
+        updateDragOverlayTransform(visualTranslateY)
+      } else {
+        MTSRef.current?.MTSSetTransform(
+          latestDragTranslate.current.x,
+          visualTranslateY,
+        )
+      }
     } else {
       MTSRef.current?.MTSSetTransform(
         latestDragTranslate.current.x,
@@ -801,6 +841,7 @@ function SortableInteractiveItem(props: SortableItemProps) {
     return visualTranslateY
   }, [
     MTSRef,
+    getDragOverlayElement,
     getVisualTranslateY,
     latestDragTranslate,
     scrollableBoundaryId,
@@ -993,7 +1034,9 @@ function SortableInteractiveItem(props: SortableItemProps) {
         autoScrollStickyDirection.current = overflow > 0 ? 1 : -1
       }
     }
-    activateDragOverlay()
+    if (dragOverlayActivatorRefMap) {
+      dragOverlayActivatorRefMap.current[sortingKey] = activateDragOverlay
+    }
     handleDragStart?.(pagePoint, sortingKey, event)
     if (autoScrollStickyDirection.current !== 0) {
       const visualTranslateY = getVisualTranslateY()
@@ -1086,6 +1129,9 @@ function SortableInteractiveItem(props: SortableItemProps) {
     if (!orderChanged) {
       // no data update -> no precommit will run -> reset locally now
       resetLocalDragVisuals()
+    }
+    if (dragOverlayActivatorRefMap) {
+      dragOverlayActivatorRefMap.current[sortingKey] = null
     }
     // if orderChanged: precommit will run resetLocalDragVisuals in the same frame as setData
   }

--- a/packages/lynx-ui-sortable/src/SortableContext.ts
+++ b/packages/lynx-ui-sortable/src/SortableContext.ts
@@ -23,6 +23,9 @@ interface SortableContextType<T = unknown> {
   dragOverlayRefMap?: MutableRefObject<
     Record<string, MainThread.Element | null>
   >
+  dragOverlayActivatorRefMap?: MutableRefObject<
+    Record<string, (() => void) | null>
+  >
   dirtyKeysRef: MutableRefObject<Record<string, boolean>>
   disabledKeysRef: MutableRefObject<Record<string, boolean>>
   scrollableStickyUpperOffset: number
@@ -39,6 +42,7 @@ interface SortableContextType<T = unknown> {
     refI: RefObject<MainThread.Element | null>,
     key: string,
   ) => void
+  clearDragOverlayRef: (key: string) => void
   handleDragStart: (
     pagePoint: Point,
     sortingKey: string,
@@ -68,6 +72,7 @@ export const SortableContext = createContext<SortableContextType>({
   setChildrenRef: noop,
   setChildrenMTSRef: noop,
   setDragOverlayRef: noop,
+  clearDragOverlayRef: noop,
   handleDragStart: noop,
   handleDragMove: noop,
   handleDragEnd: noop,

--- a/packages/lynx-ui-sortable/src/useSortable.tsx
+++ b/packages/lynx-ui-sortable/src/useSortable.tsx
@@ -25,7 +25,7 @@ interface SortableOptionsType<T> {
   dirtyKeysRef: MainThreadRef<Record<string, boolean>>
   disabledKeysRef: MainThreadRef<Record<string, boolean>>
   onDragEnd?: (sortedKeyArray: SortableData<T>[]) => void
-  onDragStart?: () => void
+  onDragStart?: (sortingKey: string) => void
   debugLog?: boolean
 }
 
@@ -65,8 +65,8 @@ export function useSortable<T>(
     dirtyKeysRef.current[sortingKey] = true
   }, [itemMTSRefMap, dirtyKeysRef])
 
-  const handleDragStartJS = useCallback(() => {
-    onDragStart?.()
+  const handleDragStartJS = useCallback((sortingKey: string) => {
+    onDragStart?.(sortingKey)
   }, [onDragStart])
 
   const handleDragStart = useCallback(
@@ -76,7 +76,7 @@ export function useSortable<T>(
       event: MainThread.MouseEvent | MainThread.TouchEvent,
     ) => {
       'main thread'
-      runOnBackground(handleDragStartJS)()
+      runOnBackground(handleDragStartJS)(sortingKey)
       touchStartPoint.current = pagePoint
       changedKey.current.push(sortingKey)
       changeItemZIndex(10000, sortingKey)


### PR DESCRIPTION
## Summary
- render no drag overlay while idle and only the active item overlay during dragging
- mount the overlay before activating its main-thread drag treatment
- add a 90-item Sortable performance demo and trace marker queries
- include a patch changeset for @lynx-js/lynx-ui-sortable

## Validation
- Sortable package and dependencies build successfully
- 90-item Sortable example builds successfully
- pre-commit lint, format, style, and spelling checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Render only the active drag overlay in `lynx-ui-sortable`.
- Mount the drag overlay before activating the main-thread drag treatment.
- Pass the sorting key through the `onDragStart` callback.
- Add a 90-item Sortable performance demo with trace instrumentation and SQL analysis.
- Include a patch changeset for `@lynx-js/lynx-ui-sortable`.
- Verify builds and pre-commit checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->