### PR TITLE
feat(slider): add two-thumb range selection

### DIFF
--- a/.changeset/bright-slider-exports.md
+++ b/.changeset/bright-slider-exports.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/lynx-ui': minor
+---
+
+Export the generic slider value model and thumb index types from the aggregate package.

--- a/.changeset/bright-sliders-range.md
+++ b/.changeset/bright-sliders-range.md
@@ -1,0 +1,7 @@
+---
+'@lynx-js/lynx-ui-slider': minor
+'@lynx-example/lynx-ui-slider': patch
+'@lynx-js/skill-lynx-ui': patch
+---
+
+Add ordered two-thumb range selection to `SliderRoot`, including controlled and uncontrolled tuples, indexed thumbs, step snapping, non-crossing drag behavior, and a price-range example. Single and range values share `SliderRootProps<Value>` and `SliderRef<Value>`; React-extracted props and refs use the neutral `SliderValue` shape, while the generic defaults to `number` for existing explicit annotations.

--- a/apps/examples/Slider/PriceRange/index.css
+++ b/apps/examples/Slider/PriceRange/index.css
@@ -1,0 +1,238 @@
+@import "@lynx-js/luna-styles/index.css";
+@import "../shared/base.css";
+
+.price-range-page {
+  align-items: center;
+  box-sizing: border-box;
+  padding-top: 64px;
+  padding-right: 32px;
+  padding-bottom: 32px;
+  padding-left: 32px;
+}
+
+.price-range-card {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  gap: 0;
+  padding: 32px 28px;
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  background-color: var(--canvas);
+  box-shadow: var(--shadow);
+}
+
+.price-range-header {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: space-between;
+  column-gap: 12px;
+}
+
+.price-range-heading-group {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  row-gap: 8px;
+}
+
+.price-range-heading {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--content-2);
+}
+
+.price-range-drag-status {
+  font-size: 13px;
+  color: var(--content-muted);
+}
+
+.price-range-all-vehicles {
+  height: 28px;
+  padding-right: 10px;
+  padding-left: 10px;
+  border-radius: 9999px;
+  font-size: 13px;
+  line-height: 28px;
+  color: var(--content-2);
+  background-color: var(--neutral-faint);
+}
+
+.price-range-selection {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 24px;
+  padding: 16px;
+  border: 1px solid var(--rule);
+  border-radius: 16px;
+  background-color: var(--paper);
+}
+
+.price-range-selection-label {
+  font-size: 14px;
+  color: var(--content-muted);
+}
+
+.price-range-selection-value {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.price-range-slider-section {
+  display: flex;
+  flex-direction: column;
+  margin-top: 14px;
+}
+
+.price-range-slider {
+  position: relative;
+  width: auto;
+  height: 64px;
+  margin-right: 30px;
+  margin-left: 30px;
+}
+
+.price-range-track {
+  width: 100%;
+  height: 6px;
+  border-radius: 9999px;
+  background-color: var(--neutral-ambient);
+}
+
+.price-range-indicator {
+  width: 100%;
+  height: 6px;
+  margin-top: 29px;
+  border-radius: 9999px;
+  background: linear-gradient(90deg, var(--primary), var(--primary-2));
+}
+
+.price-range-thumb {
+  position: relative;
+  width: 58px;
+  height: 64px;
+}
+
+.price-range-thumb-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 58px;
+  height: 26px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 24px;
+  text-align: center;
+  color: var(--content-2);
+  background-color: var(--paper-clear);
+}
+
+.price-range-thumb-dot {
+  position: absolute;
+  top: 22px;
+  left: 19px;
+  width: 20px;
+  height: 20px;
+  box-sizing: border-box;
+  border: 5px solid var(--canvas);
+  border-radius: 9999px;
+  background-color: var(--primary);
+  box-shadow: var(--shadow);
+  transition: transform 100ms ease-out;
+}
+
+.price-range-thumb.ui-active .price-range-thumb-dot {
+  transform: scale(1.15);
+}
+
+.price-range-endpoints {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-top: -4px;
+  margin-right: 24px;
+  margin-left: 24px;
+}
+
+.price-range-endpoint {
+  font-size: 12px;
+  color: var(--content-subtle);
+}
+
+.price-range-response-hint {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  column-gap: 6px;
+  height: 36px;
+  margin-top: 18px;
+  border-radius: 12px;
+  background-color: var(--secondary-2);
+}
+
+.price-range-response-icon {
+  font-size: 16px;
+  color: var(--secondary-content);
+}
+
+.price-range-response-text {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--secondary-content);
+}
+
+.price-range-options {
+  display: flex;
+  flex-direction: column;
+  row-gap: 10px;
+  margin-top: 14px;
+}
+
+.price-range-option-row {
+  display: flex;
+  flex-direction: row;
+  column-gap: 10px;
+  width: 100%;
+}
+
+.price-range-option {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  height: 48px;
+  border: 1px solid var(--line);
+  border-radius: 9999px;
+  background-color: var(--paper);
+  transition: background-color 100ms ease-out, border-color 100ms ease-out;
+}
+
+.price-range-option.ui-active {
+  background-color: var(--paper-clear);
+}
+
+.price-range-option--selected {
+  border-color: var(--primary);
+  background-color: var(--primary);
+}
+
+.price-range-option--selected.ui-active {
+  background-color: var(--primary-2);
+}
+
+.price-range-option-text {
+  font-size: 13px;
+  color: var(--content-2);
+}
+
+.price-range-option-text--selected {
+  font-weight: 600;
+  color: var(--primary-content);
+}

--- a/apps/examples/Slider/PriceRange/index.tsx
+++ b/apps/examples/Slider/PriceRange/index.tsx
@@ -1,0 +1,199 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from '@lynx-js/react'
+
+import {
+  Button,
+  SliderIndicator,
+  SliderRoot,
+  SliderThumb,
+  SliderTrack,
+} from '@lynx-js/lynx-ui'
+import type { SliderRangeValue } from '@lynx-js/lynx-ui'
+import { clsx } from 'clsx'
+
+import './index.css'
+
+type PriceRange = readonly [number, number]
+
+interface VehiclePreset {
+  label: string
+  prices: PriceRange
+}
+
+const MIN_PRICE = 14
+const MAX_PRICE = 140
+const PRICE_SPAN = MAX_PRICE - MIN_PRICE
+
+const VEHICLE_PRESETS: readonly VehiclePreset[] = [
+  { label: 'Saver', prices: [16, 40] },
+  { label: 'Economy', prices: [16, 46] },
+  { label: 'Taxi', prices: [18, 60] },
+  { label: 'Comfort', prices: [20, 70] },
+  { label: 'Business', prices: [80, 120] },
+  { label: 'Luxury', prices: [80, 140] },
+]
+
+const VEHICLE_PRESET_ROWS = [
+  VEHICLE_PRESETS.slice(0, 2),
+  VEHICLE_PRESETS.slice(2, 4),
+  VEHICLE_PRESETS.slice(4, 6),
+]
+
+function priceToRatio(price: number): number {
+  return (price - MIN_PRICE) / PRICE_SPAN
+}
+
+function ratioToPrice(ratio: number): number {
+  return Math.round(MIN_PRICE + ratio * PRICE_SPAN)
+}
+
+function toSliderRange(prices: PriceRange): SliderRangeValue {
+  return [priceToRatio(prices[0]), priceToRatio(prices[1])]
+}
+
+function formatPriceRange(prices: PriceRange): string {
+  return `$${prices[0]}–$${prices[1]}`
+}
+
+const INITIAL_RANGE = toSliderRange(VEHICLE_PRESETS[0].prices)
+
+function App() {
+  const [range, setRange] = useState<SliderRangeValue>(INITIAL_RANGE)
+  const [committedRange, setCommittedRange] = useState<SliderRangeValue>(
+    INITIAL_RANGE,
+  )
+  const [dragging, setDragging] = useState(false)
+
+  const displayedPrices: PriceRange = [
+    ratioToPrice(range[0]),
+    ratioToPrice(range[1]),
+  ]
+  const committedPrices: PriceRange = [
+    ratioToPrice(committedRange[0]),
+    ratioToPrice(committedRange[1]),
+  ]
+
+  const selectPreset = (preset: VehiclePreset) => {
+    const nextRange = toSliderRange(preset.prices)
+    setRange(nextRange)
+    setCommittedRange(nextRange)
+    setDragging(false)
+  }
+
+  return (
+    <view className='demo-container price-range-page lunaris-dark luna-gradient-berry'>
+      <view className='demo-canvas price-range-card'>
+        <view className='price-range-header'>
+          <view className='price-range-heading-group'>
+            <text className='price-range-heading'>
+              Selected price range
+            </text>
+            <text className='price-range-drag-status'>
+              {dragging
+                ? 'Adjusting price range'
+                : `Confirmed ${formatPriceRange(committedPrices)}`}
+            </text>
+          </view>
+          <text className='price-range-all-vehicles'>All vehicles ›</text>
+        </view>
+
+        <view className='price-range-selection'>
+          <text className='price-range-selection-label'>Price range</text>
+          <text className='price-range-selection-value'>
+            {formatPriceRange(displayedPrices)}
+          </text>
+        </view>
+
+        <view className='price-range-slider-section'>
+          <SliderRoot
+            className='price-range-slider'
+            value={range}
+            step={1 / PRICE_SPAN}
+            onDragging={() => {
+              setDragging((active) => !active)
+            }}
+            onValueChange={(nextValue) => {
+              setRange(nextValue)
+            }}
+            onValueCommit={(nextValue) => {
+              setRange(nextValue)
+              setCommittedRange(nextValue)
+              setDragging(false)
+            }}
+          >
+            <SliderTrack className='price-range-track'>
+              <SliderIndicator className='price-range-indicator' />
+              <SliderThumb index={0} className='price-range-thumb'>
+                <text className='price-range-thumb-label'>
+                  ${displayedPrices[0]}
+                </text>
+                <view className='price-range-thumb-dot' />
+              </SliderThumb>
+              <SliderThumb index={1} className='price-range-thumb'>
+                <text className='price-range-thumb-label'>
+                  ${displayedPrices[1]}
+                </text>
+                <view className='price-range-thumb-dot' />
+              </SliderThumb>
+            </SliderTrack>
+          </SliderRoot>
+
+          <view className='price-range-endpoints'>
+            <text className='price-range-endpoint'>${MIN_PRICE}</text>
+            <text className='price-range-endpoint'>${MAX_PRICE}</text>
+          </view>
+        </view>
+
+        <view className='price-range-response-hint'>
+          <text className='price-range-response-icon'>⚡</text>
+          <text className='price-range-response-text'>
+            Estimated response in about 2 min
+          </text>
+        </view>
+
+        <view className='price-range-options'>
+          {VEHICLE_PRESET_ROWS.map((row, rowIndex) => (
+            <view
+              className='price-range-option-row'
+              key={`price-range-row-${rowIndex}`}
+            >
+              {row.map((preset) => {
+                const selected = displayedPrices[0] === preset.prices[0]
+                  && displayedPrices[1] === preset.prices[1]
+
+                return (
+                  <Button
+                    className={clsx(
+                      'price-range-option',
+                      selected && 'price-range-option--selected',
+                    )}
+                    key={preset.label}
+                    onClick={() => {
+                      selectPreset(preset)
+                    }}
+                  >
+                    <text
+                      className={clsx(
+                        'price-range-option-text',
+                        selected && 'price-range-option-text--selected',
+                      )}
+                    >
+                      {preset.label} {formatPriceRange(preset.prices)}
+                    </text>
+                  </Button>
+                )
+              })}
+            </view>
+          ))}
+        </view>
+      </view>
+    </view>
+  )
+}
+
+root.render(<App />)
+
+export default App

