### PR TITLE
fix(types): emit strict ESM declaration paths

### DIFF
--- a/.changeset/strict-esm-package-types.md
+++ b/.changeset/strict-esm-package-types.md
@@ -1,0 +1,26 @@
+---
+'@lynx-js/lynx-ui-button': patch
+'@lynx-js/lynx-ui-checkbox': patch
+'@lynx-js/lynx-ui-common': patch
+'@lynx-js/lynx-ui-dialog': patch
+'@lynx-js/lynx-ui-draggable': patch
+'@lynx-js/lynx-ui-feed-list': patch
+'@lynx-js/lynx-ui-form': patch
+'@lynx-js/lynx-ui-input': patch
+'@lynx-js/lynx-ui-input-otp': patch
+'@lynx-js/lynx-ui-lazy-component': patch
+'@lynx-js/lynx-ui-list': patch
+'@lynx-js/lynx-ui-overlay': patch
+'@lynx-js/lynx-ui-popover': patch
+'@lynx-js/lynx-ui-presence': patch
+'@lynx-js/lynx-ui-radio-group': patch
+'@lynx-js/lynx-ui-scroll-view': patch
+'@lynx-js/lynx-ui-sheet': patch
+'@lynx-js/lynx-ui-slider': patch
+'@lynx-js/lynx-ui-sortable': patch
+'@lynx-js/lynx-ui-swipe-action': patch
+'@lynx-js/lynx-ui-swiper': patch
+'@lynx-js/lynx-ui-switch': patch
+---
+
+Emit declaration imports with explicit ESM-compatible paths.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,14 @@ jobs:
       runs-on: lynx-ubuntu-24.04-medium
       run: pnpm check:exports
 
+  check-package-types:
+    name: Check Package Types
+    needs: build
+    uses: ./.github/workflows/common-test.yml
+    with:
+      runs-on: lynx-ubuntu-24.04-medium
+      run: pnpm check:package-types
+
   test-publish:
     name: Test Publish
     needs: build
@@ -190,6 +198,7 @@ jobs:
       - code-style-check
       - luna-vars
       - check-exports
+      - check-package-types
       - eslint
       - test-publish
       - test-typos

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Build
         run: |
           corepack pnpm turbo build --summarize
+          corepack pnpm check:package-types
       - name: Save Turbo Result
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -98,6 +99,7 @@ jobs:
       - name: Build
         run: |
           corepack pnpm turbo build --summarize
+          corepack pnpm check:package-types
       - name: Get Current Date
         id: date
         run: echo "date=$(date -u +'%Y-%m-%d %H:%M:%S')" >> "${GITHUB_OUTPUT}"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check:manypkg": "pnpm dlx @manypkg/cli check",
     "check:mdx": "node tools/scripts/check-mdx-top-level-esm.mjs",
     "check:new-packages": "node tools/scripts/check-new-publishable-packages.mjs",
+    "check:package-types": "node tools/scripts/check-package-types.mjs",
     "check:sherif": "pnpm dlx sherif@latest",
     "check:skills-eval-definitions": "pnpm --filter @lynx-js/skill-lynx-ui check:eval-definitions",
     "check:skills-references": "pnpm --filter @lynx-js/skill-lynx-ui check:references",

--- a/tools/configs/rslib.base.ts
+++ b/tools/configs/rslib.base.ts
@@ -34,6 +34,11 @@ export const baseConfig: RslibConfig = {
         emitCss: true,
       },
       dts: true,
+      redirect: {
+        dts: {
+          extension: true,
+        },
+      },
     },
   ],
 }

