### PR TITLE
fix(ci): run required checks for documentation changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "**/*.md"
   merge_group:
     types: [checks_requested]
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,10 @@ LUNA foundation packages under `luna/packages/` build from local source with Rsl
 Before submitting changes, ensure the project builds and passes checks.
 **CRITICAL**: You MUST run `pnpm turbo build` to perform a full workspace build and ensure no compilation errors are introduced.
 
+The required `Done` check from the `Test` workflow must be reported for every pull request targeting
+`main`, including documentation-only and changeset-only pull requests. Do not add pull request path
+filters that can skip the entire workflow.
+
 ```bash
 # Build all packages
 pnpm run build


### PR DESCRIPTION
## Summary

- run the required `Test` workflow for documentation-only and changeset-only pull requests
- document that every pull request targeting `main` must report the required `Done` check

## Why

The `main` ruleset requires the GitHub Actions `Done` check. With `pull_request.paths-ignore: **/*.md`, Markdown-only pull requests do not create the `Test` workflow or its `Done` job and remain blocked. This also skips formatting, spelling, and changeset validation for Markdown files that are consumed by downstream documentation workflows (lynx-website).

Repository history contains 21 merged pull requests that changed only Markdown/MDX files. Eleven changed only `.md` files and were affected by the current filter; PR #279 provides a current reproduction with no workflow runs.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm turbo build`
- `NODE_OPTIONS=--max-old-space-size=16384 pnpm check:all`
- `actionlint` 1.7.12 (repository runner labels configured as known custom labels)

No changeset is required because this only changes repository CI behavior and contributor guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Run the required `Test` workflow for every pull request targeting `main`.
- Require the `Done` check for documentation-only and changeset-only pull requests.
- Document the CI requirement and validate repository install, build, checks, and `actionlint`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->