--- a/apps/examples/Slider/lynx.config.mjs
+++ b/apps/examples/Slider/lynx.config.mjs
@@ -7,6 +7,7 @@ import { exampleConfig } from '../../../tools/configs/exampleConfig.mjs'
 const defaultConfig = exampleConfig({
   SliderBasic: './Basic/index.tsx',
   SliderControlled: './Controlled/index.tsx',
+  SliderPriceRange: './PriceRange/index.tsx',
   SliderShapes: './Shapes/index.tsx',
   SliderFacade: './Facade/index.tsx',
   SliderDynamicWidth: './DynamicWidth/index.tsx',

--- a/packages/lynx-ui-slider/README.md
+++ b/packages/lynx-ui-slider/README.md
@@ -1,6 +1,7 @@
 # @lynx-js/lynx-ui-slider
 
-A primitives-first slider component package for lynx-ui.
+A primitives-first slider component package for lynx-ui. It supports both
+single-value sliders and two-thumb range sliders.
 
 ## Installation
 
@@ -51,6 +52,36 @@ export function SliderPrimitiveDemo() {
 }
 ```
 
+### Range Composition
+
+Pass an ordered tuple to `value` or `defaultValue` to select an interval. A
+range slider uses two `SliderThumb` primitives: `index={0}` represents the
+lower value and `index={1}` represents the upper value.
+
+```tsx
+<SliderRoot defaultValue={[0.2, 0.8]}>
+  <SliderTrack className='slider-track'>
+    <SliderIndicator className='slider-indicator' />
+    <SliderThumb index={0} className='slider-thumb-wrapper'>
+      <view className='slider-thumb-dot' />
+    </SliderThumb>
+    <SliderThumb index={1} className='slider-thumb-wrapper'>
+      <view className='slider-thumb-dot' />
+    </SliderThumb>
+  </SliderTrack>
+</SliderRoot>
+```
+
+Range values are normalized into ascending order, clamped to `[0, 1]`, and
+snapped to `step` when provided. Range-thumb collision behavior is intentionally
+non-crossing: the thumbs may meet, but the active thumb stops at the other
+value without swapping identities or pushing the other thumb. This is the
+stable default behavior.
+
+Both value shapes use the generic `SliderRootProps<Value>` and
+`SliderRef<Value>` contracts. Their generic defaults to `number`; use
+`SliderRangeValue` when an explicit range annotation is needed.
+
 ## Component Structure
 
 ```tsx
@@ -64,14 +95,16 @@ export function SliderPrimitiveDemo() {
 </SliderRoot>
 ```
 
-- **`SliderRoot`**: owns interaction logic and exposes `SliderRef` imperative methods in uncontrolled mode.
+- **`SliderRoot`**: owns interaction logic and supports a number or a two-value tuple.
 - **`SliderTrack`**: establishes the measurement/layout coordinate space and renders the base rail.
-- **`SliderIndicator`**: renders the active progress indicator, with width driven by the current ratio.
-- **`SliderThumb`**: is positioned inside `SliderTrack` by the current ratio and renders custom thumb content.
+- **`SliderIndicator`**: renders progress from the origin for a single value or the selected interval for a range.
+- **`SliderThumb`**: renders custom thumb content; range mode identifies its lower and upper thumbs with `index`.
 
 Styling for track/thumb size and colors is expected to be done through `className` or inline `style`, instead of dedicated style props.
 
-`SliderIndicator` and `SliderThumb` are siblings inside `SliderTrack`, so the filled region stays purely visual while the thumb position is driven directly by value.
+`SliderIndicator` and `SliderThumb` are siblings inside `SliderTrack`, so the
+filled region stays purely visual while each thumb position is driven directly
+by value.
 
 ## About @lynx-js/lynx-ui
 

--- a/packages/lynx-ui-slider/README_zh.md
+++ b/packages/lynx-ui-slider/README_zh.md
@@ -1,6 +1,6 @@
 # @lynx-js/lynx-ui-slider
 
-一个适用于 ReactLynx 的 Slider 组件包，优先提供可组合的基础能力。
+一个适用于 ReactLynx 的 Slider 组件包，优先提供可组合的基础能力，同时支持单值滑块和双拇指区间滑块。
 
 ## 安装
 
@@ -35,6 +35,22 @@ _（如有需要，也可以通过 `pnpm add @lynx-js/lynx-ui-slider` 单独安�
   </SliderTrack>
 </SliderRoot>
 ```
+
+区间模式通过 `value` 或 `defaultValue` 传入有序二元组，并使用两个带索引的 `SliderThumb`：
+
+```tsx
+<SliderRoot defaultValue={[0.2, 0.8]}>
+  <SliderTrack>
+    <SliderIndicator />
+    <SliderThumb index={0} />
+    <SliderThumb index={1} />
+  </SliderTrack>
+</SliderRoot>
+```
+
+`index={0}` 表示下限，`index={1}` 表示上限。区间值会按升序归一化、限制在 `[0, 1]` 内，并在设置 `step` 时吸附到对应步进。区间拇指明确采用禁止交叉的碰撞策略：两个拇指可以重合，但活动拇指会停在另一个值处，不会交换身份或推动另一个拇指。这是稳定的默认行为。`SliderIndicator` 在区间模式下渲染两个拇指之间的选中范围。
+
+两种值形态共用泛型 `SliderRootProps<Value>` 与 `SliderRef<Value>`。泛型默认为 `number`；需要显式标注区间时使用 `SliderRangeValue`。
 
 ## 关于 @lynx-js/lynx-ui
 

--- a/packages/lynx-ui-slider/SKILL.md
+++ b/packages/lynx-ui-slider/SKILL.md
@@ -1,17 +1,19 @@
 # lynx-ui-slider SKILL
 
-`lynx-ui-slider` is a primitives-first slider package for ReactLynx. It provides composable building blocks (`SliderRoot`, `SliderTrack`, `SliderIndicator`, `SliderThumb`).
+`lynx-ui-slider` is a primitives-first slider package for ReactLynx. It provides composable building blocks (`SliderRoot`, `SliderTrack`, `SliderIndicator`, `SliderThumb`) for single-value and two-thumb range selection.
 
 ## 1. Core Capabilities
 
 - **Primitives Composition**: Build slider UI with `SliderRoot` + `SliderTrack` + `SliderIndicator` + `SliderThumb`.
+- **Range Selection**: Pass a `[lower, upper]` tuple and render thumbs with `index={0}` and `index={1}`.
 - **Shared Base Props**: All primitives inherit `className` and `style` from `ComponentBasicProps`.
-- **Controlled & Uncontrolled Modes**: Use `value` + `onValueChange` for controlled mode, or `defaultValue` for uncontrolled mode.
-- **Imperative API** (uncontrolled only): Access `updateValue` and `getValue` through `SliderRef`. Throws in controlled mode.
+- **Controlled & Uncontrolled Modes**: Use `value` + `onValueChange` for controlled mode, or `defaultValue` for uncontrolled mode, with either a number or range tuple.
+- **Imperative API** (uncontrolled only): Access `updateValue` and `getValue` through `SliderRef<Value>`. Use its default `number` shape for a single value or `SliderRef<SliderRangeValue>` for a range. Throws in controlled mode.
 - **RTL Support**: Set `enableRTL` to make the indicator and thumb resolve right-to-left.
 - **Stepping**: Set `step` to snap values to discrete increments.
 - **Disabled Mode**: Set `disabled` to prevent dragging while still displaying the current value.
 - **Interaction Callbacks**: `onDragging(value)` when dragging state changes, `onValueChange(value, source)` for slider-driven updates, `onValueCommit(value)` at drag end.
+- **Ordered Range Dragging**: Lower and upper thumbs may meet but cannot cross during a drag.
 - **Headless Styling**: Supports styling via `className` and `style` props on every primitive.
 
 ## 2. AI Coding Guide
@@ -73,6 +75,42 @@ function ControlledSlider() {
 }
 ```
 
+### Controlled Range Example
+
+```tsx
+import { useState } from '@lynx-js/react'
+import {
+  SliderIndicator,
+  SliderRoot,
+  SliderThumb,
+  SliderTrack,
+} from '@lynx-js/lynx-ui'
+import type { SliderRangeValue } from '@lynx-js/lynx-ui'
+
+function ControlledRangeSlider() {
+  const [range, setRange] = useState<SliderRangeValue>([0.2, 0.8])
+
+  return (
+    <SliderRoot value={range} onValueChange={setRange}>
+      <SliderTrack className='track'>
+        <SliderIndicator className='indicator' />
+        <SliderThumb index={0} className='thumb'>
+          <view />
+        </SliderThumb>
+        <SliderThumb index={1} className='thumb'>
+          <view />
+        </SliderThumb>
+      </SliderTrack>
+    </SliderRoot>
+  )
+}
+```
+
+Use `index={0}` only for the lower thumb and `index={1}` only for the upper
+thumb. `SliderIndicator` automatically spans between the two values. Input
+tuples are sorted, clamped to `[0, 1]`, and snapped to `step`; an active thumb
+is constrained by the other thumb and cannot cross it.
+
 ### RTL Example
 
 ```tsx
@@ -93,32 +131,49 @@ function ControlledSlider() {
 **Example Prompts:**
 
 - "Create a controlled slider with custom thumb UI and `onValueCommit` callback."
+- "Build a controlled price-range slider with indexed lower and upper thumbs."
 - "Build a headless slider with `step={0.1}` and custom class names for each primitive."
 - "Add an RTL slider with `enableRTL` and optional RTL container styling."
 
 ## 3. Props Reference
 
-### SliderRootProps
+### SliderRootProps<Value>
 
 `SliderRootProps`, `SliderTrackProps`, `SliderIndicatorProps`, and `SliderThumbProps` all inherit `className` and `style` from `ComponentBasicProps`.
 
-| Prop            | Type                              | Default | Description                                                                         |
-| --------------- | --------------------------------- | ------- | ----------------------------------------------------------------------------------- |
-| `value`         | `number`                          | —       | Controlled value `[0, 1]`. Do not use with `defaultValue`.                          |
-| `defaultValue`  | `number`                          | `0`     | Initial value for uncontrolled mode.                                                |
-| `step`          | `number`                          | —       | Snap interval in `[0, 1]`.                                                          |
-| `disabled`      | `boolean`                         | `false` | Prevent interaction while keeping the slider value visible.                         |
-| `enableRTL`     | `boolean`                         | `false` | Reverse range direction (right-to-left).                                            |
-| `onDragging`    | `(value: number) => void`         | —       | Fires when dragging starts and when dragging ends.                                  |
-| `onValueChange` | `(value: number, source) => void` | —       | Fires after drag updates and `updateValue` calls. Source is `'drag'` or `'external'`. |
-| `onValueCommit` | `(value: number) => void`         | —       | Fires at drag end with final value.                                                 |
+`Value` is either `number` or `SliderRangeValue`. It defaults to `number` for existing single-value usage and is inferred automatically from `value` or `defaultValue`.
 
-### SliderRef (uncontrolled only)
+| Prop            | Type                             | Default | Description                                                                           |
+| --------------- | -------------------------------- | ------- | ------------------------------------------------------------------------------------- |
+| `value`         | `Value`                          | —       | Controlled value. Do not use with `defaultValue`.                                     |
+| `defaultValue`  | `Value`                          | `0`     | Initial uncontrolled value. Range usage must provide a tuple here or through `value`. |
+| `step`          | `number`                         | —       | Snap interval in `[0, 1]`.                                                            |
+| `disabled`      | `boolean`                        | `false` | Prevent interaction while keeping the slider value visible.                           |
+| `enableRTL`     | `boolean`                        | `false` | Reverse slider direction (right-to-left).                                              |
+| `onDragging`    | `(value: Value) => void`         | —       | Fires when dragging starts and when dragging ends.                                    |
+| `onValueChange` | `(value: Value, source) => void` | —       | Fires after slider-driven updates. Source is `'drag'` or `'external'`.                 |
+| `onValueCommit` | `(value: Value) => void`         | —       | Fires at drag end with the final value.                                               |
 
-| Method        | Signature                           | Description                                        |
-| ------------- | ----------------------------------- | -------------------------------------------------- |
-| `updateValue` | `(value: number, options?) => void` | Set value imperatively. Throws in controlled mode. |
-| `getValue`    | `() => number`                      | Read current value. Throws in controlled mode.     |
+For explicit annotations, use `SliderRootProps` for a single value and `SliderRootProps<SliderRangeValue>` for a range. Both shapes use the same component and callbacks.
+
+### SliderRef<Value> (uncontrolled only)
+
+| Method        | Signature                          | Description                                        |
+| ------------- | ---------------------------------- | -------------------------------------------------- |
+| `updateValue` | `(value: Value, options?) => void` | Set value imperatively. Throws in controlled mode. |
+| `getValue`    | `() => Value`                      | Read current value. Throws in controlled mode.     |
+
+Use `SliderRef` for a single value and `SliderRef<SliderRangeValue>` for a range.
+
+### SliderThumbProps in range mode
+
+Single-value sliders use the default `index={0}`. For a range, set `index={0}` on the lower thumb and `index={1}` on the upper thumb.
+
+### SliderUIVariants
+
+Slider primitives receive `ui-disabled` when disabled. During interaction,
+the root, track, and indicator receive `ui-active`; only the thumb being moved
+receives `ui-active` in range mode.
 
 ## 4. FAQ
 
@@ -142,6 +197,16 @@ A: They will throw an error. In controlled mode, update external state through `
 
 A: Input values are clamped to `[0, 1]` internally.
 
+**Q: How do I create a two-thumb range slider?**
+
+A: Pass a `[lower, upper]` tuple to `value` or `defaultValue`, then render two `SliderThumb` primitives with `index={0}` and `index={1}`. The indicator fills the selected interval.
+
+**Q: Can the lower and upper thumbs cross?**
+
+A: No. A dragged thumb is clamped to the other value. The two thumbs may meet,
+but their lower/upper identities remain stable: the active thumb does not swap
+with or push the other thumb. This non-crossing policy is the stable default.
+
 **Q: How do I enable RTL?**
 
 A: Pass `enableRTL` to `SliderRoot`. Add `direction: rtl` only if you also want the surrounding container layout or text flow to follow RTL.
@@ -154,5 +219,5 @@ A: `SliderIndicator` is the pure visual fill layer. Keep `SliderThumb` as a sibl
 
 - **`SliderRoot`**: Owns measurement, drag behavior, value management, and context provider.
 - **`SliderTrack`**: Base rail plus the measurement/layout coordinate space for its children.
-- **`SliderIndicator`**: Foreground visual indicator with width bound to value. Supports RTL via `right: 0` positioning.
-- **`SliderThumb`**: Visual thumb node positioned inside `SliderTrack` by the current ratio.
+- **`SliderIndicator`**: Foreground visual indicator from the origin to a single value, or between both range values. Supports RTL.
+- **`SliderThumb`**: Visual thumb node positioned inside `SliderTrack`; use `index` to identify both range endpoints.

--- a/packages/lynx-ui-slider/docs/APIReference.mdx
+++ b/packages/lynx-ui-slider/docs/APIReference.mdx
@@ -2,10 +2,14 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
 
 ### SliderRoot
-    Root primitive props.
 
-`SliderRoot` owns interaction logic (dragging and value tracking)
-and provides context for child primitives.
+Root primitive props for a single-value or range slider. The generic
+selects the value shape and defaults to `number` for existing single-value
+usage. A range slider must provide its tuple through either `value` or
+`defaultValue` so the runtime can determine the shape.
+Range-thumb collision behavior is intentionally non-crossing: thumbs may
+meet, but the active thumb stops at the other value without swapping or
+pushing the other thumb.
 
 <UIApiTable source={[
   {
@@ -102,17 +106,33 @@ and provides context for child primitives.
   },
   {
     "name": "defaultValue",
-    "type": "number",
+    "type": "number | SliderRangeValue",
     "summary": [
       {
         "kind": "text",
-        "text": "Initial value for uncontrolled usage."
+        "text": "Initial value for uncontrolled usage. A single-value slider starts at\n"
+      },
+      {
+        "kind": "code",
+        "text": "`0`"
+      },
+      {
+        "kind": "text",
+        "text": " when omitted; a range slider must provide a tuple."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "非受控模式下的初始值。"
+        "text": "非受控模式下的初始值。省略时，单值滑块从 "
+      },
+      {
+        "kind": "code",
+        "text": "`0`"
+      },
+      {
+        "kind": "text",
+        "text": " 开始；区间滑块必须提供二元组。"
       }
     ],
     "defaultValue": "0",
@@ -120,7 +140,15 @@ and provides context for child primitives.
     "isSupportIOS": false,
     "isSupportAndroid": false,
     "isSupportHarmony": false,
-    "docTypeFallback": null
+    "docTypeFallback": {
+      "tag": "@docTypeFallback",
+      "content": [
+        {
+          "kind": "text",
+          "text": "number | SliderRangeValue"
+        }
+      ]
+    }
   },
   {
     "name": "disabled",
@@ -184,17 +212,17 @@ and provides context for child primitives.
   },
   {
     "name": "onDragging",
-    "type": "(value: number) => void",
+    "type": "(value: number | SliderRangeValue) => void",
     "summary": [
       {
         "kind": "text",
-        "text": "Triggered when dragging state changes, with the current progress value. The callback fires when dragging starts and when dragging ends."
+        "text": "Triggered when dragging state changes, with the current slider value.\nThe callback fires when dragging starts and when dragging ends."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "拖拽状态变化时触发，传入当前进度值。开始拖拽和结束拖拽时都会触发。"
+        "text": "拖拽状态变化时触发，传入当前滑块值。开始拖拽和结束拖拽时都会触发。"
       }
     ],
     "defaultValue": "",
@@ -202,15 +230,23 @@ and provides context for child primitives.
     "isSupportIOS": false,
     "isSupportAndroid": false,
     "isSupportHarmony": false,
-    "docTypeFallback": null
+    "docTypeFallback": {
+      "tag": "@docTypeFallback",
+      "content": [
+        {
+          "kind": "text",
+          "text": "(value: number | SliderRangeValue) => void"
+        }
+      ]
+    }
   },
   {
     "name": "onValueChange",
-    "type": "(value: number, source: SliderValueChangeSource) => void",
+    "type": "(value: number | SliderRangeValue, source: SliderValueChangeSource) => void",
     "summary": [
       {
         "kind": "text",
-        "text": "Triggered after slider-driven value updates, including dragging and "
+        "text": "Triggered after slider-driven value updates, including dragging and\n"
       },
       {
         "kind": "code",
@@ -218,7 +254,7 @@ and provides context for child primitives.
       },
       {
         "kind": "text",
-        "text": ". In controlled mode, use this callback to keep the external "
+        "text": ". In controlled mode, use this callback to keep\nthe external "
       },
       {
         "kind": "code",
@@ -256,11 +292,19 @@ and provides context for child primitives.
     "isSupportIOS": false,
     "isSupportAndroid": false,
     "isSupportHarmony": false,
-    "docTypeFallback": null
+    "docTypeFallback": {
+      "tag": "@docTypeFallback",
+      "content": [
+        {
+          "kind": "text",
+          "text": "(value: number | SliderRangeValue, source: SliderValueChangeSource) => void"
+        }
+      ]
+    }
   },
   {
     "name": "onValueCommit",
-    "type": "(value: number) => void",
+    "type": "(value: number | SliderRangeValue) => void",
     "summary": [
       {
         "kind": "text",
@@ -278,7 +322,15 @@ and provides context for child primitives.
     "isSupportIOS": false,
     "isSupportAndroid": false,
     "isSupportHarmony": false,
-    "docTypeFallback": null
+    "docTypeFallback": {
+      "tag": "@docTypeFallback",
+      "content": [
+        {
+          "kind": "text",
+          "text": "(value: number | SliderRangeValue) => void"
+        }
+      ]
+    }
   },
   {
     "name": "step",
@@ -358,11 +410,11 @@ and provides context for child primitives.
   },
   {
     "name": "value",
-    "type": "number",
+    "type": "number | SliderRangeValue",
     "summary": [
       {
         "kind": "text",
-        "text": "Controlled value in range "
+        "text": "Controlled slider value. Pass a number in "
       },
       {
         "kind": "code",
@@ -370,7 +422,7 @@ and provides context for child primitives.
       },
       {
         "kind": "text",
-        "text": ". When provided, the slider is in controlled mode. Do not use together with "
+        "text": " or an ordered\nlower/upper tuple. Do not use together with "
       },
       {
         "kind": "code",
@@ -384,7 +436,7 @@ and provides context for child primitives.
     "summary_zh": [
       {
         "kind": "text",
-        "text": "受控模式下的值，范围 "
+        "text": "受控滑块值。传入范围 "
       },
       {
         "kind": "code",
@@ -392,7 +444,7 @@ and provides context for child primitives.
       },
       {
         "kind": "text",
-        "text": "。传入此属性时滑块为受控模式，请勿与 "
+        "text": " 内的数值或有序的下限/上限二元组。请勿与 "
       },
       {
         "kind": "code",
@@ -408,13 +460,363 @@ and provides context for child primitives.
     "isSupportIOS": false,
     "isSupportAndroid": false,
     "isSupportHarmony": false,
+    "docTypeFallback": {
+      "tag": "@docTypeFallback",
+      "content": [
+        {
+          "kind": "text",
+          "text": "number | SliderRangeValue"
+        }
+      ]
+    }
+  }
+]}/>
+
+
+### SliderRangeValue
+
+<UIApiTable source={[
+  {
+    "name": "SliderRangeValue",
+    "type": "readonly [number, number]",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Ordered lower and upper values for a range slider. Both values use the normalized "
+      },
+      {
+        "kind": "code",
+        "text": "`[0, 1]`"
+      },
+      {
+        "kind": "text",
+        "text": " scale.\nDuring dragging, the lower and upper thumbs may meet, but they never cross,\nswap identities, or push one another."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "区间滑块的下限值和上限值。两个值都使用标准化的 "
+      },
+      {
+        "kind": "code",
+        "text": "`[0, 1]`"
+      },
+      {
+        "kind": "text",
+        "text": " 范围。\n拖拽时，下限和上限拇指可以相遇，但不会交叉、交换身份或推动彼此。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": false,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>
+
+
+### SliderValue
+
+<UIApiTable source={[
+  {
+    "name": "SliderValue",
+    "type": "number | SliderRangeValue",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Value accepted by "
+      },
+      {
+        "kind": "code",
+        "text": "`SliderRoot`"
+      },
+      {
+        "kind": "text",
+        "text": ": either one normalized value or an ordered\nlower/upper tuple."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "code",
+        "text": "`SliderRoot`"
+      },
+      {
+        "kind": "text",
+        "text": " 接受的值：单个标准化数值，或有序的下限/上限二元组。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": false,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>
+
+
+### SliderThumbIndex
+
+<UIApiTable source={[
+  {
+    "name": "SliderThumbIndex",
+    "type": "0 | 1",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Index of a slider thumb. A single-value slider uses index "
+      },
+      {
+        "kind": "code",
+        "text": "`0`"
+      },
+      {
+        "kind": "text",
+        "text": "; a range\nslider uses index "
+      },
+      {
+        "kind": "code",
+        "text": "`0`"
+      },
+      {
+        "kind": "text",
+        "text": " for the lower value and "
+      },
+      {
+        "kind": "code",
+        "text": "`1`"
+      },
+      {
+        "kind": "text",
+        "text": " for the upper value."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "滑块拇指的索引。单值滑块使用索引 "
+      },
+      {
+        "kind": "code",
+        "text": "`0`"
+      },
+      {
+        "kind": "text",
+        "text": "；区间滑块使用索引 "
+      },
+      {
+        "kind": "code",
+        "text": "`0`"
+      },
+      {
+        "kind": "text",
+        "text": " 表示下限、索引 "
+      },
+      {
+        "kind": "code",
+        "text": "`1`"
+      },
+      {
+        "kind": "text",
+        "text": " 表示上限。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": false,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>
+
+
+### SliderValueChangeSource
+
+<UIApiTable source={[
+  {
+    "name": "SliderValueChangeSource",
+    "type": "external | drag",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Source of a value change.\n\n- "
+      },
+      {
+        "kind": "code",
+        "text": "`external`"
+      },
+      {
+        "kind": "text",
+        "text": ": value updated by imperative API calls.\n- "
+      },
+      {
+        "kind": "code",
+        "text": "`drag`"
+      },
+      {
+        "kind": "text",
+        "text": ": value updated by pointer/touch dragging."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "值变更的来源。\n\n- "
+      },
+      {
+        "kind": "code",
+        "text": "`external`"
+      },
+      {
+        "kind": "text",
+        "text": "：通过命令式 API 调用更新。\n- "
+      },
+      {
+        "kind": "code",
+        "text": "`drag`"
+      },
+      {
+        "kind": "text",
+        "text": "：通过指针/触摸拖拽更新。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": false,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>
+
+
+### SliderUpdateValueOptions
+
+Options used by `SliderRef.updateValue`.
+
+<UIApiTable source={[
+  {
+    "name": "force",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Bypass drag-time guard and force update even while dragging."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "跳过拖拽保护，在拖拽过程中也强制更新。"
+      }
+    ],
+    "defaultValue": "false",
+    "isOption": true,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "source",
+    "type": "SliderValueChangeSource",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Mark the update source for analytics/logic branching."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "标记更新来源，用于分析或逻辑分支。"
+      }
+    ],
+    "defaultValue": "'external'",
+    "isOption": true,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>
+
+
+### SliderUIVariants
+
+UI variants applied by slider primitives based on interaction state.
+Use them as CSS selectors to style active and disabled states.
+
+<UIApiTable source={[
+  {
+    "name": "ui-active",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Applied while the slider is actively being interacted with. On "
+      },
+      {
+        "kind": "code",
+        "text": "`SliderThumb`"
+      },
+      {
+        "kind": "text",
+        "text": ", only the active thumb receives this variant."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "滑块处于交互中时生效。在 "
+      },
+      {
+        "kind": "code",
+        "text": "`SliderThumb`"
+      },
+      {
+        "kind": "text",
+        "text": " 上，仅当前活动的拇指会获得此状态。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "ui-disabled",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Applied when the slider is disabled."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "滑块被禁用时生效。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
     "docTypeFallback": null
   }
 ]}/>
 
 
 ### SliderTrack
-    Track primitive props.
+
+Track primitive props.
 
 `SliderTrack` establishes the measurement/layout coordinate space and renders the base rail.
 
@@ -521,9 +923,10 @@ and provides context for child primitives.
 
 
 ### SliderIndicator
-    Indicator primitive props.
 
-`SliderIndicator` is a pure visual layer whose width is controlled by root value.
+Indicator primitive props.
+
+`SliderIndicator` is a pure visual layer. It fills from zero to the value in single-value mode and spans the selected interval in range mode.
 
 <UIApiTable source={[
   {
@@ -574,7 +977,8 @@ and provides context for child primitives.
 
 
 ### SliderThumb
-    Thumb primitive props.
+
+Thumb primitive props.
 
 `SliderThumb` is positioned by the current ratio inside `SliderTrack` and does not own interaction logic.
 
@@ -624,6 +1028,76 @@ and provides context for child primitives.
     "docTypeFallback": null
   },
   {
+    "name": "index",
+    "type": "SliderThumbIndex",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Value index represented by this thumb. A single-value slider uses the\ndefault index "
+      },
+      {
+        "kind": "code",
+        "text": "`0`"
+      },
+      {
+        "kind": "text",
+        "text": "; a range slider uses "
+      },
+      {
+        "kind": "code",
+        "text": "`0`"
+      },
+      {
+        "kind": "text",
+        "text": " for the lower thumb and "
+      },
+      {
+        "kind": "code",
+        "text": "`1`"
+      },
+      {
+        "kind": "text",
+        "text": "\nfor the upper thumb."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "此拇指对应的值索引。单值滑块使用默认索引 "
+      },
+      {
+        "kind": "code",
+        "text": "`0`"
+      },
+      {
+        "kind": "text",
+        "text": "；区间滑块使用 "
+      },
+      {
+        "kind": "code",
+        "text": "`0`"
+      },
+      {
+        "kind": "text",
+        "text": " 表示下限拇指，使用 "
+      },
+      {
+        "kind": "code",
+        "text": "`1`"
+      },
+      {
+        "kind": "text",
+        "text": " 表示上限拇指。"
+      }
+    ],
+    "defaultValue": "0",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
     "name": "style",
     "type": "CSSProperties",
     "summary": [
@@ -644,5 +1118,91 @@ and provides context for child primitives.
     "isSupportAndroid": true,
     "isSupportHarmony": true,
     "docTypeFallback": null
+  }
+]}/>
+
+
+## SliderRef
+
+Imperative methods exposed by `SliderRoot` for the selected value shape.
+The generic defaults to `number` for compatibility with existing
+single-value refs; use `SliderRef<SliderRangeValue>` for a range slider.
+
+<UIApiTable source={[
+  {
+    "name": "getValue",
+    "type": "() => number | SliderRangeValue",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Read the current slider value using the selected value shape."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "使用所选值形态读取当前滑块值。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": false,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": {
+      "tag": "@docTypeFallback",
+      "content": [
+        {
+          "kind": "text",
+          "text": "() => number | SliderRangeValue"
+        }
+      ]
+    }
+  },
+  {
+    "name": "updateValue",
+    "type": "(value: number | SliderRangeValue, options?: SliderUpdateValueOptions) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Imperatively set the slider value. Every number in the selected value\nshape uses the normalized range "
+      },
+      {
+        "kind": "code",
+        "text": "`[0, 1]`"
+      },
+      {
+        "kind": "text",
+        "text": "."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "命令式地设置滑块值。所选值形态中的每个数值都使用标准化范围 "
+      },
+      {
+        "kind": "code",
+        "text": "`[0, 1]`"
+      },
+      {
+        "kind": "text",
+        "text": "。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": {
+      "tag": "@docTypeFallback",
+      "content": [
+        {
+          "kind": "text",
+          "text": "(value: number | SliderRangeValue, options?: SliderUpdateValueOptions) => void"
+        }
+      ]
+    }
   }
 ]}/>

--- a/packages/lynx-ui-slider/package.json
+++ b/packages/lynx-ui-slider/package.json
@@ -30,7 +30,8 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@lynx-js/lynx-ui-common": "workspace:*"
+    "@lynx-js/lynx-ui-common": "workspace:*",
+    "clsx": "catalog:"
   },
   "devDependencies": {
     "@lynx-js/react": "catalog:",

--- a/packages/lynx-ui-slider/src/SliderIndicator/index.tsx
+++ b/packages/lynx-ui-slider/src/SliderIndicator/index.tsx
@@ -4,14 +4,19 @@
 
 import { memo } from '@lynx-js/react'
 
+import { clsx } from 'clsx'
+
 import { useSliderContext } from '../context'
 import type { SliderIndicatorProps } from '../types'
+import { getSliderIndicatorGeometry } from '../utils'
 
 export const SliderIndicator = memo(function SliderIndicator(
   props: SliderIndicatorProps,
 ) {
-  const { indicatorRef, currentValue, enableRTL } = useSliderContext()
+  const { active, currentValue, disabled, enableRTL, indicatorRef } =
+    useSliderContext()
   const { className, style } = props
+  const { offset, size } = getSliderIndicatorGeometry(currentValue.current)
 
   return (
     <view
@@ -21,11 +26,19 @@ export const SliderIndicator = memo(function SliderIndicator(
         top: '0px',
         bottom: '0px',
         overflow: 'visible',
-        ...(enableRTL ? { right: '0px' } : { left: '0px' }),
-        width: `${currentValue.current * 100}%`,
+        ...(enableRTL
+          ? { right: `${offset * 100}%` }
+          : { left: `${offset * 100}%` }),
+        width: `${size * 100}%`,
       }}
     >
-      <view className={className} style={style} />
+      <view
+        className={clsx(className, {
+          'ui-active': active,
+          'ui-disabled': disabled,
+        })}
+        style={style}
+      />
     </view>
   )
 })

--- a/packages/lynx-ui-slider/src/SliderRoot/index.tsx
+++ b/packages/lynx-ui-slider/src/SliderRoot/index.tsx
@@ -10,24 +10,93 @@ import {
   useEffect,
   useImperativeHandle,
   useRef,
+  useState,
 } from '@lynx-js/react'
-import type { ForwardedRef } from '@lynx-js/react'
+import type {
+  ForwardRefExoticComponent,
+  ForwardedRef,
+  MemoExoticComponent,
+  ReactElement,
+  RefAttributes,
+} from '@lynx-js/react'
 
 import { getRectByRef } from '@lynx-js/lynx-ui-common'
 import type { NodesRef } from '@lynx-js/types'
+import { clsx } from 'clsx'
 
 import { SliderContext } from '../context'
 import type {
   SliderRef,
   SliderRootProps,
+  SliderThumbIndex,
   SliderUpdateValueOptions,
+  SliderValue,
   SliderValueChangeSource,
 } from '../types'
-import { clamp01, getTouchX, getVisualRatio, snapToStep } from '../utils'
+import {
+  areSliderValuesEqual,
+  clamp01,
+  cloneSliderValue,
+  getInitialSliderThumbIndex,
+  getSliderIndicatorGeometry,
+  getSliderThumbValue,
+  getTouchX,
+  getVisualRatio,
+  isSliderValueCollapsed,
+  normalizeSliderValue,
+  resolveSliderDrag,
+} from '../utils'
 
-export const SliderRoot = memo(forwardRef(SliderRootImpl))
+type InternalSliderRootProps = SliderRootProps<SliderValue>
+type InternalSliderRef = SliderRef<SliderValue>
 
-function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
+type SliderRootCallProps<Value extends SliderValue> =
+  & SliderRootProps<Value>
+  & {
+    ref?: ForwardedRef<SliderRef<Value>>
+  }
+
+type SliderRootComponent = <Value extends SliderValue = number>(
+  props: SliderRootCallProps<Value>,
+) => ReactElement
+
+interface SliderInteractionState {
+  pointerActive: boolean
+  dragging: boolean
+  pendingThumbIndex: SliderThumbIndex | null
+  activeThumbIndex: SliderThumbIndex | null
+  lastActiveThumbIndex: SliderThumbIndex | null
+  startedCollapsed: boolean
+}
+
+interface RenderedSliderInteractionState {
+  active: boolean
+  activeThumbIndex: SliderThumbIndex | null
+}
+
+type SliderRootRuntimeComponent = MemoExoticComponent<
+  ForwardRefExoticComponent<
+    InternalSliderRootProps & RefAttributes<InternalSliderRef>
+  >
+>
+
+const MemoizedSliderRoot: SliderRootRuntimeComponent = memo(
+  forwardRef(SliderRootImpl),
+)
+
+type SliderRootStatics = Pick<
+  typeof MemoizedSliderRoot,
+  keyof typeof MemoizedSliderRoot
+>
+
+export const SliderRoot = MemoizedSliderRoot as
+  & SliderRootComponent
+  & SliderRootStatics
+
+function SliderRootImpl(
+  props: InternalSliderRootProps,
+  ref: ForwardedRef<InternalSliderRef>,
+) {
   const {
     value: controlledValue,
     defaultValue = 0,
@@ -46,103 +115,205 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
   const isWebPlatform = useRef<boolean>(SystemInfo.platform === 'web')
 
   const isWebMouseDown = useRef<boolean>(false)
-
   const isControlled = controlledValue !== undefined
+  const previousEnableRTL = useRef(enableRTL)
+  const [renderedInteraction, setRenderedInteraction] = useState<
+    RenderedSliderInteractionState
+  >({ active: false, activeThumbIndex: null })
+  const active = renderedInteraction.active && !disabled
 
   const trackRef = useRef<NodesRef>(null)
   const indicatorRef = useRef<NodesRef>(null)
-  const thumbRef = useRef<NodesRef>(null)
+  const thumbRefs = [
+    useRef<NodesRef>(null),
+    useRef<NodesRef>(null),
+  ] as const
 
   const bgWidth = useRef<number>(0)
   const bgLeft = useRef<number>(0)
   const leftMeasured = useRef<boolean>(false)
   const isMeasuringBounds = useRef<boolean>(false)
   const pendingMoveX = useRef<number | null>(null)
-
-  const isDragging = useRef<boolean>(false)
-  const currentValue = useRef<number>(
-    snapToStep(clamp01(isControlled ? controlledValue : defaultValue), step),
+  const pendingEnd = useRef<boolean>(false)
+  const interaction = useRef<SliderInteractionState>({
+    pointerActive: false,
+    dragging: false,
+    pendingThumbIndex: null,
+    activeThumbIndex: null,
+    lastActiveThumbIndex: null,
+    startedCollapsed: false,
+  })
+  const currentValue = useRef<SliderValue>(
+    normalizeSliderValue(
+      isControlled ? controlledValue : defaultValue,
+      step,
+    ),
   )
 
-  const applyNativeValue = (next: number): void => {
+  const applyNativeValue = (next: SliderValue): void => {
+    const { offset, size } = getSliderIndicatorGeometry(next)
+    const indicatorOffset = `${offset * 100}%`
+
     indicatorRef.current
       ?.setNativeProps?.({
-        width: `${next * 100}%`,
+        width: `${size * 100}%`,
+        ...(enableRTL
+          ? { right: indicatorOffset }
+          : { left: indicatorOffset }),
       })
       ?.exec?.()
 
-    thumbRef.current
+    const lowerValue = getSliderThumbValue(next, 0)
+    thumbRefs[0].current
       ?.setNativeProps?.({
-        left: `${getVisualRatio(next, enableRTL) * 100}%`,
+        left: `${getVisualRatio(lowerValue, enableRTL) * 100}%`,
+      })
+      ?.exec?.()
+
+    const upperValue = getSliderThumbValue(next, 1)
+    thumbRefs[1].current
+      ?.setNativeProps?.({
+        left: `${getVisualRatio(upperValue, enableRTL) * 100}%`,
       })
       ?.exec?.()
   }
 
-  const syncCurrentValue = (next: number): boolean => {
-    if (currentValue.current === next) return false
+  const syncCurrentValue = (next: SliderValue): boolean => {
+    if (areSliderValuesEqual(currentValue.current, next)) return false
     currentValue.current = next
     applyNativeValue(next)
     return true
   }
 
   const updateValue = (
-    value: number,
+    value: SliderValue,
     options: SliderUpdateValueOptions = {},
   ): void => {
-    const next = snapToStep(clamp01(value), step)
+    const next = normalizeSliderValue(value, step)
     const source: SliderValueChangeSource = options.source ?? 'external'
 
-    if (isDragging.current && !options.force && source === 'external') {
+    if (
+      interaction.current.dragging && !options.force && source === 'external'
+    ) {
       return
     }
 
     if (!syncCurrentValue(next)) return
 
-    onValueChange?.(next, source)
+    onValueChange?.(cloneSliderValue(next), source)
   }
 
   useEffect(() => {
-    if (!isControlled) return
-    const next = snapToStep(clamp01(controlledValue), step)
-    syncCurrentValue(next)
-  }, [controlledValue, isControlled, step])
+    const directionChanged = previousEnableRTL.current !== enableRTL
+    previousEnableRTL.current = enableRTL
 
-  const getValue = (): number => currentValue.current
+    if (!isControlled) {
+      if (directionChanged) applyNativeValue(currentValue.current)
+      return
+    }
+
+    if (controlledValue === undefined) return
+
+    const next = normalizeSliderValue(controlledValue, step)
+    if (!syncCurrentValue(next) && directionChanged) {
+      applyNativeValue(next)
+    }
+  }, [controlledValue, enableRTL, isControlled, step])
+
+  const getValue = (): SliderValue => cloneSliderValue(currentValue.current)
+
+  const resolveNextDrag = (value: number) => {
+    const interactionState = interaction.current
+    const resolution = resolveSliderDrag(
+      currentValue.current,
+      value,
+      {
+        activeThumbIndex: interactionState.activeThumbIndex ?? undefined,
+        preferredThumbIndex: interactionState.lastActiveThumbIndex ?? undefined,
+        startedCollapsed: interactionState.startedCollapsed,
+        step,
+      },
+    )
+
+    const previousIndex = interactionState.activeThumbIndex
+    interactionState.activeThumbIndex = resolution.activeThumbIndex
+    interactionState.lastActiveThumbIndex = resolution.activeThumbIndex
+    interactionState.startedCollapsed = resolution.startedCollapsed
+    if (previousIndex !== resolution.activeThumbIndex) {
+      setRenderedInteraction({
+        active: true,
+        activeThumbIndex: resolution.activeThumbIndex,
+      })
+    }
+
+    return resolution
+  }
 
   const applyMeasuredMoveX = (x: number): void => {
     const value = valueFromX(x)
     if (value === null) return
 
-    setDragging(true, value)
-    updateValue(value, { source: 'drag', force: true })
+    const resolution = resolveNextDrag(value)
+    const next = resolution.value
+    setDragging(true, resolution.dragStartValue)
+    updateValue(next, { source: 'drag', force: true })
   }
 
   const updateBounds = (res: unknown): boolean => {
-    const left = Number(
-      (res as { left?: unknown } | null | undefined)?.left,
-    )
-    const width = Number(
-      (res as { width?: unknown } | null | undefined)?.width,
-    )
+    const rect = res as
+      | {
+        left?: unknown
+        width?: unknown
+      }
+      | null
+      | undefined
+    const left = typeof rect?.left === 'number' ? rect.left : Number.NaN
+    const width = typeof rect?.width === 'number' ? rect.width : Number.NaN
 
-    if (Number.isFinite(left)) {
-      bgLeft.current = left
+    if (!Number.isFinite(left) || !Number.isFinite(width) || width <= 0) {
+      bgWidth.current = 0
+      leftMeasured.current = false
+      return false
     }
 
-    if (Number.isFinite(width) && width > 0) {
-      bgWidth.current = width
-    }
+    bgLeft.current = left
+    bgWidth.current = width
+    leftMeasured.current = true
+    return true
+  }
 
-    const ready = Number.isFinite(bgLeft.current) && bgWidth.current > 0
-    leftMeasured.current = ready
-    return ready
+  const resetInteraction = (): void => {
+    const interactionState = interaction.current
+    interactionState.pointerActive = false
+    interactionState.pendingThumbIndex = null
+    interactionState.activeThumbIndex = null
+    interactionState.startedCollapsed = false
+    pendingEnd.current = false
+    pendingMoveX.current = null
+    setRenderedInteraction((previous) =>
+      previous.active || previous.activeThumbIndex !== null
+        ? { active: false, activeThumbIndex: null }
+        : previous
+    )
+  }
+
+  const finishInteraction = (): void => {
+    resetInteraction()
+
+    if (!interaction.current.dragging) return
+
+    const value = currentValue.current
+    setDragging(false, value)
+    onValueCommit?.(cloneSliderValue(value))
   }
 
   const flushPendingMoveX = (): void => {
     if (pendingMoveX.current === null || !leftMeasured.current) return
     const x = pendingMoveX.current
+    const shouldFinish = pendingEnd.current
     pendingMoveX.current = null
     applyMeasuredMoveX(x)
+    if (shouldFinish) finishInteraction()
   }
 
   const measureBounds = (): void => {
@@ -155,18 +326,25 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
     getRectByRef(trackRef)
       .then((res) => {
         isMeasuringBounds.current = false
-        updateBounds(res)
-        flushPendingMoveX()
+        if (updateBounds(res)) {
+          flushPendingMoveX()
+        } else if (pendingEnd.current) {
+          finishInteraction()
+        }
       })
       .catch(() => {
         isMeasuringBounds.current = false
+        if (pendingEnd.current) finishInteraction()
       })
   }
 
-  const setDragging = (nextDragging: boolean, value: number): void => {
-    if (isDragging.current === nextDragging) return
-    isDragging.current = nextDragging
-    onDragging?.(value)
+  const setDragging = (
+    nextDragging: boolean,
+    value: SliderValue,
+  ): void => {
+    if (interaction.current.dragging === nextDragging) return
+    interaction.current.dragging = nextDragging
+    onDragging?.(cloneSliderValue(value))
   }
 
   const valueFromX = (x: number): number | null => {
@@ -177,7 +355,7 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
   }
 
   const handleMoveX = (x: number): void => {
-    if (disabled) return
+    if (disabled || !interaction.current.pointerActive) return
     if (!Number.isFinite(x)) return
 
     if (!leftMeasured.current || bgWidth.current <= 0) {
@@ -190,20 +368,46 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
   }
 
   const handleInteractionStart = (x: number): void => {
-    if (disabled) return
-    if (!Number.isFinite(x)) return
+    const interactionState = interaction.current
+    const requestedThumbIndex = interactionState.pendingThumbIndex
+    interactionState.pendingThumbIndex = null
 
+    if (disabled || !Number.isFinite(x)) {
+      resetInteraction()
+      return
+    }
+
+    const initialThumbIndex = getInitialSliderThumbIndex(
+      currentValue.current,
+      requestedThumbIndex,
+    )
+    interactionState.pointerActive = true
+    interactionState.activeThumbIndex = initialThumbIndex
+    interactionState.startedCollapsed = isSliderValueCollapsed(
+      currentValue.current,
+    )
+    pendingEnd.current = false
+    setRenderedInteraction({
+      active: true,
+      activeThumbIndex: initialThumbIndex,
+    })
     pendingMoveX.current = x
     leftMeasured.current = false
     measureBounds()
   }
 
   const handleEnd = (): void => {
-    if (!isDragging.current) return
+    interaction.current.pointerActive = false
+    if (
+      pendingMoveX.current !== null
+      && !leftMeasured.current
+      && isMeasuringBounds.current
+    ) {
+      pendingEnd.current = true
+      return
+    }
 
-    const value = currentValue.current
-    setDragging(false, value)
-    onValueCommit?.(value)
+    finishInteraction()
   }
 
   const handleTrackLayoutChange = (event: {
@@ -223,18 +427,20 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
   }
 
   const getMouseX = (event: unknown): number => {
-    const xInTouches = (
-      event as
-        | { touches?: Array<{ clientX?: unknown }> }
-        | null
-        | undefined
-    )?.touches?.[0]?.clientX
+    const xInTouches = Number(
+      (
+        event as
+          | { touches?: Array<{ clientX?: unknown }> }
+          | null
+          | undefined
+      )?.touches?.[0]?.clientX,
+    )
 
     const x = Number(
       (event as { clientX?: unknown } | null | undefined)?.clientX,
     )
 
-    return xInTouches ? Number(xInTouches) : x
+    return Number.isFinite(xInTouches) ? xInTouches : x
   }
 
   const handleMouseX = (event: unknown): void => {
@@ -254,10 +460,17 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
     handleInteractionStart(getTouchX(event))
   }
 
+  const handleThumbInteractionStart = (index: SliderThumbIndex): void => {
+    interaction.current.pendingThumbIndex = index
+  }
+
   useImperativeHandle(
     ref,
     () => ({
-      updateValue: (value: number, options?: SliderUpdateValueOptions) => {
+      updateValue: (
+        value: SliderValue,
+        options?: SliderUpdateValueOptions,
+      ) => {
         if (isControlled) {
           throw new Error(
             'SliderRoot: updateValue() must not be called in controlled mode. Update the `value` prop instead.',
@@ -280,16 +493,23 @@ function SliderRootImpl(props: SliderRootProps, ref: ForwardedRef<SliderRef>) {
   const contextValue = {
     trackRef,
     indicatorRef,
-    thumbRef,
+    thumbRefs,
     currentValue,
+    active,
+    activeThumbIndex: renderedInteraction.activeThumbIndex,
+    disabled,
     enableRTL,
+    onThumbInteractionStart: handleThumbInteractionStart,
     onTrackLayoutChange: handleTrackLayoutChange,
   }
 
   return (
     <SliderContext.Provider value={contextValue}>
       <view
-        className={className}
+        className={clsx(className, {
+          'ui-active': active,
+          'ui-disabled': disabled,
+        })}
         flatten={false}
         style={style}
         // block-native-event={true}

--- a/packages/lynx-ui-slider/src/SliderThumb/index.tsx
+++ b/packages/lynx-ui-slider/src/SliderThumb/index.tsx
@@ -4,26 +4,49 @@
 
 import { memo } from '@lynx-js/react'
 
+import { clsx } from 'clsx'
+
 import { useSliderContext } from '../context'
 import type { SliderThumbProps } from '../types'
-import { getVisualRatio } from '../utils'
+import { getSliderThumbValue, getVisualRatio } from '../utils'
 
 export const SliderThumb = memo(function SliderThumb(props: SliderThumbProps) {
-  const { thumbRef, currentValue, enableRTL } = useSliderContext()
-  const { children, className, style } = props
+  const {
+    thumbRefs,
+    active,
+    activeThumbIndex,
+    currentValue,
+    disabled,
+    enableRTL,
+    onThumbInteractionStart,
+  } = useSliderContext()
+  const { children, className, index = 0, style } = props
+  const value = getSliderThumbValue(currentValue.current, index)
 
   return (
     <view
-      ref={thumbRef}
+      ref={thumbRefs[index]}
       style={{
         position: 'absolute',
         top: '50%',
-        left: `${getVisualRatio(currentValue.current, enableRTL) * 100}%`,
+        left: `${getVisualRatio(value, enableRTL) * 100}%`,
         transform: 'translate(-50%, -50%)',
         zIndex: 1,
       }}
+      bindmousedown={() => {
+        onThumbInteractionStart(index)
+      }}
+      bindtouchstart={() => {
+        onThumbInteractionStart(index)
+      }}
     >
-      <view className={className} style={style}>
+      <view
+        className={clsx(className, {
+          'ui-active': active && activeThumbIndex === index,
+          'ui-disabled': disabled,
+        })}
+        style={style}
+      >
         {children}
       </view>
     </view>

--- a/packages/lynx-ui-slider/src/SliderTrack/index.tsx
+++ b/packages/lynx-ui-slider/src/SliderTrack/index.tsx
@@ -4,11 +4,13 @@
 
 import { memo } from '@lynx-js/react'
 
+import { clsx } from 'clsx'
+
 import { useSliderContext } from '../context'
 import type { SliderTrackProps } from '../types'
 
 export const SliderTrack = memo(function SliderTrack(props: SliderTrackProps) {
-  const { trackRef, onTrackLayoutChange } = useSliderContext()
+  const { active, disabled, trackRef, onTrackLayoutChange } = useSliderContext()
   const { children, className, style } = props
 
   return (
@@ -25,7 +27,13 @@ export const SliderTrack = memo(function SliderTrack(props: SliderTrackProps) {
       }}
       bindlayoutchange={onTrackLayoutChange}
     >
-      <view className={className} style={style} />
+      <view
+        className={clsx(className, {
+          'ui-active': active,
+          'ui-disabled': disabled,
+        })}
+        style={style}
+      />
       {children}
     </view>
   )

--- a/packages/lynx-ui-slider/src/context/index.tsx
+++ b/packages/lynx-ui-slider/src/context/index.tsx
@@ -6,12 +6,22 @@ import { createContext, useContext } from '@lynx-js/react'
 
 import type { NodesRef } from '@lynx-js/types'
 
+import type { SliderThumbIndex, SliderValue } from '../types'
+
+interface SliderNodeRef {
+  current: NodesRef | null
+}
+
 export interface SliderContextValue {
-  trackRef: { current: NodesRef | null }
-  indicatorRef: { current: NodesRef | null }
-  thumbRef: { current: NodesRef | null }
-  currentValue: { current: number }
+  trackRef: SliderNodeRef
+  indicatorRef: SliderNodeRef
+  thumbRefs: readonly [SliderNodeRef, SliderNodeRef]
+  currentValue: { current: SliderValue }
+  active: boolean
+  activeThumbIndex: SliderThumbIndex | null
+  disabled: boolean
   enableRTL: boolean
+  onThumbInteractionStart: (index: SliderThumbIndex) => void
   onTrackLayoutChange: (event: {
     params: { width: number, height: number }
     detail?: { width: number, height: number }

--- a/packages/lynx-ui-slider/src/index.tsx
+++ b/packages/lynx-ui-slider/src/index.tsx
@@ -9,10 +9,14 @@ export { SliderThumb } from './SliderThumb'
 
 export type {
   SliderIndicatorProps,
+  SliderRangeValue,
   SliderRef,
   SliderRootProps,
+  SliderThumbIndex,
   SliderThumbProps,
   SliderTrackProps,
+  SliderUIVariants,
   SliderUpdateValueOptions,
+  SliderValue,
   SliderValueChangeSource,
 } from './types'

--- a/packages/lynx-ui-slider/src/types/index.docs.ts
+++ b/packages/lynx-ui-slider/src/types/index.docs.ts
@@ -20,6 +20,57 @@ import type { ComponentBasicProps } from '@lynx-js/lynx-ui-common'
 export type SliderValueChangeSource = 'external' | 'drag'
 
 /**
+ * Ordered lower and upper values for a range slider. Both values use the normalized `[0, 1]` scale.
+ * During dragging, the lower and upper thumbs may meet, but they never cross,
+ * swap identities, or push one another.
+ * @zh 区间滑块的下限值和上限值。两个值都使用标准化的 `[0, 1]` 范围。
+ * 拖拽时，下限和上限拇指可以相遇，但不会交叉、交换身份或推动彼此。
+ */
+export type SliderRangeValue = readonly [number, number]
+
+/**
+ * Value accepted by `SliderRoot`: either one normalized value or an ordered
+ * lower/upper tuple.
+ * @zh `SliderRoot` 接受的值：单个标准化数值，或有序的下限/上限二元组。
+ */
+export type SliderValue = number | SliderRangeValue
+
+type ResolvedSliderValue<Value extends SliderValue> = Value extends
+  SliderRangeValue ? SliderRangeValue : number
+
+/**
+ * Index of a slider thumb. A single-value slider uses index `0`; a range
+ * slider uses index `0` for the lower value and `1` for the upper value.
+ * @zh 滑块拇指的索引。单值滑块使用索引 `0`；区间滑块使用索引 `0` 表示下限、索引 `1` 表示上限。
+ */
+export type SliderThumbIndex = 0 | 1
+
+/**
+ * UI variants applied by slider primitives based on interaction state.
+ * Use them as CSS selectors to style active and disabled states.
+ * @zh 滑块原语根据交互状态注入的 ui-variants，可用于 CSS selector 定制激活态和禁用态。
+ */
+export interface SliderUIVariants {
+  /**
+   * Applied while the slider is actively being interacted with. On `SliderThumb`, only the active thumb receives this variant.
+   * @zh 滑块处于交互中时生效。在 `SliderThumb` 上，仅当前活动的拇指会获得此状态。
+   * @iOS
+   * @Android
+   * @Harmony
+   */
+  'ui-active'?: boolean
+
+  /**
+   * Applied when the slider is disabled.
+   * @zh 滑块被禁用时生效。
+   * @iOS
+   * @Android
+   * @Harmony
+   */
+  'ui-disabled'?: boolean
+}
+
+/**
  * Options used by `SliderRef.updateValue`.
  * @zh `SliderRef.updateValue` 使用的选项。
  */
@@ -39,47 +90,45 @@ export interface SliderUpdateValueOptions {
 }
 
 /**
- * Imperative methods exposed by `SliderRoot`.
- * @zh `SliderRoot` 暴露的命令式方法。
+ * Imperative methods exposed by `SliderRoot` for the selected value shape.
+ * The generic defaults to `number` for compatibility with existing
+ * single-value refs; use `SliderRef<SliderRangeValue>` for a range slider.
+ * @zh `SliderRoot` 针对所选值形态暴露的命令式方法。泛型默认为 `number`，以兼容现有单值 ref；区间滑块请使用 `SliderRef<SliderRangeValue>`。
  */
-export interface SliderRef {
+export interface SliderRef<in out Value extends SliderValue = number> {
   /**
-   * Imperatively set slider value in range `[0, 1]`.
-   * @zh 命令式地设置滑块值，取值范围 `[0, 1]`。
+   * Imperatively set the slider value. Every number in the selected value
+   * shape uses the normalized range `[0, 1]`.
+   * @docTypeFallback (value: number | SliderRangeValue, options?: SliderUpdateValueOptions) => void
+   * @zh 命令式地设置滑块值。所选值形态中的每个数值都使用标准化范围 `[0, 1]`。
    */
   updateValue: (
-    value: number,
+    value: ResolvedSliderValue<Value>,
     options?: SliderUpdateValueOptions,
   ) => void
   /**
-   * Read current slider value in range `[0, 1]`.
-   * @zh 读取当前滑块值，取值范围 `[0, 1]`。
+   * Read the current slider value using the selected value shape.
+   * @docTypeFallback () => number | SliderRangeValue
+   * @zh 使用所选值形态读取当前滑块值。
    */
-  getValue: () => number
+  getValue: () => ResolvedSliderValue<Value>
 }
 
 /**
- * Root primitive props.
+ * Root primitive props for the selected value shape.
  *
  * `SliderRoot` owns interaction logic (dragging and value tracking)
- * and provides context for child primitives.
+ * and provides context for child primitives. Pass a `number` for a
+ * single-value slider or a `SliderRangeValue` tuple for a range slider. The
+ * generic defaults to `number` for compatibility and is normally inferred
+ * from `value` or `defaultValue`.
+ * @zh 针对所选值形态的根原语组件属性。
  *
- * @zh 根原语组件属性。
- *
- * `SliderRoot` 负责交互逻辑（拖拽、值跟踪）并为子原语组件提供上下文。
+ * `SliderRoot` 负责交互逻辑（拖拽、值跟踪）并为子原语组件提供上下文。传入 `number` 创建单值滑块，传入 `SliderRangeValue` 二元组创建区间滑块。泛型默认为 `number` 以保持兼容，通常可根据 `value` 或 `defaultValue` 自动推断。
  */
-export interface SliderRootProps extends ComponentBasicProps {
-  /**
-   * Controlled value in range `[0, 1]`. When provided, the slider is in controlled mode. Do not use together with `defaultValue`.
-   * @zh 受控模式下的值，范围 `[0, 1]`。传入此属性时滑块为受控模式，请勿与 `defaultValue` 同时使用。
-   */
-  value?: number
-  /**
-   * Initial value for uncontrolled usage.
-   * @defaultValue 0
-   * @zh 非受控模式下的初始值。
-   */
-  defaultValue?: number
+interface SliderRootBaseProps<Value extends SliderValue>
+  extends ComponentBasicProps
+{
   /**
    * Stepping interval in range `[0, 1]`. When set, the value snaps to the nearest multiple of `step`.
    * @zh 步进间隔，范围 `[0, 1]`。设置后值会吸附到最近的 `step` 倍数。
@@ -98,26 +147,93 @@ export interface SliderRootProps extends ComponentBasicProps {
    */
   enableRTL?: boolean
   /**
-   * Triggered when dragging state changes, with the current progress value. The callback fires when dragging starts and when dragging ends.
-   * @zh 拖拽状态变化时触发，传入当前进度值。开始拖拽和结束拖拽时都会触发。
+   * Triggered when dragging state changes, with the current slider value.
+   * The callback fires when dragging starts and when dragging ends.
+   * @docTypeFallback (value: number | SliderRangeValue) => void
+   * @zh 拖拽状态变化时触发，传入当前滑块值。开始拖拽和结束拖拽时都会触发。
    */
-  onDragging?: (value: number) => void
+  onDragging?: (value: ResolvedSliderValue<Value>) => void
   /**
-   * Triggered after slider-driven value updates, including dragging and `SliderRef.updateValue`. In controlled mode, use this callback to keep the external `value` prop in sync with the rendered value.
+   * Triggered after slider-driven value updates, including dragging and
+   * `SliderRef.updateValue`. In controlled mode, use this callback to keep
+   * the external `value` prop in sync with the rendered value.
+   * @docTypeFallback (value: number | SliderRangeValue, source: SliderValueChangeSource) => void
    * @zh 由滑块自身驱动的值更新后触发，包括拖拽和 `SliderRef.updateValue`。在受控模式下，请通过此回调让外部 `value` 属性与渲染值保持同步。
    */
-  onValueChange?: (value: number, source: SliderValueChangeSource) => void
+  onValueChange?: (
+    value: ResolvedSliderValue<Value>,
+    source: SliderValueChangeSource,
+  ) => void
   /**
    * Triggered at the end of a drag interaction with the final value.
+   * @docTypeFallback (value: number | SliderRangeValue) => void
    * @zh 拖拽交互结束时以最终值触发。适用于只需要最终提交值的场景，例如持久化到后端。
    */
-  onValueCommit?: (value: number) => void
+  onValueCommit?: (value: ResolvedSliderValue<Value>) => void
   /**
    * Primitive children composition, usually: `SliderTrack` containing `SliderIndicator` and optional `SliderThumb`.
    * @zh 子原语组件组合，通常为：`SliderTrack` 内包含 `SliderIndicator` 以及可选的 `SliderThumb`。
    */
   children?: ReactNode
 }
+
+type SliderExclusiveValueProps<Value extends SliderValue> =
+  | {
+    value: Value
+    defaultValue?: never
+  }
+  | {
+    value?: never
+    defaultValue: Value
+  }
+
+interface SliderScalarValueProps<Value extends number> {
+  /**
+   * Controlled slider value. Pass a number in `[0, 1]` or an ordered
+   * lower/upper tuple. Do not use together with `defaultValue`.
+   * @docTypeFallback number | SliderRangeValue
+   * @zh 受控滑块值。传入范围 `[0, 1]` 内的数值或有序的下限/上限二元组。请勿与 `defaultValue` 同时使用。
+   */
+  value?: Value
+  /**
+   * Initial value for uncontrolled usage. A single-value slider starts at
+   * `0` when omitted; a range slider must provide a tuple.
+   * @defaultValue 0
+   * @docTypeFallback number | SliderRangeValue
+   * @zh 非受控模式下的初始值。省略时，单值滑块从 `0` 开始；区间滑块必须提供二元组。
+   */
+  defaultValue?: Value
+}
+
+type SliderMixedValueProps<Value extends SliderValue> =
+  | {
+    value?: Extract<Value, number>
+    defaultValue?: Extract<Value, number>
+  }
+  | SliderExclusiveValueProps<Value>
+
+// Keep the pre-range optional scalar pair source-compatible. Range and mixed
+// value shapes stay exclusive so controlled mode is unambiguous.
+type SliderValueProps<Value extends SliderValue> = [Value] extends [number]
+  ? SliderScalarValueProps<Value>
+  : [Value] extends [SliderRangeValue] ? SliderExclusiveValueProps<Value>
+  : SliderMixedValueProps<Value>
+
+/**
+ * Root primitive props for a single-value or range slider. The generic
+ * selects the value shape and defaults to `number` for existing single-value
+ * usage. A range slider must provide its tuple through either `value` or
+ * `defaultValue` so the runtime can determine the shape.
+ * Range-thumb collision behavior is intentionally non-crossing: thumbs may
+ * meet, but the active thumb stops at the other value without swapping or
+ * pushing the other thumb.
+ * @zh 单值或区间滑块的根原语组件属性。泛型用于选择值形态，并默认为 `number` 以兼容现有单值用法。区间滑块必须通过 `value` 或 `defaultValue` 提供二元组，以便运行时确定值形态。
+ * 区间拇指采用明确的禁止交叉策略：两个拇指可以相遇，但活动拇指会停在另一个值处，不会交换身份或推动另一个拇指。
+ * @interface
+ */
+export type SliderRootProps<Value extends SliderValue = number> =
+  & SliderRootBaseProps<Value>
+  & SliderValueProps<Value>
 
 /**
  * Track primitive props.
@@ -139,11 +255,11 @@ export interface SliderTrackProps extends ComponentBasicProps {
 /**
  * Indicator primitive props.
  *
- * `SliderIndicator` is a pure visual layer whose width is controlled by root value.
+ * `SliderIndicator` is a pure visual layer. It fills from zero to the value in single-value mode and spans the selected interval in range mode.
  *
  * @zh 指示条原语组件属性。
  *
- * `SliderIndicator` 是纯视觉层，其宽度由根组件的值控制。
+ * `SliderIndicator` 是纯视觉层。单值模式下从零填充到当前值，区间模式下覆盖选中的区间。
  */
 export interface SliderIndicatorProps extends ComponentBasicProps {}
 
@@ -157,6 +273,17 @@ export interface SliderIndicatorProps extends ComponentBasicProps {}
  * `SliderThumb` 在 `SliderTrack` 内按照当前比例定位，不负责独立交互逻辑。
  */
 export interface SliderThumbProps extends ComponentBasicProps {
+  /**
+   * Value index represented by this thumb. A single-value slider uses the
+   * default index `0`; a range slider uses `0` for the lower thumb and `1`
+   * for the upper thumb.
+   * @defaultValue 0
+   * @zh 此拇指对应的值索引。单值滑块使用默认索引 `0`；区间滑块使用 `0` 表示下限拇指，使用 `1` 表示上限拇指。
+   * @iOS
+   * @Android
+   * @Harmony
+   */
+  index?: SliderThumbIndex
   /**
    * Custom thumb content.
    * @zh 自定义拇指内容。

--- a/packages/lynx-ui-slider/src/utils/index.test.ts
+++ b/packages/lynx-ui-slider/src/utils/index.test.ts
@@ -1,0 +1,312 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, it } from 'vitest'
+
+import type { SliderRangeValue } from '../types'
+
+import {
+  areSliderValuesEqual,
+  clamp01,
+  cloneSliderValue,
+  getClosestSliderThumbIndex,
+  getDraggedSliderThumbIndex,
+  getInitialSliderThumbIndex,
+  getSliderIndicatorGeometry,
+  getSliderThumbValue,
+  getTouchX,
+  getVisualRatio,
+  isSliderRangeValue,
+  isSliderValueCollapsed,
+  normalizeSliderRangeValue,
+  normalizeSliderValue,
+  resolveSliderDrag,
+  snapToStep,
+  updateSliderValue,
+} from '.'
+
+describe('single-value slider utilities', () => {
+  it('clamps finite and non-finite values to the normalized range', () => {
+    expect(clamp01(-0.25)).toBe(0)
+    expect(clamp01(0.4)).toBe(0.4)
+    expect(clamp01(1.25)).toBe(1)
+    expect(clamp01(Number.NaN)).toBe(0)
+    expect(clamp01(Number.POSITIVE_INFINITY)).toBe(0)
+    expect(clamp01(Number.NEGATIVE_INFINITY)).toBe(0)
+  })
+
+  it('resolves visual ratios in LTR and RTL', () => {
+    expect(getVisualRatio(0.2, false)).toBe(0.2)
+    expect(getVisualRatio(0.2, true)).toBe(0.8)
+  })
+
+  it('snaps values while avoiding common floating point artifacts', () => {
+    expect(snapToStep(0.26, 0.1)).toBe(0.3)
+    expect(snapToStep(0.24, 0.1)).toBe(0.2)
+    expect(snapToStep(0.98, 0.25)).toBe(1)
+    expect(snapToStep(0.42, undefined)).toBe(0.42)
+    expect(snapToStep(0.42, 0)).toBe(0.42)
+    expect(snapToStep(0.42, Number.NaN)).toBe(0.42)
+  })
+
+  it('normalizes a scalar by clamping before snapping', () => {
+    expect(normalizeSliderValue(-0.2)).toBe(0)
+    expect(normalizeSliderValue(1.2)).toBe(1)
+    expect(normalizeSliderValue(0.26, 0.1)).toBe(0.3)
+  })
+
+  it('extracts the touch x coordinate and returns NaN when absent', () => {
+    expect(getTouchX({ detail: { x: 0 } })).toBe(0)
+    expect(getTouchX({ detail: { x: '24' } })).toBe(24)
+    expect(getTouchX({ detail: {} })).toBeNaN()
+    expect(getTouchX(null)).toBeNaN()
+  })
+})
+
+describe('range detection and normalization', () => {
+  it('recognizes only two-number tuples', () => {
+    expect(isSliderRangeValue([0.2, 0.8])).toBe(true)
+    expect(isSliderRangeValue([Number.NaN, 0.8])).toBe(true)
+    expect(isSliderRangeValue(0.2)).toBe(false)
+    expect(isSliderRangeValue([0.2])).toBe(false)
+    expect(isSliderRangeValue([0.2, 0.8, 1])).toBe(false)
+    expect(isSliderRangeValue(['0.2', 0.8])).toBe(false)
+  })
+
+  it('clamps, snaps, and orders range endpoints', () => {
+    expect(normalizeSliderRangeValue([-0.2, 1.3])).toEqual([0, 1])
+    expect(normalizeSliderRangeValue([0.83, 0.24])).toEqual([0.24, 0.83])
+    expect(normalizeSliderRangeValue([0.83, 0.24], 0.1)).toEqual([0.2, 0.8])
+    expect(normalizeSliderRangeValue([Number.NaN, 0.8])).toEqual([0, 0.8])
+  })
+
+  it('returns a fresh tuple without modifying the input', () => {
+    const input: SliderRangeValue = [0.8, 0.2]
+    const normalized = normalizeSliderValue(input)
+
+    expect(normalized).toEqual([0.2, 0.8])
+    expect(normalized).not.toBe(input)
+    expect(input).toEqual([0.8, 0.2])
+  })
+
+  it('clones tuples while preserving scalar values', () => {
+    const range: SliderRangeValue = [0.2, 0.8]
+    const clonedRange = cloneSliderValue(range)
+
+    expect(clonedRange).toEqual(range)
+    expect(clonedRange).not.toBe(range)
+    expect(cloneSliderValue(0.4)).toBe(0.4)
+  })
+
+  it('detects collapsed values only for range tuples', () => {
+    expect(isSliderValueCollapsed(0.5)).toBe(false)
+    expect(isSliderValueCollapsed([0.5, 0.5])).toBe(true)
+    expect(isSliderValueCollapsed([0.5, 0.5000000000005])).toBe(true)
+    expect(isSliderValueCollapsed([0.5, 0.500001])).toBe(false)
+  })
+})
+
+describe('range value comparison and thumb access', () => {
+  it('compares scalar values and range values structurally', () => {
+    expect(areSliderValuesEqual(0.4, 0.4)).toBe(true)
+    expect(areSliderValuesEqual(0.4, 0.5)).toBe(false)
+    expect(areSliderValuesEqual([0.2, 0.8], [0.2, 0.8])).toBe(true)
+    expect(areSliderValuesEqual([0.2, 0.8], [0.2, 0.9])).toBe(false)
+    expect(areSliderValuesEqual(0.2, [0.2, 0.8])).toBe(false)
+  })
+
+  it('reads the requested endpoint while scalar mode ignores the index', () => {
+    expect(getSliderThumbValue([0.2, 0.8], 0)).toBe(0.2)
+    expect(getSliderThumbValue([0.2, 0.8], 1)).toBe(0.8)
+    expect(getSliderThumbValue(0.4, 0)).toBe(0.4)
+    expect(getSliderThumbValue(0.4, 1)).toBe(0.4)
+  })
+
+  it('selects the initial thumb from either value shape', () => {
+    expect(getInitialSliderThumbIndex(0.4, null)).toBe(0)
+    expect(getInitialSliderThumbIndex(0.4, 1)).toBe(0)
+    expect(getInitialSliderThumbIndex([0.2, 0.8], null)).toBeNull()
+    expect(getInitialSliderThumbIndex([0.2, 0.8], 1)).toBe(1)
+  })
+})
+
+describe('closest range thumb selection', () => {
+  it('always selects the only scalar thumb', () => {
+    expect(getClosestSliderThumbIndex(0.2, 0.8, 1)).toBe(0)
+  })
+
+  it('selects the endpoint nearest to the target', () => {
+    expect(getClosestSliderThumbIndex([0.2, 0.8], 0.25)).toBe(0)
+    expect(getClosestSliderThumbIndex([0.2, 0.8], 0.75)).toBe(1)
+  })
+
+  it('uses the preferred index for an exact tie', () => {
+    expect(getClosestSliderThumbIndex([0.2, 0.8], 0.5)).toBe(0)
+    expect(getClosestSliderThumbIndex([0.2, 0.8], 0.5, 1)).toBe(1)
+  })
+
+  it('uses direction around a collapsed range before the preferred index', () => {
+    expect(getClosestSliderThumbIndex([0.5, 0.5], 0.4, 1)).toBe(0)
+    expect(getClosestSliderThumbIndex([0.5, 0.5], 0.6, 0)).toBe(1)
+    expect(getClosestSliderThumbIndex([0.5, 0.5], 0.5)).toBe(0)
+    expect(getClosestSliderThumbIndex([0.5, 0.5], 0.5, 1)).toBe(1)
+  })
+
+  it('normalizes reversed ranges before selecting a thumb', () => {
+    expect(getClosestSliderThumbIndex([0.8, 0.2], 0.7)).toBe(1)
+  })
+})
+
+describe('dragged range thumb selection', () => {
+  it('always keeps the only scalar thumb active', () => {
+    expect(getDraggedSliderThumbIndex(0.2, 0.8, 1, 1, true)).toBe(0)
+  })
+
+  it('keeps an active thumb while the range is expanded', () => {
+    expect(getDraggedSliderThumbIndex([0.2, 0.8], 0.3, 1)).toBe(1)
+    expect(getDraggedSliderThumbIndex([0.2, 0.8], 0.7, 0)).toBe(0)
+  })
+
+  it('uses drag direction to reopen a collapsed range', () => {
+    expect(getDraggedSliderThumbIndex([0.5, 0.5], 0.4, 1, 1, true)).toBe(0)
+    expect(getDraggedSliderThumbIndex([0.5, 0.5], 0.6, 0, 0, true)).toBe(1)
+    expect(
+      getDraggedSliderThumbIndex(
+        [0.5, 0.5000000000005],
+        0.4,
+        1,
+        1,
+        true,
+      ),
+    ).toBe(0)
+  })
+
+  it('does not switch thumbs when an expanded drag collapses the range', () => {
+    expect(getDraggedSliderThumbIndex([0.5, 0.5], 0.7, 0, 0)).toBe(0)
+    expect(getDraggedSliderThumbIndex([0.5, 0.5], 0.3, 1, 1)).toBe(1)
+  })
+
+  it('keeps the active thumb at the exact collapsed value', () => {
+    expect(getDraggedSliderThumbIndex([0.5, 0.5], 0.5, 1)).toBe(1)
+    expect(
+      getDraggedSliderThumbIndex(
+        [0.5, 0.5000000000005],
+        0.5000000000004,
+        1,
+      ),
+    ).toBe(1)
+  })
+})
+
+describe('slider value updates', () => {
+  it('updates and normalizes a scalar value', () => {
+    expect(updateSliderValue(0.2, 0, 0.63, 0.1)).toBe(0.6)
+    expect(updateSliderValue(0.2, 0, 2)).toBe(1)
+  })
+
+  it('updates either endpoint without mutating the input', () => {
+    const input: SliderRangeValue = [0.2, 0.8]
+
+    expect(updateSliderValue(input, 0, 0.3)).toEqual([0.3, 0.8])
+    expect(updateSliderValue(input, 1, 0.7)).toEqual([0.2, 0.7])
+    expect(input).toEqual([0.2, 0.8])
+  })
+
+  it('prevents thumbs from crossing while allowing them to meet', () => {
+    expect(updateSliderValue([0.2, 0.8], 0, 0.9)).toEqual([0.8, 0.8])
+    expect(updateSliderValue([0.2, 0.8], 1, 0.1)).toEqual([0.2, 0.2])
+    expect(updateSliderValue([0.2, 0.8], 0, 0.8)).toEqual([0.8, 0.8])
+    expect(updateSliderValue([0.2, 0.8], 1, 0.2)).toEqual([0.2, 0.2])
+  })
+
+  it('clamps and snaps the updated endpoint', () => {
+    expect(updateSliderValue([0.2, 0.8], 0, -1, 0.1)).toEqual([0, 0.8])
+    expect(updateSliderValue([0.2, 0.8], 1, 2, 0.1)).toEqual([0.2, 1])
+    expect(updateSliderValue([0.2, 0.8], 0, 0.26, 0.1)).toEqual([
+      0.3,
+      0.8,
+    ])
+  })
+
+  it('normalizes a reversed input before applying the update', () => {
+    expect(updateSliderValue([0.8, 0.2], 0, 0.3)).toEqual([0.3, 0.8])
+  })
+})
+
+describe('slider drag resolution', () => {
+  it('does not swap or push thumbs when they collide', () => {
+    expect(
+      resolveSliderDrag([0.2, 0.8], 0.9, { activeThumbIndex: 0 }),
+    ).toMatchObject({
+      value: [0.8, 0.8],
+      activeThumbIndex: 0,
+    })
+    expect(
+      resolveSliderDrag([0.2, 0.8], 0.1, { activeThumbIndex: 1 }),
+    ).toMatchObject({
+      value: [0.2, 0.2],
+      activeThumbIndex: 1,
+    })
+  })
+
+  it('resolves scalar and range values through the same contract', () => {
+    expect(resolveSliderDrag(0.2, 0.63, { step: 0.1 })).toEqual({
+      value: 0.6,
+      dragStartValue: 0.63,
+      activeThumbIndex: 0,
+      startedCollapsed: false,
+    })
+    expect(resolveSliderDrag([0.2, 0.8], 0.7)).toEqual({
+      value: [0.2, 0.7],
+      dragStartValue: [0.2, 0.7],
+      activeThumbIndex: 1,
+      startedCollapsed: false,
+    })
+  })
+
+  it('tracks whether an initially collapsed range can still change direction', () => {
+    expect(
+      resolveSliderDrag([0.5, 0.5], 0.5, { startedCollapsed: true }),
+    ).toEqual({
+      value: [0.5, 0.5],
+      dragStartValue: [0.5, 0.5],
+      activeThumbIndex: 0,
+      startedCollapsed: true,
+    })
+    expect(
+      resolveSliderDrag([0.5, 0.5], 0.7, { startedCollapsed: true }),
+    ).toEqual({
+      value: [0.5, 0.7],
+      dragStartValue: [0.5, 0.7],
+      activeThumbIndex: 1,
+      startedCollapsed: false,
+    })
+  })
+})
+
+describe('indicator geometry', () => {
+  it('starts scalar indicators at zero', () => {
+    expect(getSliderIndicatorGeometry(0.4)).toEqual({ offset: 0, size: 0.4 })
+    expect(getSliderIndicatorGeometry(2)).toEqual({ offset: 0, size: 1 })
+  })
+
+  it('uses the lower endpoint and range span', () => {
+    expect(getSliderIndicatorGeometry([0.2, 0.8])).toEqual({
+      offset: 0.2,
+      size: 0.6,
+    })
+    expect(getSliderIndicatorGeometry([0.8, 0.2])).toEqual({
+      offset: 0.2,
+      size: 0.6,
+    })
+    expect(getSliderIndicatorGeometry([0.5, 0.5])).toEqual({
+      offset: 0.5,
+      size: 0,
+    })
+    expect(getSliderIndicatorGeometry([-1, 2])).toEqual({
+      offset: 0,
+      size: 1,
+    })
+  })
+})

--- a/packages/lynx-ui-slider/src/utils/index.ts
+++ b/packages/lynx-ui-slider/src/utils/index.ts
@@ -2,6 +2,29 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import type { SliderRangeValue, SliderThumbIndex, SliderValue } from '../types'
+
+export interface SliderIndicatorGeometry {
+  offset: number
+  size: number
+}
+
+export interface SliderDragResolution<Value extends SliderValue = SliderValue> {
+  value: Value
+  dragStartValue: Value
+  activeThumbIndex: SliderThumbIndex
+  startedCollapsed: boolean
+}
+
+export interface SliderDragOptions {
+  activeThumbIndex?: SliderThumbIndex
+  preferredThumbIndex?: SliderThumbIndex
+  startedCollapsed?: boolean
+  step?: number
+}
+
+const SLIDER_VALUE_EPSILON = 1e-12
+
 export const clamp01 = (value: number): number => {
   if (!Number.isFinite(value)) return 0
   return Math.min(Math.max(value, 0), 1)
@@ -12,10 +35,246 @@ export const getVisualRatio = (value: number, enableRTL: boolean): number => {
 }
 
 export const snapToStep = (value: number, step: number | undefined): number => {
-  if (step === undefined || step <= 0) return value
+  if (step === undefined || !Number.isFinite(step) || step <= 0) return value
   const snapped = Math.round(value / step) * step
   const decimalCount = (step.toString().split('.')[1] || '').length
   return clamp01(Number.parseFloat(snapped.toFixed(decimalCount)))
+}
+
+export const isSliderRangeValue = (
+  value: unknown,
+): value is SliderRangeValue => {
+  return Array.isArray(value)
+    && value.length === 2
+    && typeof value[0] === 'number'
+    && typeof value[1] === 'number'
+}
+
+export const cloneSliderValue = <Value extends SliderValue>(
+  value: Value,
+): Value => {
+  return (isSliderRangeValue(value) ? [value[0], value[1]] : value) as Value
+}
+
+export const normalizeSliderRangeValue = (
+  value: SliderRangeValue,
+  step?: number,
+): SliderRangeValue => {
+  const first = snapToStep(clamp01(value[0]), step)
+  const second = snapToStep(clamp01(value[1]), step)
+
+  return first <= second ? [first, second] : [second, first]
+}
+
+export const isSliderValueCollapsed = (value: SliderValue): boolean => {
+  if (!isSliderRangeValue(value)) return false
+
+  const [lower, upper] = normalizeSliderRangeValue(value)
+  return Math.abs(upper - lower) <= SLIDER_VALUE_EPSILON
+}
+
+export function normalizeSliderValue(value: number, step?: number): number
+export function normalizeSliderValue(
+  value: SliderRangeValue,
+  step?: number,
+): SliderRangeValue
+export function normalizeSliderValue(
+  value: SliderValue,
+  step?: number,
+): SliderValue
+export function normalizeSliderValue(
+  value: SliderValue,
+  step?: number,
+): SliderValue {
+  if (isSliderRangeValue(value)) {
+    return normalizeSliderRangeValue(value, step)
+  }
+
+  return snapToStep(clamp01(value), step)
+}
+
+export const areSliderValuesEqual = (
+  first: SliderValue,
+  second: SliderValue,
+): boolean => {
+  const firstIsRange = isSliderRangeValue(first)
+  const secondIsRange = isSliderRangeValue(second)
+
+  if (firstIsRange !== secondIsRange) return false
+  if (!firstIsRange || !secondIsRange) return first === second
+
+  return first[0] === second[0] && first[1] === second[1]
+}
+
+export const getSliderThumbValue = (
+  value: SliderValue,
+  index: SliderThumbIndex = 0,
+): number => {
+  return isSliderRangeValue(value) ? value[index] : value
+}
+
+export const getInitialSliderThumbIndex = (
+  value: SliderValue,
+  requestedIndex: SliderThumbIndex | null,
+): SliderThumbIndex | null => {
+  if (!isSliderRangeValue(value)) return 0
+  return requestedIndex
+}
+
+export const getClosestSliderThumbIndex = (
+  value: SliderValue,
+  targetValue: number,
+  preferredIndex?: SliderThumbIndex,
+): SliderThumbIndex => {
+  if (!isSliderRangeValue(value)) return 0
+
+  const [lower, upper] = normalizeSliderRangeValue(value)
+  const target = clamp01(targetValue)
+
+  if (lower === upper) {
+    if (target < lower) return 0
+    if (target > upper) return 1
+    return preferredIndex ?? 0
+  }
+
+  const lowerDistance = Math.abs(target - lower)
+  const upperDistance = Math.abs(target - upper)
+
+  if (Math.abs(lowerDistance - upperDistance) <= SLIDER_VALUE_EPSILON) {
+    return preferredIndex ?? 0
+  }
+  if (lowerDistance < upperDistance) return 0
+  return 1
+}
+
+export const getDraggedSliderThumbIndex = (
+  value: SliderValue,
+  targetValue: number,
+  activeIndex?: SliderThumbIndex,
+  preferredIndex?: SliderThumbIndex,
+  allowCollapsedDirectionChange = false,
+): SliderThumbIndex => {
+  if (!isSliderRangeValue(value)) return 0
+
+  const [lower, upper] = normalizeSliderRangeValue(value)
+  const target = clamp01(targetValue)
+  const movedAway = Math.abs(target - lower) > SLIDER_VALUE_EPSILON
+
+  if (
+    allowCollapsedDirectionChange
+    && isSliderValueCollapsed([lower, upper])
+    && movedAway
+  ) {
+    return target < lower ? 0 : 1
+  }
+
+  return activeIndex
+    ?? getClosestSliderThumbIndex(value, target, preferredIndex)
+}
+
+export function updateSliderValue(
+  value: number,
+  index: SliderThumbIndex,
+  nextValue: number,
+  step?: number,
+): number
+export function updateSliderValue(
+  value: SliderRangeValue,
+  index: SliderThumbIndex,
+  nextValue: number,
+  step?: number,
+): SliderRangeValue
+export function updateSliderValue(
+  value: SliderValue,
+  index: SliderThumbIndex,
+  nextValue: number,
+  step?: number,
+): SliderValue
+export function updateSliderValue(
+  value: SliderValue,
+  index: SliderThumbIndex,
+  nextValue: number,
+  step?: number,
+): SliderValue {
+  if (!isSliderRangeValue(value)) {
+    return normalizeSliderValue(nextValue, step)
+  }
+
+  const [lower, upper] = normalizeSliderRangeValue(value, step)
+  const next = snapToStep(clamp01(nextValue), step)
+
+  // Keep lower/upper thumb identity stable. The active thumb may meet the
+  // other thumb, but it never crosses, swaps with, or pushes that thumb.
+  if (index === 0) {
+    return [Math.min(next, upper), upper]
+  }
+
+  return [lower, Math.max(next, lower)]
+}
+
+export function resolveSliderDrag(
+  value: number,
+  targetValue: number,
+  options?: SliderDragOptions,
+): SliderDragResolution<number>
+export function resolveSliderDrag(
+  value: SliderRangeValue,
+  targetValue: number,
+  options?: SliderDragOptions,
+): SliderDragResolution<SliderRangeValue>
+export function resolveSliderDrag(
+  value: SliderValue,
+  targetValue: number,
+  options?: SliderDragOptions,
+): SliderDragResolution
+export function resolveSliderDrag(
+  value: SliderValue,
+  targetValue: number,
+  options: SliderDragOptions = {},
+): SliderDragResolution {
+  const activeThumbIndex = getDraggedSliderThumbIndex(
+    value,
+    targetValue,
+    options.activeThumbIndex,
+    options.preferredThumbIndex,
+    options.startedCollapsed,
+  )
+  const nextValue = updateSliderValue(
+    value,
+    activeThumbIndex,
+    targetValue,
+    options.step,
+  )
+
+  return {
+    value: nextValue,
+    // Preserve the single-value callback contract from before range support:
+    // drag start reports pointer progress before step snapping.
+    dragStartValue: isSliderRangeValue(nextValue)
+      ? nextValue
+      : clamp01(targetValue),
+    activeThumbIndex,
+    startedCollapsed: isSliderRangeValue(nextValue)
+      && isSliderValueCollapsed(nextValue)
+      && options.startedCollapsed === true,
+  }
+}
+
+export const getSliderIndicatorGeometry = (
+  value: SliderValue,
+): SliderIndicatorGeometry => {
+  if (isSliderRangeValue(value)) {
+    const [lower, upper] = normalizeSliderRangeValue(value)
+    return {
+      offset: lower,
+      size: Number.parseFloat((upper - lower).toFixed(12)),
+    }
+  }
+
+  return {
+    offset: 0,
+    size: clamp01(value),
+  }
 }
 
 export const getTouchX = (event: unknown): number => {

--- a/packages/lynx-ui-slider/vitest.config.ts
+++ b/packages/lynx-ui-slider/vitest.config.ts
@@ -1,0 +1,13 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from 'vitest/config'
+
+const config = defineConfig({
+  test: {
+    name: 'lynx-ui-slider',
+  },
+})
+
+export default config

--- a/packages/lynx-ui/src/index.tsx
+++ b/packages/lynx-ui/src/index.tsx
@@ -284,11 +284,15 @@ export {
 } from '@lynx-js/lynx-ui-slider'
 export type {
   SliderIndicatorProps,
+  SliderRangeValue,
   SliderRef,
   SliderRootProps,
+  SliderThumbIndex,
   SliderThumbProps,
   SliderTrackProps,
+  SliderUIVariants,
   SliderUpdateValueOptions,
+  SliderValue,
   SliderValueChangeSource,
 } from '@lynx-js/lynx-ui-slider'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1863,6 +1863,9 @@ importers:
       '@lynx-js/lynx-ui-common':
         specifier: workspace:*
         version: link:../lynx-ui-common
+      clsx:
+        specifier: 'catalog:'
+        version: 2.1.1
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'

--- a/tools/typedoc/index.ts
+++ b/tools/typedoc/index.ts
@@ -70,6 +70,13 @@ const primitivesConfig: Record<string, string[]> = {
   ],
   'lynx-ui-slider': [
     'SliderRoot',
+    'Slider',
+    'SliderRangeValue',
+    'SliderValue',
+    'SliderThumbIndex',
+    'SliderValueChangeSource',
+    'SliderUpdateValueOptions',
+    'SliderUIVariants',
     'SliderTrack',
     'SliderIndicator',
     'SliderThumb',

--- a/tools/typedoc/tpl-data.ts
+++ b/tools/typedoc/tpl-data.ts
@@ -20,7 +20,9 @@
 import * as fs from 'node:fs'
 import path from 'node:path'
 
-const doGetTagContent = tagObject => {
+import { ReflectionKind } from 'typedoc'
+
+const doGetTagContent = (tagObject: any): any[] => {
   return Array.isArray(tagObject?.content) ? tagObject.content : []
 }
 interface TypeDocJson {
@@ -328,7 +330,11 @@ const doCalcReflectionType = (
   }
 }
 
-const doTypeCalc = (t: any, isZhContext: boolean, currentPkgName?: string) => {
+const doTypeCalc = (
+  t: any,
+  isZhContext: boolean,
+  currentPkgName?: string,
+): any => {
   try {
     const { type, name, types, declaration } = t
 
@@ -340,6 +346,16 @@ const doTypeCalc = (t: any, isZhContext: boolean, currentPkgName?: string) => {
       }
       case 'array':
         return `${t.elementType.name}[]`
+      case 'tuple':
+        return `[${
+          t.elements.map((element: any) =>
+            doTypeCalc(element, isZhContext, currentPkgName)
+          ).join(', ')
+        }]`
+      case 'typeOperator':
+        return `${t.operator} ${
+          doTypeCalc(t.target, isZhContext, currentPkgName)
+        }`
       case 'templateLiteral':
         return t.head + t.tail?.map((ti: any) => ti?.[1]).join(',')
       case 'union':
@@ -430,10 +446,14 @@ const doMoreForItem = (item: any, currentPkgName?: string) => {
     'tag',
     '@docTypeFallback',
   )
+  const fallbackType = doGetTagContent(docTypeFallback)
+    .map((content: any) => content?.text ?? '')
+    .join('')
+    .trim()
 
   return {
     name,
-    type: doTypeCalc(type, false, currentPkgName),
+    type: fallbackType || doTypeCalc(type, false, currentPkgName),
     summary,
     summary_zh,
     defaultValue: doDefaultValueCalc(defaultValue),
@@ -531,6 +551,9 @@ const doGenDocData = async (
               title: ra.name,
               flag: rootFlag + '##',
               comment: ra.comment,
+              typeAlias: ra.kind === ReflectionKind.TypeAlias
+                ? doMoreForItem(ra, currentPkgName)
+                : undefined,
               children: doGetChildren(
                 ra.groups as {
                   title: string

--- a/tools/typedoc/tpl.ts
+++ b/tools/typedoc/tpl.ts
@@ -444,15 +444,16 @@ function genProps(data: any, hasMultipleProps?: boolean, isZh?: boolean) {
 
   let context = ''
 
-  if (!children) return ''
+  if (!children?.length) return ''
 
   context = `
 ${
     hasMultipleProps
-      ? `### ${title.replace(/props$/i, '').trim()} `
+      ? `### ${title.replace(/props$/i, '').trim()}`
       : `## ${title}`
   }
-    ${comments ? comments : ''}
+
+${comments ?? ''}
   `
   children.map((d: any) => {
     const rawItems = Array.isArray(d.children) ? d.children : []
@@ -503,19 +504,34 @@ ${classRenderPropPreamble}
   return context
 }
 
-function genRef(data: any) {
+function genRef(data: any, isZh?: boolean) {
   const title = data.title
   const children = data.children
+  const comments = getCommentText(data.comment, isZh)
 
-  if (!children) return ''
+  if (!children?.length) return ''
 
-  return children.map((d: any) => {
+  return children.map((d: any, index: number) => {
     const sourceString = JSON.stringify(d.children, null, 2)
     return `
 ## ${title}
+
+${index === 0 ? comments ?? '' : ''}
+
 <UIApiTable source={${sourceString}}/>
   `
   }).join('\n')
+}
+
+function genTypeAlias(data: any) {
+  if (!data.typeAlias) return ''
+
+  const sourceString = JSON.stringify([data.typeAlias], null, 2)
+  return `
+### ${data.title}
+
+<UIApiTable source={${sourceString}}/>
+  `
 }
 
 const doGenMdx = (data: any, isZh?: boolean) => {
@@ -569,6 +585,10 @@ const doGenTplWithData = async (
     if (b.title.includes('Ref')) return -1
 
     const getOrderIndex = (name: string) => {
+      const normalizedName = name.replace(/(?:Props|Ref)$/, '')
+      const exactIndex = titleOrder.indexOf(normalizedName)
+      if (exactIndex !== -1) return exactIndex
+
       const index = titleOrder.findIndex(item => name.includes(item))
       return index === -1 ? titleOrder.length : index
     }
@@ -647,14 +667,21 @@ const doGenTplWithData = async (
   ${
       sortedData.map((item: any) => {
         if (renderPropsTitlesToSkip.has(item.title)) return ''
-        if (!titleOrder.includes(item.title.replace(/(Props|Ref)$/, ''))) {
+        if (!titleOrder.includes(item.title.replace(/(?:Props|Ref)$/, ''))) {
           return
         }
-        if (item.title.includes('Props')) {
-          return genProps(item, multipleProps, isZh)
-        }
         if (item.title.includes('Ref')) {
-          return genRef(item)
+          return genRef(item, isZh)
+        }
+        if (item.typeAlias) {
+          return genTypeAlias(item)
+        }
+        if (
+          item.title.includes('Props')
+          || item.title.endsWith('UIVariants')
+          || item.children?.length
+        ) {
+          return genProps(item, multipleProps, isZh)
         }
         return
       }).join('\n')
@@ -674,7 +701,10 @@ const doGenTplWithData = async (
           return doGenMdx([item], isZh)
         }
         if (item.title.includes('Ref')) {
-          return genRef(item)
+          return genRef(item, isZh)
+        }
+        if (item.typeAlias) {
+          return genTypeAlias(item)
         }
         return doGenMdx([item], isZh)
       }).join('\n')
@@ -692,7 +722,8 @@ const doGenTplWithData = async (
     )
   }
 
-  fs.writeFileSync(savePath, content)
+  const normalizedContent = content.replace(/[ \t]+$/gm, '').trimEnd()
+  fs.writeFileSync(savePath, `${normalizedContent}\n`)
 }
 
 export { doGenTplWithData }


### PR DESCRIPTION
## Summary

- extend `SliderRoot` with controlled and uncontrolled two-thumb range values, indexed thumbs, step snapping, RTL support, non-crossing drag behavior, and collapsed-range reopening
- model single and range values as equal variants of one generic API: `SliderValue`, `SliderRootProps<Value>`, and `SliderRef<Value>`; existing unannotated usage still defaults to `number`
- expose the unified value model from both slider and aggregate packages, including interaction UI variants
- add the LUNA-themed `SliderPriceRange` example plus API docs, skill guidance, changesets, and scalar/range utility coverage
- keep single-thumb drag callbacks and runtime behavior compatible while sharing the same interaction pipeline with range values

## Testing

- `pnpm tsx tools/typedoc/index.ts lynx-ui-slider`
- `pnpm turbo build --summarize` (57/57 tasks)
- `pnpm exec vitest run` (17 files, 119/119 tests)
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm check:all`
- `pnpm check:package-types` (23 packages with Bundler and NodeNext)
- `pnpm exec tsc -p apps/examples/Slider/tsconfig.json --noEmit`
- `pnpm check:skills-references`
- `pnpm check:skills-eval-definitions`
- manually verified single-thumb and range dragging on Web and a lynx-sandbox Android device
- manually verified controlled range updates, collapse, and reopening on the sandbox device


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Support controlled and uncontrolled two-thumb range selection in `SliderRoot`.
- Implement indexed thumbs, step snapping, RTL positioning, collapsed-range reopening, and non-crossing drag behavior.
- Unify scalar and range APIs through generic `SliderValue`, `SliderRootProps<Value>`, and `SliderRef<Value>` contracts.
- Export slider value, thumb index, and UI variant types from `lynx-ui-slider` and aggregate `lynx-ui` packages.
- Apply `ui-active` and `ui-disabled` interaction variants to slider primitives.
- Add the LUNA-themed `SliderPriceRange` example with vehicle presets.
- Document range APIs in API, skill, README, and generated documentation.
- Extend slider utilities with normalization, validation, thumb selection, updates, drag resolution, and indicator geometry.
- Configure Vitest utility coverage and TypeDoc generation for the new APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->