### PR TITLE
ci: add optional example bundle analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
   build:
     name: Build
     uses: ./.github/workflows/build.yml
+  bundle-analysis:
+    name: Bundle Analysis
+    needs: build
+    uses: ./.github/workflows/workflow-bundle-analysis.yml
   code-style-check:
     name: Code Style Check
     runs-on: lynx-ubuntu-24.04-medium

--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -1,0 +1,28 @@
+name: RelativeCI
+
+on:
+  # zizmor: ignore[dangerous-triggers] This workflow only uploads artifacts
+  # produced by the completed repository workflow.
+  workflow_run:
+    workflows: ["Bundle Analysis", "Test"]
+    types:
+      - completed
+
+permissions:
+  actions: read
+
+jobs:
+  upload:
+    name: Upload example bundles
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: lynx-ubuntu-24.04-medium
+    timeout-minutes: 10
+    env:
+      RELATIVE_CI_PROJECT_EXAMPLES_KEY: ${{ secrets.RELATIVE_CI_PROJECT_EXAMPLES_KEY }}
+    steps:
+      - name: Send bundle statistics to RelativeCI
+        uses: relative-ci/agent-action@fcf45416581928e8dd62eded78ce98c78e5149f8 # v3
+        with:
+          artifactName: examples-relative-ci-artifacts
+          key: ${{ env.RELATIVE_CI_PROJECT_EXAMPLES_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow-bundle-analysis.yml
+++ b/.github/workflows/workflow-bundle-analysis.yml
@@ -1,0 +1,50 @@
+name: Bundle Analysis
+
+on:
+  workflow_call:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+env:
+  CI: 1
+  TURBO_TELEMETRY_DISABLED: 1
+
+jobs:
+  build:
+    name: Build example bundles
+    if: github.event_name != 'merge_group'
+    runs-on: lynx-ubuntu-24.04-medium
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "24"
+          package-manager-cache: false
+      - name: Turbo Cache
+        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        with:
+          path: .turbo
+          key: turbo-v4-${{ runner.os }}-${{ github.sha }}
+      - name: Install
+        run: |
+          npm install -g corepack@latest
+          corepack enable
+          pnpm install --frozen-lockfile
+      - name: Build examples with bundle statistics
+        run: pnpm examples:build
+        env:
+          NODE_OPTIONS: --max-old-space-size=16384
+          RSPEEDY_BUNDLE_ANALYSIS: 1
+      - name: Merge bundle statistics
+        run: pnpm merge:example-bundle-stats
+      - name: Upload bundle statistics
+        uses: relative-ci/agent-upload-artifact-action@a2b5741b4f7e6a989c84ec1a3059696b23c152e5 # v2
+        with:
+          artifactName: examples-relative-ci-artifacts
+          webpackStatsFile: artifacts/example-bundle-stats.json

--- a/package.json
+++ b/package.json
@@ -37,10 +37,12 @@
     "install:all": "pnpm install",
     "knip": "knip",
     "make-new-component": "tsx tools/make-new-component/index.ts",
+    "merge:example-bundle-stats": "node tools/scripts/merge-example-bundle-stats.mjs",
     "prepare": "husky",
     "spell": "cspell lint --config cspell.jsonc --gitignore --no-progress --no-must-find-files --show-suggestions **",
     "test": "vitest",
     "test:changesets-private": "node --test tools/scripts/check-changeset-private-targets.test.mjs",
+    "test:example-bundle-stats": "node --test tools/scripts/merge-example-bundle-stats.test.mjs",
     "test:new-packages": "node --test tools/scripts/check-new-publishable-packages.test.mjs",
     "version:packages": "pnpm ensure:skills-changeset && changeset version"
   },

--- a/tools/configs/bundleAnalysisStatsPlugin.mjs
+++ b/tools/configs/bundleAnalysisStatsPlugin.mjs
@@ -1,0 +1,57 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const BUNDLE_STATS_JSON_OPTIONS = {
+  assets: true,
+  chunks: true,
+  modules: true,
+  entrypoints: true,
+  chunkGroups: true,
+}
+
+export function pluginLynxBundleAnalysisStats() {
+  return {
+    name: 'lynx-ui:bundle-analysis-stats',
+    setup(api) {
+      if (!process.env['RSPEEDY_BUNDLE_ANALYSIS']) return
+
+      api.onAfterBuild(({ stats }) => {
+        if (!stats) return
+
+        const statsPath = path.join(api.context.distPath, 'stats.json')
+        mkdirSync(path.dirname(statsPath), { recursive: true })
+        writeFileSync(
+          statsPath,
+          JSON.stringify(
+            selectLynxStats(
+              stats.toJson(BUNDLE_STATS_JSON_OPTIONS),
+            ),
+            null,
+            2,
+          ),
+        )
+      })
+    },
+  }
+}
+
+export function selectLynxStats(stats) {
+  if (!stats.children?.length) return withoutEmptyChildren(stats)
+
+  const lynxStats = stats.children.find(({ name }) =>
+    name === 'lynx' || name?.startsWith('lynx-')
+  )
+  return withoutEmptyChildren(lynxStats ?? stats.children[0])
+}
+
+function withoutEmptyChildren(stats) {
+  if (!stats.children || stats.children.length > 0) return stats
+
+  const result = { ...stats }
+  delete result.children
+  return result
+}

--- a/tools/configs/exampleConfig.mjs
+++ b/tools/configs/exampleConfig.mjs
@@ -1,6 +1,8 @@
 import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin'
 import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin'
 
+import { pluginLynxBundleAnalysisStats } from './bundleAnalysisStatsPlugin.mjs'
+
 export const exampleConfig = (entry, options = {}) => {
   const needWeb = typeof options === 'boolean'
     ? options
@@ -33,6 +35,7 @@ export const exampleConfig = (entry, options = {}) => {
     },
 
     plugins: [
+      pluginLynxBundleAnalysisStats(),
       pluginQRCode({
         schema(url) {
           return `${url}?fullscreen=true&luna_theme=lunaris-dark&bar_color=0d0d0d&bg_color=0d0d0d`

--- a/tools/scripts/merge-example-bundle-stats.mjs
+++ b/tools/scripts/merge-example-bundle-stats.mjs
@@ -1,0 +1,160 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { createHash } from 'node:crypto'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const repoRoot = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+)
+
+function namespaceValue(project, value, separator = '/') {
+  return `${project}${separator}${String(value)}`
+}
+
+function namespaceChunkId(project, chunkId) {
+  return namespaceValue(project, chunkId, ':')
+}
+
+function namespaceModule(module, project) {
+  const result = {
+    name: namespaceValue(project, module.name),
+    size: module.size,
+    chunks: (module.chunks ?? []).map(chunkId =>
+      namespaceChunkId(project, chunkId)
+    ),
+  }
+
+  if (Array.isArray(module.modules)) {
+    result.modules = module.modules.map(child =>
+      namespaceModule(child, project)
+    )
+  }
+
+  return result
+}
+
+function namespaceAsset(asset, project) {
+  return {
+    name: namespaceValue(project, asset.name),
+    size: asset.size,
+  }
+}
+
+function namespaceChunk(chunk, project) {
+  return {
+    id: namespaceChunkId(project, chunk.id),
+    entry: chunk.entry,
+    initial: chunk.initial,
+    names: (chunk.names ?? []).map(name => namespaceValue(project, name, ':')),
+    files: (chunk.files ?? []).map(file => namespaceValue(project, file)),
+  }
+}
+
+function mergeSortedExampleBundleStats(sources) {
+  const assets = []
+  const modules = []
+  const chunks = []
+  const hash = createHash('sha256')
+  let sourceCount = 0
+
+  for (const { project, stats } of sources) {
+    sourceCount += 1
+    if (!Array.isArray(stats.assets) || stats.assets.length === 0) {
+      throw new Error(`Bundle statistics for ${project} contain no assets`)
+    }
+
+    const projectAssets = stats.assets.map(asset =>
+      namespaceAsset(asset, project)
+    )
+    const projectModules = (stats.modules ?? []).map(module =>
+      namespaceModule(module, project)
+    )
+    const projectChunks = (stats.chunks ?? []).map(chunk =>
+      namespaceChunk(chunk, project)
+    )
+
+    assets.push(...projectAssets)
+    modules.push(...projectModules)
+    chunks.push(...projectChunks)
+    hash.update(project)
+    hash.update(JSON.stringify({
+      assets: projectAssets,
+      modules: projectModules,
+      chunks: projectChunks,
+    }))
+  }
+
+  if (sourceCount === 0) {
+    throw new Error('No example bundle statistics were found')
+  }
+
+  return { hash: hash.digest('hex'), assets, modules, chunks }
+}
+
+export function mergeExampleBundleStats(sources) {
+  return mergeSortedExampleBundleStats(
+    [...sources].sort((a, b) => a.project.localeCompare(b.project, 'en')),
+  )
+}
+
+export function findExampleBundleStats(examplesDirectory) {
+  const sources = readdirSync(examplesDirectory, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => ({
+      project: entry.name,
+      statsPath: path.join(examplesDirectory, entry.name, 'dist/stats.json'),
+    }))
+    .sort((a, b) => a.project.localeCompare(b.project, 'en'))
+
+  const missingProjects = sources
+    .filter(({ statsPath }) => !existsSync(statsPath))
+    .map(({ project }) => project)
+
+  if (missingProjects.length > 0) {
+    throw new Error(
+      `Missing bundle statistics for: ${missingProjects.join(', ')}`,
+    )
+  }
+
+  return sources
+}
+
+function* readExampleBundleStats(sources) {
+  for (const { project, statsPath } of sources) {
+    yield {
+      project,
+      stats: JSON.parse(readFileSync(statsPath, 'utf8')),
+    }
+  }
+}
+
+export function writeMergedExampleBundleStats({
+  examplesDirectory,
+  outputPath,
+}) {
+  const stats = mergeSortedExampleBundleStats(
+    readExampleBundleStats(findExampleBundleStats(examplesDirectory)),
+  )
+
+  mkdirSync(path.dirname(outputPath), { recursive: true })
+  writeFileSync(outputPath, `${JSON.stringify(stats, null, 2)}\n`)
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  writeMergedExampleBundleStats({
+    examplesDirectory: path.join(repoRoot, 'apps/examples'),
+    outputPath: path.join(repoRoot, 'artifacts/example-bundle-stats.json'),
+  })
+}

--- a/tools/scripts/merge-example-bundle-stats.test.mjs
+++ b/tools/scripts/merge-example-bundle-stats.test.mjs
@@ -1,0 +1,85 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { mergeExampleBundleStats } from './merge-example-bundle-stats.mjs'
+
+function source(project) {
+  return {
+    project,
+    stats: {
+      hash: `${project}-hash`,
+      assets: [{ name: 'main.js', size: 100, chunks: [0] }],
+      modules: [{ name: './src/index.tsx', size: 50, chunks: [0] }],
+      chunks: [{
+        id: 0,
+        entry: true,
+        initial: true,
+        names: ['main'],
+        files: ['main.js'],
+      }],
+    },
+  }
+}
+
+describe('mergeExampleBundleStats', () => {
+  it('namespaces identifiers that can collide between examples', () => {
+    const result = mergeExampleBundleStats([
+      source('Button'),
+      source('Dialog'),
+    ])
+
+    assert.deepEqual(
+      result.assets.map(asset => asset.name),
+      ['Button/main.js', 'Dialog/main.js'],
+    )
+    assert.deepEqual(
+      result.modules.map(module => [module.name, module.chunks]),
+      [
+        ['Button/./src/index.tsx', ['Button:0']],
+        ['Dialog/./src/index.tsx', ['Dialog:0']],
+      ],
+    )
+    assert.deepEqual(
+      result.chunks.map(chunk => [chunk.id, chunk.names, chunk.files]),
+      [
+        ['Button:0', ['Button:main'], ['Button/main.js']],
+        ['Dialog:0', ['Dialog:main'], ['Dialog/main.js']],
+      ],
+    )
+  })
+
+  it('is deterministic regardless of input order', () => {
+    const first = mergeExampleBundleStats([
+      source('Dialog'),
+      source('Button'),
+    ])
+    const second = mergeExampleBundleStats([
+      source('Button'),
+      source('Dialog'),
+    ])
+
+    assert.deepEqual(first, second)
+  })
+
+  it('fails when no statistics are available', () => {
+    assert.throws(
+      () => mergeExampleBundleStats([]),
+      /No example bundle statistics were found/u,
+    )
+  })
+
+  it('fails when an example has no assets', () => {
+    assert.throws(
+      () =>
+        mergeExampleBundleStats([{
+          project: 'Button',
+          stats: { assets: [] },
+        }]),
+      /Bundle statistics for Button contain no assets/u,
+    )
+  })
+})

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "env": ["RSPEEDY_BUNDLE_ANALYSIS"],
       "outputs": ["dist/**"]
     },
     "dev": {


### PR DESCRIPTION
Adds repository-level bundle-size reporting for Lynx UI examples.

- Emits Lynx-only bundle statistics through the shared example configuration.
- Combines all 20 examples into one namespaced statistics artifact and reports it through one RelativeCI project.
- Keeps bundle analysis outside the required Done aggregation.

Configure the RELATIVE_CI_PROJECT_EXAMPLES_KEY repository secret to enable reporting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Enable optional Lynx bundle statistics for every example project.
- Combine all 20 examples into one namespaced bundle statistics artifact.
- Report the combined artifact through one RelativeCI project.
- Keep bundle analysis outside the required `Done` aggregation.
- Configure reporting with the `RELATIVE_CI_PROJECT_EXAMPLES_KEY` repository secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->