### PR TITLE
ci: run CI for pull requests targeting any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 name: Test
 on:
+  # Run CI for PRs targeting any branch so feature branches can be validated.
   pull_request:
-    branches:
-      - main
   merge_group:
     types: [checks_requested]
 permissions:


### PR DESCRIPTION
## Summary
- Remove the pull request target-branch filter from the Test workflow.
- Allow feature branch pull requests to run the required CI checks.

## Testing
- pnpm dprint check .github/workflows/ci.yml
- pnpm turbo build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Run the Test workflow for pull requests targeting any branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->