--- a/tools/scripts/check-package-types.mjs
+++ b/tools/scripts/check-package-types.mjs
@@ -1,0 +1,141 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+)
+const packagesRoot = path.join(repoRoot, 'packages')
+const ts = await import(
+  pathToFileURL(
+    path.join(
+      packagesRoot,
+      'lynx-ui-button/node_modules/typescript/lib/typescript.js',
+    ),
+  )
+)
+
+const assetImportRE =
+  /\.(?:css|less|sass|scss|svg|png|jpe?g|gif|webp|avif)(?:\?.*)?$/i
+const resolutionDiagnosticCodes = new Set([2307, 2834, 2835, 7016])
+
+function getPackageEntries() {
+  return fs.readdirSync(packagesRoot, { withFileTypes: true }).flatMap(
+    (entry) => {
+      if (!entry.isDirectory() || !entry.name.startsWith('lynx-ui')) return []
+
+      const packageRoot = path.join(packagesRoot, entry.name)
+      const packageJsonPath = path.join(packageRoot, 'package.json')
+      if (!fs.existsSync(packageJsonPath)) return []
+
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+      if (packageJson.private || !packageJson.types) return []
+
+      const typesEntry = path.resolve(packageRoot, packageJson.types)
+      if (!fs.existsSync(typesEntry)) {
+        throw new Error(
+          `${packageJson.name}: missing declaration entry ${
+            path.relative(repoRoot, typesEntry)
+          }; build packages before running this check.`,
+        )
+      }
+
+      return [{ name: packageJson.name, packageRoot, typesEntry }]
+    },
+  )
+}
+
+function getRelativeSpecifier(diagnostic) {
+  const match = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+    .match(
+      /(?:module|path) ['"](\.{1,2}\/[^'"]+)['"]/i,
+    )
+  if (match) return match[1]
+
+  if (diagnostic.file && diagnostic.start !== undefined) {
+    const token = ts.getTokenAtPosition(diagnostic.file, diagnostic.start)
+    if (ts.isStringLiteralLike(token) && token.text.startsWith('.')) {
+      return token.text
+    }
+  }
+}
+
+function isRelevantDiagnostic(diagnostic, packages) {
+  if (!diagnostic.file || !resolutionDiagnosticCodes.has(diagnostic.code)) {
+    return false
+  }
+
+  const packageEntry = packages.find(({ packageRoot }) =>
+    diagnostic.file.fileName.startsWith(
+      `${packageRoot}${path.sep}dist${path.sep}`,
+    )
+  )
+  if (!packageEntry) return false
+
+  const specifier = getRelativeSpecifier(diagnostic)
+  return Boolean(specifier && !assetImportRE.test(specifier))
+}
+
+function formatDiagnostic(diagnostic) {
+  const position = diagnostic.file.getLineAndCharacterOfPosition(
+    diagnostic.start ?? 0,
+  )
+  const location = `${path.relative(repoRoot, diagnostic.file.fileName)}:${
+    position.line + 1
+  }:${position.character + 1}`
+  return `${location} TS${diagnostic.code}: ${
+    ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+  }`
+}
+
+function checkResolution(packages, label, moduleResolution, module) {
+  const program = ts.createProgram(
+    packages.map(({ typesEntry }) => typesEntry),
+    {
+      allowJs: false,
+      module,
+      moduleResolution,
+      noEmit: true,
+      skipLibCheck: false,
+      target: ts.ScriptTarget.ESNext,
+    },
+  )
+  const diagnostics = ts.getPreEmitDiagnostics(program).filter((diagnostic) =>
+    isRelevantDiagnostic(diagnostic, packages)
+  )
+
+  if (diagnostics.length > 0) {
+    throw new Error(
+      `${label} declaration resolution failed:\n${
+        diagnostics.map((diagnostic) => formatDiagnostic(diagnostic)).join('\n')
+      }`,
+    )
+  }
+}
+
+try {
+  const packages = getPackageEntries()
+  checkResolution(
+    packages,
+    'Bundler',
+    ts.ModuleResolutionKind.Bundler,
+    ts.ModuleKind.ESNext,
+  )
+  checkResolution(
+    packages,
+    'NodeNext',
+    ts.ModuleResolutionKind.NodeNext,
+    ts.ModuleKind.NodeNext,
+  )
+  console.log(
+    `Package type resolution check passed for ${packages.length} packages (Bundler and NodeNext).`,
+  )
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+}


### PR DESCRIPTION
- Emit explicit ESM-compatible paths in generated declarations.
- Check package declaration resolution with both Bundler and NodeNext.
- Enforce the declaration contract in pull request and publish workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Emit explicit ESM-compatible paths in `lynx-ui` declaration files.
- Validate package type resolution in Bundler and NodeNext modes.
- Enforce package type checks in CI and publish workflows.
- Enable declaration-file extension redirection in the Rslib configuration.
- Add patch release entries for 22 `lynx-ui` packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->