### PR TITLE
feat(feed-list): add native refresh mode

### DIFF
--- a/.changeset/native-feed-list-refresh.md
+++ b/.changeset/native-feed-list-refresh.md
@@ -1,0 +1,6 @@
+---
+'@lynx-js/lynx-ui-feed-list': minor
+'@lynx-example/lynx-ui-feed-list': patch
+---
+
+Add a `refreshOptions.mode: 'native'` option that implements FeedList pull-to-refresh with the native `<refresh>` element while preserving refresh callbacks and imperative methods.

--- a/apps/examples/FeedList/Refresh/index.tsx
+++ b/apps/examples/FeedList/Refresh/index.tsx
@@ -72,6 +72,7 @@ function App() {
         scrollOrientation='vertical'
         refreshOptions={{
           enableRefresh: true,
+          mode: 'native',
           headerContent: refreshHeader,
           onStartRefresh: handleStartRefresh,
         }}

--- a/packages/lynx-ui-feed-list/SKILL.md
+++ b/packages/lynx-ui-feed-list/SKILL.md
@@ -8,6 +8,7 @@ Note: Use `FeedList` only when you need pull-to-refresh and load-more behaviors.
 
 - **High-Performance Virtual List**: Inherits all the performance features of `List`, including virtual scrolling and multi-layout support (`single`, `flow`, `waterfall`).
 - **Pull-to-Refresh**: Enable via `refreshOptions`, supports custom refresh headers.
+- **Native Pull-to-Refresh**: Set `refreshOptions.mode` to `'native'` to use the native `<refresh>` element while keeping the same callbacks and ref methods.
 - **Load More**: Use `onScrollToLower`, `loadMoreFooter`, and `noMoreDataFooter` to implement pagination states.
 - **Gesture Coordination**: Coordinate gestures with parent containers (like `Popup`) via `main-thread:gesture`.
 
@@ -42,7 +43,12 @@ function BasicFeedList() {
       ref={feedListRef}
       listId='my-feed-list'
       listType='single'
-      refreshOptions={{ onRefresh: handleRefresh }}
+      refreshOptions={{
+        enableRefresh: true,
+        mode: 'native',
+        headerContent: <text>Refreshing…</text>,
+        onStartRefresh: handleRefresh,
+      }}
       onScrollToLower={handleLoadMore}
       style={{ width: '100%', height: '500px' }}
     >
@@ -183,6 +189,29 @@ function FooterStateExample() {
   )
 }
 ```
+
+### Selecting the Refresh Implementation
+
+`FeedList` uses `useRefreshAndBounce` by default. Set `refreshOptions.mode` to `'native'` when a vertical list should use the platform-native `<refresh>` element instead. The `startRefresh()` and `finishRefresh()` ref methods and the callbacks in `refreshOptions` work in both modes.
+
+```tsx
+<FeedList
+  ref={listRef}
+  listId='native-refresh-feed'
+  listType='single'
+  scrollOrientation='vertical'
+  refreshOptions={{
+    enableRefresh: true,
+    mode: 'native',
+    headerContent: <RefreshHeader />,
+    onStartRefresh,
+  }}
+>
+  {/* ... list-items ... */}
+</FeedList>
+```
+
+Do not set `mode: 'native'` for horizontal lists. Keep the default hook-based mode when custom `bounceableOptions` must coordinate upper-edge bouncing with refresh gestures.
 
 ### 4. FAQ
 

--- a/packages/lynx-ui-feed-list/docs/APIReference.mdx
+++ b/packages/lynx-ui-feed-list/docs/APIReference.mdx
@@ -619,13 +619,45 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "summary": [
       {
         "kind": "text",
-        "text": "Accept true for default options. If you need to customize the refresh effect, you can pass in the RefreshProps."
+        "text": "Accept true for default options. Pass "
+      },
+      {
+        "kind": "code",
+        "text": "`RefreshProps`"
+      },
+      {
+        "kind": "text",
+        "text": " to customize the refresh effect or select the native implementation with "
+      },
+      {
+        "kind": "code",
+        "text": "`mode: 'native'`"
+      },
+      {
+        "kind": "text",
+        "text": "."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "接受true为默认选项。如果需要自定义刷新效果，可以传入RefreshProps。"
+        "text": "接受 true 使用默认选项。传入 "
+      },
+      {
+        "kind": "code",
+        "text": "`RefreshProps`"
+      },
+      {
+        "kind": "text",
+        "text": " 可以自定义刷新效果，或通过 "
+      },
+      {
+        "kind": "code",
+        "text": "`mode: 'native'`"
+      },
+      {
+        "kind": "text",
+        "text": " 选择原生刷新实现。"
       }
     ],
     "defaultValue": "false",
@@ -1683,5 +1715,4 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "docTypeFallback": null
   }
 ]}/>
-  
-  
+

--- a/packages/lynx-ui-feed-list/src/hooks/useRefresh.ts
+++ b/packages/lynx-ui-feed-list/src/hooks/useRefresh.ts
@@ -51,6 +51,13 @@ export interface BounceableBasicProps {
 
 export interface RefreshProps {
   enableRefresh: boolean
+  /**
+   * Select the pull-to-refresh implementation. `hook` uses
+   * `useRefreshAndBounce`; `native` uses the platform `<refresh>` element.
+   * Native mode only supports vertical lists.
+   * @defaultValue 'hook'
+   */
+  mode?: 'hook' | 'native'
   // biome-ignore lint/suspicious/noExplicitAny: expected
   headerContent: any
   validAnimationVersion?: boolean

--- a/packages/lynx-ui-feed-list/src/index.tsx
+++ b/packages/lynx-ui-feed-list/src/index.tsx
@@ -1,6 +1,7 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+// cspell:ignore bindheaderoffset bindheaderreleased bindrefreshstatechange bindstartrefresh scrollchild
 
 import type { ForwardedRef, ReactElement } from '@lynx-js/react'
 import {
@@ -14,6 +15,12 @@ import {
 
 import { List } from '@lynx-js/lynx-ui-list'
 import type { ListRef } from '@lynx-js/lynx-ui-list'
+import type {
+  LayoutChangeEvent,
+  RefreshHeaderOffsetEvent,
+  RefreshStartRefreshEvent,
+  RefreshStateChangeEvent,
+} from '@lynx-js/types'
 
 import { useRefreshAndBounce as useRefreshAndBounceInternal } from './hooks/useRefresh'
 import type {
@@ -63,6 +70,8 @@ function FeedListImpl(props: FeedListProps, ref: ForwardedRef<FeedListRef>) {
   } = props
   const [hasMoreData, setHasMoreData] = useState(true)
   const baseListRef = useRef<ListRef>(null)
+  const nativeRefreshHeaderSizeRef = useRef(0)
+  const nativeRefreshOffsetRef = useRef(0)
   let refreshProps: RefreshProps = {
     enableRefresh: false,
     headerContent: null,
@@ -83,6 +92,8 @@ function FeedListImpl(props: FeedListProps, ref: ForwardedRef<FeedListRef>) {
     ;({ enableRefresh } = refreshOptions)
     refreshProps = refreshOptions
   }
+  const enableNativeRefresh = enableRefresh && refreshProps.mode === 'native'
+  const enableHookRefresh = enableRefresh && refreshProps.mode !== 'native'
 
   // Initialize bounceableProps
   let enableBounce = false
@@ -100,20 +111,22 @@ function FeedListImpl(props: FeedListProps, ref: ForwardedRef<FeedListRef>) {
   }
 
   const useRefreshAndBounceProps: useRefreshAndBounceReturnInternal | null =
-    enableBounce || enableRefresh
+    enableBounce || enableHookRefresh
       // biome-ignore lint/correctness/useHookAtTopLevel: expected
       ? useRefreshAndBounceInternal({
         bounceableOptions: bounceableProps,
         debugLog,
         enableRTL,
-        refreshOptions: refreshProps,
+        refreshOptions: enableNativeRefresh
+          ? { ...refreshProps, enableRefresh: false }
+          : refreshProps,
         id: listId,
         scrollOrientation: scrollOrientation,
       })
       : null
   // @ts-expect-error error
   let refreshHeader: ReactElement = null
-  if (enableRefresh) {
+  if (enableHookRefresh) {
     refreshHeader = (
       <view
         id={`${listId}-refreshHeaderWrapper`}
@@ -171,7 +184,7 @@ function FeedListImpl(props: FeedListProps, ref: ForwardedRef<FeedListRef>) {
     (enableBounce
       && (bounceableProps.singleSidedBounce === 'upper'
         || bounceableProps.singleSidedBounce === 'both'))
-    || enableRefresh
+    || enableHookRefresh
   ) {
     upperExposureView = (
       <list-item item-key='upperExposureView' key='upperExposureView' full-span>
@@ -208,9 +221,24 @@ function FeedListImpl(props: FeedListProps, ref: ForwardedRef<FeedListRef>) {
       </list-item>
     )
   }
+  const invokeNativeRefreshMethod = (
+    method: 'autoStartRefresh' | 'finishRefresh',
+  ) => {
+    'background only'
+    lynx
+      .createSelectorQuery()
+      .select(`#${listId}-refreshView`)
+      .invoke({ method })
+      .exec()
+  }
   const finishRefresh = () => {
+    'background only'
+    if (enableNativeRefresh) {
+      invokeNativeRefreshMethod('finishRefresh')
+      return
+    }
     if (
-      enableRefresh
+      enableHookRefresh
       && useRefreshAndBounceProps
       && useRefreshAndBounceProps.finishRefresh
     ) {
@@ -220,7 +248,7 @@ function FeedListImpl(props: FeedListProps, ref: ForwardedRef<FeedListRef>) {
   const startRefreshMainThreadMethod = () => {
     'main thread'
     if (
-      enableRefresh
+      enableHookRefresh
       && useRefreshAndBounceProps
       && useRefreshAndBounceProps.startRefreshMethod
     ) {
@@ -229,7 +257,58 @@ function FeedListImpl(props: FeedListProps, ref: ForwardedRef<FeedListRef>) {
   }
 
   const startRefresh = () => {
+    'background only'
+    if (enableNativeRefresh) {
+      invokeNativeRefreshMethod('autoStartRefresh')
+      return
+    }
     void runOnMainThread(startRefreshMainThreadMethod)()
+  }
+
+  const handleNativeRefreshHeaderLayout = (event: LayoutChangeEvent) => {
+    'background only'
+    nativeRefreshHeaderSizeRef.current = event.detail.height
+  }
+
+  const handleNativeRefreshOffset = (event: RefreshHeaderOffsetEvent) => {
+    'background only'
+    const headerSize = nativeRefreshHeaderSizeRef.current
+    const offset = event.detail.offsetPercent * headerSize
+    nativeRefreshOffsetRef.current = offset
+    refreshProps.onRefreshOffsetChange?.({
+      offset,
+      headerSize,
+      isDragging: event.detail.isDragging,
+    })
+  }
+
+  const handleNativeRefreshStateChange = (
+    event: RefreshStateChangeEvent,
+  ) => {
+    'background only'
+    refreshProps.onRefreshStateChange?.({ state: event.detail.state })
+  }
+
+  const handleNativeRefreshHeaderReleased = () => {
+    'background only'
+    refreshProps.onHeaderReleased?.({
+      offset: nativeRefreshOffsetRef.current,
+      headerSize: nativeRefreshHeaderSizeRef.current,
+    })
+  }
+
+  const handleNativeStartRefresh = (event: RefreshStartRefreshEvent) => {
+    'background only'
+    const triggeredBy = event.detail.isManual ? 'drag' : 'startRefresh'
+    refreshProps.onStartRefresh?.({ triggeredBy })
+  }
+
+  // These attributes are supported by the native refresh implementation, but
+  // are not yet included in the public `<refresh>` element types.
+  const nativeRefreshViewProps = {
+    'enable-loadmore': false,
+    'detect-scrollchild': true,
+    bindheaderreleased: handleNativeRefreshHeaderReleased,
   }
 
   const scrollTo = (
@@ -386,6 +465,7 @@ function FeedListImpl(props: FeedListProps, ref: ForwardedRef<FeedListRef>) {
       </List>
     )
   }
+  const list = innerList()
   return (
     <view
       id='bounceLayout'
@@ -394,8 +474,28 @@ function FeedListImpl(props: FeedListProps, ref: ForwardedRef<FeedListRef>) {
         horizontal ? '100%' : (style?.height ?? '100%')
       }; width: ${horizontal ? (style?.width ?? '100%') : '100%'};`}
     >
-      {innerList()}
-      {enableRefresh ? refreshHeader : startBounceView}
+      {enableNativeRefresh
+        ? (
+          <refresh
+            {...nativeRefreshViewProps}
+            id={`${listId}-refreshView`}
+            className='lynx-ui-feed-list__refresh-view'
+            enable-refresh={true}
+            bindstartrefresh={handleNativeStartRefresh}
+            bindheaderoffset={handleNativeRefreshOffset}
+            bindrefreshstatechange={handleNativeRefreshStateChange}
+          >
+            <refresh-header
+              className='lynx-ui-feed-list__refresh-header'
+              bindlayoutchange={handleNativeRefreshHeaderLayout}
+            >
+              {refreshProps.headerContent}
+            </refresh-header>
+            {list}
+          </refresh>
+        )
+        : list}
+      {enableHookRefresh ? refreshHeader : startBounceView}
       {endBounceView}
     </view>
   )

--- a/packages/lynx-ui-feed-list/src/styles.css
+++ b/packages/lynx-ui-feed-list/src/styles.css
@@ -1,3 +1,15 @@
+.lynx-ui-feed-list__refresh-view {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+}
+
+.lynx-ui-feed-list__refresh-header {
+  position: absolute;
+  overflow: visible;
+}
+
 .lynx-ui-feed-list__horizontal-start-wrapper {
   position: absolute;
   right: 100%;

--- a/packages/lynx-ui-feed-list/src/types/index.docs.ts
+++ b/packages/lynx-ui-feed-list/src/types/index.docs.ts
@@ -38,11 +38,11 @@ export interface FeedListRef extends ListRef {
 export interface FeedListProps extends Omit<ListProps, 'ref'> {
   ref?: ForwardedRef<FeedListRef>
   /**
-   * Accept true for default options. If you need to customize the refresh effect, you can pass in the RefreshProps.
+   * Accept true for default options. Pass `RefreshProps` to customize the refresh effect or select the native implementation with `mode: 'native'`.
    * @defaultValue false
    * @Android
    * @iOS
-   * @zh 接受true为默认选项。如果需要自定义刷新效果，可以传入RefreshProps。
+   * @zh 接受 true 使用默认选项。传入 `RefreshProps` 可以自定义刷新效果，或通过 `mode: 'native'` 选择原生刷新实现。
    */
   refreshOptions?: boolean | RefreshProps
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Add native `<refresh>` support to `FeedList` through `refreshOptions.mode: 'native'`.
- Preserve refresh callbacks and imperative methods across refresh modes.
- Document native refresh behavior, limitations, and configuration.
- Configure the FeedList example and release changeset for native refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->