### PR TITLE
fix(feed-list): preserve bounces for native refresh

### DIFF
--- a/.changeset/fix-native-feed-list-bounces.md
+++ b/.changeset/fix-native-feed-list-bounces.md
@@ -1,0 +1,6 @@
+---
+'@lynx-js/lynx-ui-feed-list': patch
+'@lynx-example/lynx-ui-feed-list': patch
+---
+
+Preserve the List `bounces` prop when FeedList uses native pull-to-refresh, and enable it in the native refresh example.

--- a/apps/examples/FeedList/Refresh/index.tsx
+++ b/apps/examples/FeedList/Refresh/index.tsx
@@ -77,7 +77,7 @@ function App() {
           onStartRefresh: handleStartRefresh,
         }}
         useRefactorList={true}
-        bounces={false}
+        bounces={true}
       >
         <list-item item-key='demo-header'>
           <view className='demo-header' />

--- a/packages/lynx-ui-feed-list/src/index.tsx
+++ b/packages/lynx-ui-feed-list/src/index.tsx
@@ -456,7 +456,9 @@ function FeedListImpl(props: FeedListProps, ref: ForwardedRef<FeedListRef>) {
         // worklet will trigger FiberFlushElementTree and cause layout. After react 0.22.0, the element in arg0 will be empty, thus marking layout dirty from the root.
         // If the transform is not initialized, attaching it afterward will change the IsStackingContextNode() status and mark the layout as dirty for the List. This will trigger an extra layoutComplete. To avoid this, we need to initialize the transform.
         style={{ ...style, transform: 'translateY(0px)' }}
-        bounces={!enableBounce && !enableRefresh && bounces}
+        // Hook refresh owns the upper-edge bounce. Native refresh relies on
+        // the List bounce behavior, so keep honoring the public bounces prop.
+        bounces={!enableBounce && !enableHookRefresh && bounces}
       >
         {upperExposureView}
         {children}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Preserve `bounces` for native refresh in `FeedList`.
- Enable `bounces` in the native refresh example.
- Declare patch releases for the affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->