### PR TITLE
feat(tab-group): add synchronized ViewPager panels

### DIFF
--- a/.changeset/oss-tab-group-aggregate.md
+++ b/.changeset/oss-tab-group-aggregate.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/lynx-ui': patch
+---
+
+Export TabGroup primitives from the aggregate lynx-ui package.

--- a/.changeset/oss-tabs-open.md
+++ b/.changeset/oss-tabs-open.md
@@ -1,0 +1,7 @@
+---
+'@lynx-js/lynx-ui-tab-group': minor
+'@lynx-example/lynx-ui-tab-group': patch
+'@lynx-js/skill-lynx-ui': patch
+---
+
+Add composable TabGroup primitives for tab navigation and animated indicators.

--- a/.changeset/oss-view-pager-aggregate.md
+++ b/.changeset/oss-view-pager-aggregate.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/lynx-ui': patch
+---
+
+Export ViewPager from the aggregate Lynx UI package.

--- a/.changeset/oss-view-pager-aggregate.md
+++ b/.changeset/oss-view-pager-aggregate.md
@@ -2,4 +2,4 @@
 '@lynx-js/lynx-ui': patch
 ---
 
-Export ViewPager from the aggregate Lynx UI package.
+Export ViewPager and ViewPagerItem from the aggregate lynx-ui package.

--- a/.changeset/oss-view-pager.md
+++ b/.changeset/oss-view-pager.md
@@ -1,0 +1,7 @@
+---
+'@lynx-js/lynx-ui-view-pager': minor
+'@lynx-example/lynx-ui-view-pager': patch
+'@lynx-js/skill-lynx-ui': patch
+---
+
+Add the ViewPager component with lazy page rendering and imperative page selection.

--- a/.changeset/oss-view-pager.md
+++ b/.changeset/oss-view-pager.md
@@ -4,4 +4,4 @@
 '@lynx-js/skill-lynx-ui': patch
 ---
 
-Add the ViewPager component with lazy page rendering and imperative page selection.
+Add ViewPager and ViewPagerItem with native-ref imperative selection, state styling, and page-based lazy rendering.

--- a/.changeset/tab-group-panel-aggregate.md
+++ b/.changeset/tab-group-panel-aggregate.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/lynx-ui': patch
+---
+
+Export the ViewPager-backed TabsPanel from the aggregate lynx-ui package.

--- a/.changeset/tab-group-panel.md
+++ b/.changeset/tab-group-panel.md
@@ -1,0 +1,7 @@
+---
+'@lynx-js/lynx-ui-tab-group': minor
+'@lynx-example/lynx-ui-tab-group': patch
+'@lynx-js/skill-lynx-ui': patch
+---
+
+Add TabsPanel with ViewPager integration for synchronized tab selection and swipeable content.

--- a/apps/examples/TabGroup/Basic/index.css
+++ b/apps/examples/TabGroup/Basic/index.css
@@ -1,0 +1,46 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.tab-group-demo-basic {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding-top: calc(48px + env(safe-area-inset-top));
+  gap: 24px;
+}
+
+.tab-group-demo-basic__title {
+  padding-left: 24px;
+  font-size: 32px;
+  color: var(--content);
+}
+
+.tab-group-demo-basic__tabs {
+  width: 100vw;
+  height: 72px;
+}
+
+.tab-group-demo-basic__tab-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: max-content;
+  padding-left: 40px;
+  padding-right: 40px;
+}
+
+.tab-group-demo-basic__indicator {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.tab-group-demo-basic__indicator-line {
+  width: 80%;
+  height: 10px;
+  background-color: var(--primary);
+  border-radius: 999px;
+}

--- a/apps/examples/TabGroup/Basic/index.tsx
+++ b/apps/examples/TabGroup/Basic/index.tsx
@@ -1,0 +1,50 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from '@lynx-js/react'
+
+import { TabsBar, TabsIndicator, TabsItem, TabsRoot } from '@lynx-js/lynx-ui'
+import type { TabsData } from '@lynx-js/lynx-ui'
+
+import './index.css'
+
+export function App() {
+  const tabsArray = ['Home', 'Discover', 'Messages', 'Profile']
+  const [tabs] = useState<TabsData<string>[]>(
+    Array.from({ length: tabsArray.length }, (_, index) => ({
+      tabItem: tabsArray[index],
+      getTabKey: () => tabsArray[index],
+    })),
+  )
+
+  return (
+    <view className='tab-group-demo-basic'>
+      <text className='tab-group-demo-basic__title'>TabGroup</text>
+      <TabsRoot
+        onClickItem={index => console.info('tabs click', index)}
+        onTabChanged={index => console.info('tabs changed', index)}
+      >
+        <TabsBar
+          data={tabs}
+          className='tab-group-demo-basic__tabs'
+          renderTabItem={(tabItemData: TabsData<string>) => (
+            <TabsItem
+              key={tabItemData.getTabKey()}
+              className='tab-group-demo-basic__tab-item'
+              tabKey={tabItemData.getTabKey()}
+            >
+              <text>{tabItemData.tabItem}</text>
+            </TabsItem>
+          )}
+        >
+          <TabsIndicator className='tab-group-demo-basic__indicator'>
+            <view className='tab-group-demo-basic__indicator-line' />
+          </TabsIndicator>
+        </TabsBar>
+      </TabsRoot>
+    </view>
+  )
+}
+
+root.render(<App />)

--- a/apps/examples/TabGroup/CHANGELOG.md
+++ b/apps/examples/TabGroup/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @lynx-example/lynx-ui-tab-group
+
+## 0.0.16
+
+- Add TabGroup examples.

--- a/apps/examples/TabGroup/LICENSE
+++ b/apps/examples/TabGroup/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2026 The Lynx Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/apps/examples/TabGroup/Motion/index.css
+++ b/apps/examples/TabGroup/Motion/index.css
@@ -1,0 +1,46 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.tab-group-demo-motion {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding-top: calc(48px + env(safe-area-inset-top));
+  gap: 24px;
+}
+
+.tab-group-demo-motion__title {
+  padding-left: 24px;
+  font-size: 32px;
+  color: var(--content);
+}
+
+.tab-group-demo-motion__tabs {
+  width: 100vw;
+  height: 72px;
+}
+
+.tab-group-demo-motion__tab-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: max-content;
+  padding-left: 40px;
+  padding-right: 40px;
+}
+
+.tab-group-demo-motion__indicator {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.tab-group-demo-motion__indicator-line {
+  width: 80%;
+  height: 10px;
+  background-color: var(--primary);
+  border-radius: 999px;
+}

--- a/apps/examples/TabGroup/Motion/index.tsx
+++ b/apps/examples/TabGroup/Motion/index.tsx
@@ -1,0 +1,59 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from '@lynx-js/react'
+
+import { TabsBar, TabsIndicator, TabsItem, TabsRoot } from '@lynx-js/lynx-ui'
+import type { TabsData } from '@lynx-js/lynx-ui'
+
+import './index.css'
+
+export function App() {
+  const tabsArray = ['Spring', 'tuned', 'for', 'indicator', 'motion', 'config']
+  const [tabs] = useState<TabsData<string>[]>(
+    Array.from({ length: tabsArray.length }, (_, index) => ({
+      tabItem: tabsArray[index],
+      getTabKey: () => tabsArray[index],
+    })),
+  )
+
+  return (
+    <view className='tab-group-demo-motion'>
+      <text className='tab-group-demo-motion__title'>
+        Custom indicator spring animation
+      </text>
+      <TabsRoot
+        initialSelectIndex={1}
+        indicatorAnimation={{
+          type: 'spring',
+          stiffness: 420,
+          damping: 34,
+          mass: 1,
+        }}
+        onClickItem={index => console.info('tabs click', index)}
+        onTabChanged={index => console.info('tabs changed', index)}
+      >
+        <TabsBar
+          data={tabs}
+          className='tab-group-demo-motion__tabs'
+          renderTabItem={(tabItemData: TabsData<string>) => (
+            <TabsItem
+              key={tabItemData.getTabKey()}
+              className='tab-group-demo-motion__tab-item'
+              tabKey={tabItemData.getTabKey()}
+            >
+              <text>{tabItemData.tabItem}</text>
+            </TabsItem>
+          )}
+        >
+          <TabsIndicator className='tab-group-demo-motion__indicator'>
+            <view className='tab-group-demo-motion__indicator-line' />
+          </TabsIndicator>
+        </TabsBar>
+      </TabsRoot>
+    </view>
+  )
+}
+
+root.render(<App />)

--- a/apps/examples/TabGroup/Panel/index.css
+++ b/apps/examples/TabGroup/Panel/index.css
@@ -1,0 +1,66 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.tab-group-panel {
+  width: 100%;
+  height: 100%;
+  padding-top: calc(48px + env(safe-area-inset-top));
+  background-color: var(--canvas);
+}
+
+.tab-group-panel__tabs {
+  width: 100vw;
+  height: 72px;
+}
+
+.tab-group-panel__tab {
+  width: max-content;
+  padding-left: 32px;
+  padding-right: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tab-group-panel__indicator {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.tab-group-panel__indicator-line {
+  width: 80%;
+  height: 8px;
+  border-radius: 999px;
+  background-color: var(--primary);
+}
+
+.tab-group-panel__page {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tab-group-panel__page--0 {
+  background-color: var(--primary-2);
+}
+
+.tab-group-panel__page--1 {
+  background-color: var(--secondary-2);
+}
+
+.tab-group-panel__page--2 {
+  background-color: var(--neutral-2);
+}
+
+.tab-group-panel__page--3 {
+  background-color: var(--primary-muted);
+}
+
+.tab-group-panel__page-label {
+  color: var(--content);
+  font-size: 40px;
+  font-weight: 600;
+}

--- a/apps/examples/TabGroup/Panel/index.tsx
+++ b/apps/examples/TabGroup/Panel/index.tsx
@@ -1,0 +1,61 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root } from '@lynx-js/react'
+
+import {
+  TabsBar,
+  TabsIndicator,
+  TabsItem,
+  TabsPanel,
+  TabsRoot,
+  ViewPagerItem,
+} from '@lynx-js/lynx-ui'
+import type { TabsData } from '@lynx-js/lynx-ui'
+
+import './index.css'
+
+const labels = ['Home', 'Discover', 'Messages', 'Profile']
+const tabs: TabsData<string>[] = labels.map(label => ({
+  tabItem: label,
+  getTabKey: () => label,
+}))
+
+export function App() {
+  return (
+    <view className='tab-group-panel'>
+      <TabsRoot initialSelectIndex={0}>
+        <TabsBar
+          data={tabs}
+          className='tab-group-panel__tabs'
+          renderTabItem={item => (
+            <TabsItem
+              key={item.getTabKey()}
+              className='tab-group-panel__tab'
+              tabKey={item.getTabKey()}
+            >
+              <text>{item.tabItem}</text>
+            </TabsItem>
+          )}
+        >
+          <TabsIndicator className='tab-group-panel__indicator'>
+            <view className='tab-group-panel__indicator-line' />
+          </TabsIndicator>
+        </TabsBar>
+        <TabsPanel style={{ width: '100%', height: '400px' }}>
+          {labels.map((label, index) => (
+            <ViewPagerItem
+              key={label}
+              className={`tab-group-panel__page tab-group-panel__page--${index}`}
+            >
+              <text className='tab-group-panel__page-label'>{label}</text>
+            </ViewPagerItem>
+          ))}
+        </TabsPanel>
+      </TabsRoot>
+    </view>
+  )
+}
+
+root.render(<App />)

--- a/apps/examples/TabGroup/lynx.config.mjs
+++ b/apps/examples/TabGroup/lynx.config.mjs
@@ -1,0 +1,15 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { exampleConfig } from '../../../tools/configs/exampleConfig.mjs'
+
+const defaultConfig = exampleConfig(
+  {
+    PrimitivesTabsBasic: './Basic/index.tsx',
+    PrimitivesTabsMotion: './Motion/index.tsx',
+  },
+  { needWeb: false },
+)
+
+export default defaultConfig

--- a/apps/examples/TabGroup/lynx.config.mjs
+++ b/apps/examples/TabGroup/lynx.config.mjs
@@ -8,6 +8,7 @@ const defaultConfig = exampleConfig(
   {
     PrimitivesTabsBasic: './Basic/index.tsx',
     PrimitivesTabsMotion: './Motion/index.tsx',
+    PrimitivesTabsPanel: './Panel/index.tsx',
   },
   { needWeb: false },
 )

--- a/apps/examples/TabGroup/package.json
+++ b/apps/examples/TabGroup/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@lynx-example/lynx-ui-tab-group",
+  "version": "0.0.16",
+  "description": "Example app demonstrating TabGroup usage in lynx-ui",
+  "homepage": "https://github.com/lynx-family/lynx-ui/tree/main/apps/examples/TabGroup#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-ui.git",
+    "directory": "apps/examples/TabGroup"
+  },
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Lynx Authors"
+  },
+  "type": "module",
+  "files": [
+    "LICENSE",
+    "CHANGELOG.md",
+    "dist/",
+    "**/*.tsx",
+    "**/*.ts",
+    "**/*.css",
+    "lynx.config.mjs"
+  ],
+  "scripts": {
+    "build": "rspeedy build",
+    "build:dev": "rspeedy build --mode=development",
+    "dev": "rspeedy dev",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@lynx-js/luna-styles": "workspace:*",
+    "@lynx-js/lynx-ui": "workspace:*",
+    "@lynx-js/react": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
+    "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rspeedy": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@types/react": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/apps/examples/TabGroup/tsconfig.json
+++ b/apps/examples/TabGroup/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    ".",
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+  ],
+}

--- a/apps/examples/ViewPager/Basic/index.css
+++ b/apps/examples/ViewPager/Basic/index.css
@@ -1,0 +1,55 @@
+@import "@lynx-js/luna-styles/index.css";
+
+.view-pager-demo {
+  width: 100%;
+  height: 100%;
+  padding: 72px 24px 48px;
+  background-color: var(--canvas);
+}
+
+.view-pager-demo__title {
+  margin-bottom: 24px;
+  color: var(--content);
+  font-size: 28px;
+}
+
+.view-pager-demo__pager {
+  border-radius: 24px;
+}
+
+.view-pager-demo__page {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.view-pager-demo__page--primary {
+  background-color: var(--primary);
+}
+
+.view-pager-demo__page--primary .view-pager-demo__label {
+  color: var(--primary-content);
+}
+
+.view-pager-demo__page--secondary {
+  background-color: var(--secondary);
+}
+
+.view-pager-demo__page--secondary .view-pager-demo__label {
+  color: var(--secondary-content);
+}
+
+.view-pager-demo__page--neutral {
+  background-color: var(--neutral);
+}
+
+.view-pager-demo__page--neutral .view-pager-demo__label {
+  color: var(--neutral-content);
+}
+
+.view-pager-demo__label {
+  font-size: 40px;
+  font-weight: 600;
+}

--- a/apps/examples/ViewPager/Basic/index.css
+++ b/apps/examples/ViewPager/Basic/index.css
@@ -53,3 +53,19 @@
   font-size: 40px;
   font-weight: 600;
 }
+
+.view-pager-demo__controls {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.view-pager-demo__control {
+  color: var(--content);
+  font-size: 16px;
+}
+
+.view-pager-demo__page.ui-selected .view-pager-demo__label {
+  font-weight: 700;
+}

--- a/apps/examples/ViewPager/Basic/index.tsx
+++ b/apps/examples/ViewPager/Basic/index.tsx
@@ -1,0 +1,38 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root } from '@lynx-js/react'
+
+import { ViewPager } from '@lynx-js/lynx-ui'
+
+import './index.css'
+
+const pages = [
+  { label: 'Explore', className: 'view-pager-demo__page--primary' },
+  { label: 'Create', className: 'view-pager-demo__page--secondary' },
+  { label: 'Share', className: 'view-pager-demo__page--neutral' },
+]
+
+export function App() {
+  return (
+    <view className='view-pager-demo lunaris-light'>
+      <text className='view-pager-demo__title'>Swipe between pages</text>
+      <ViewPager
+        className='view-pager-demo__pager'
+        style={{ width: '100%', height: '400px' }}
+      >
+        {pages.map(page => (
+          <view
+            key={page.label}
+            className={`view-pager-demo__page ${page.className}`}
+          >
+            <text className='view-pager-demo__label'>{page.label}</text>
+          </view>
+        ))}
+      </ViewPager>
+    </view>
+  )
+}
+
+root.render(<App />)

--- a/apps/examples/ViewPager/Basic/index.tsx
+++ b/apps/examples/ViewPager/Basic/index.tsx
@@ -2,9 +2,10 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { root } from '@lynx-js/react'
+import { root, useRef, useState } from '@lynx-js/react'
 
-import { ViewPager } from '@lynx-js/lynx-ui'
+import { Button, ViewPager, ViewPagerItem } from '@lynx-js/lynx-ui'
+import type { ViewPagerRef } from '@lynx-js/lynx-ui'
 
 import './index.css'
 
@@ -15,22 +16,45 @@ const pages = [
 ]
 
 export function App() {
+  const pagerRef = useRef<ViewPagerRef>(null)
+  const [index, setIndex] = useState(0)
   return (
-    <view className='view-pager-demo lunaris-light'>
+    <view className='view-pager-demo lunaris-dark'>
       <text className='view-pager-demo__title'>Swipe between pages</text>
+      <view className='view-pager-demo__controls'>
+        {pages.map((page, pageIndex) => (
+          <Button
+            key={page.label}
+            onClick={() => pagerRef.current?.selectTab(pageIndex)}
+          >
+            <text className='view-pager-demo__control'>{page.label}</text>
+          </Button>
+        ))}
+      </view>
       <ViewPager
+        ref={pagerRef}
+        onPageChange={event => setIndex(event.detail.index)}
         className='view-pager-demo__pager'
-        style={{ width: '100%', height: '400px' }}
+        style={{ height: '400px' }}
       >
         {pages.map(page => (
-          <view
+          <ViewPagerItem
             key={page.label}
             className={`view-pager-demo__page ${page.className}`}
+            itemProps={{ 'accessibility-label': page.label }}
           >
-            <text className='view-pager-demo__label'>{page.label}</text>
-          </view>
+            {({ selected }) => (
+              <text className='view-pager-demo__label'>
+                {page.label}
+                {selected ? ' •' : ''}
+              </text>
+            )}
+          </ViewPagerItem>
         ))}
       </ViewPager>
+      <text className='view-pager-demo__control'>
+        Page {index + 1} of {pages.length}
+      </text>
     </view>
   )
 }

--- a/apps/examples/ViewPager/CHANGELOG.md
+++ b/apps/examples/ViewPager/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lynx-example/lynx-ui-view-pager
+
+## 0.0.16
+
+### Patch Changes
+
+- Add the ViewPager example.

--- a/apps/examples/ViewPager/LICENSE
+++ b/apps/examples/ViewPager/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/examples/ViewPager/lynx.config.mjs
+++ b/apps/examples/ViewPager/lynx.config.mjs
@@ -1,0 +1,14 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { exampleConfig } from '../../../tools/configs/exampleConfig.mjs'
+
+const defaultConfig = exampleConfig(
+  {
+    ViewPagerBasic: './Basic/index.tsx',
+  },
+  { needWeb: false },
+)
+
+export default defaultConfig

--- a/apps/examples/ViewPager/package.json
+++ b/apps/examples/ViewPager/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@lynx-example/lynx-ui-view-pager",
+  "version": "0.0.16",
+  "description": "Example app demonstrating ViewPager usage in lynx-ui",
+  "homepage": "https://github.com/lynx-family/lynx-ui/tree/main/apps/examples/ViewPager#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-ui.git",
+    "directory": "apps/examples/ViewPager"
+  },
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Lynx Authors"
+  },
+  "type": "module",
+  "files": [
+    "LICENSE",
+    "CHANGELOG.md",
+    "dist/",
+    "**/*.tsx",
+    "**/*.ts",
+    "**/*.css",
+    "lynx.config.mjs"
+  ],
+  "scripts": {
+    "build": "rspeedy build",
+    "build:dev": "rspeedy build --mode=development",
+    "dev": "rspeedy dev",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@lynx-js/luna-styles": "workspace:*",
+    "@lynx-js/lynx-ui": "workspace:*",
+    "@lynx-js/react": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
+    "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rspeedy": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@types/react": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/apps/examples/ViewPager/tsconfig.json
+++ b/apps/examples/ViewPager/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    ".",
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+  ],
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -276,9 +276,9 @@ export default tseslint.config(
   },
   {
     files: [
-      'packages/**/*.{test,spec}.ts',
-      'apps/**/*.{test,spec}.ts',
-      'tools/**/*.{test,spec}.ts',
+      'packages/**/*.{test,spec}.{ts,tsx}',
+      'apps/**/*.{test,spec}.{ts,tsx}',
+      'tools/**/*.{test,spec}.{ts,tsx}',
     ],
     extends: [tseslint.configs.disableTypeChecked],
   },

--- a/packages/lynx-ui-tab-group/CHANGELOG.md
+++ b/packages/lynx-ui-tab-group/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @lynx-js/lynx-ui-tab-group
+
+## 3.136.0
+
+- Add composable TabGroup primitives to the open-source package set.

--- a/packages/lynx-ui-tab-group/LICENSE
+++ b/packages/lynx-ui-tab-group/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/lynx-ui-tab-group/README.md
+++ b/packages/lynx-ui-tab-group/README.md
@@ -1,0 +1,53 @@
+# @lynx-js/lynx-ui-tab-group
+
+Composable primitives for building tab navigation with lynx-ui. The package provides `TabsRoot`, `TabsBar`, `TabsItem`, and `TabsIndicator`.
+
+## Installation
+
+```bash
+pnpm add @lynx-js/lynx-ui
+```
+
+## Basic usage
+
+```tsx
+import { root } from '@lynx-js/react'
+import {
+  TabsBar,
+  TabsIndicator,
+  TabsItem,
+  TabsRoot,
+} from '@lynx-js/lynx-ui'
+import type { TabsData } from '@lynx-js/lynx-ui'
+import './index.css'
+
+const tabs: TabsData<string>[] = [
+  { tabItem: 'Home', getTabKey: () => 'home' },
+  { tabItem: 'Profile', getTabKey: () => 'profile' },
+]
+
+export function App() {
+  return (
+    <TabsRoot>
+      <TabsBar
+        data={tabs}
+        renderTabItem={item => (
+          <TabsItem key={item.getTabKey()} tabKey={item.getTabKey()}>
+            <text>{item.tabItem}</text>
+          </TabsItem>
+        )}
+      >
+        <TabsIndicator />
+      </TabsBar>
+    </TabsRoot>
+  )
+}
+
+root.render(<App />)
+```
+
+See the [TabGroup examples](https://github.com/lynx-family/lynx-ui/tree/main/apps/examples/TabGroup) for complete examples.
+
+## License
+
+Apache-2.0

--- a/packages/lynx-ui-tab-group/README.md
+++ b/packages/lynx-ui-tab-group/README.md
@@ -1,6 +1,6 @@
 # @lynx-js/lynx-ui-tab-group
 
-Composable primitives for building tab navigation with lynx-ui. The package provides `TabsRoot`, `TabsBar`, `TabsItem`, and `TabsIndicator`.
+Composable primitives for building tab navigation with lynx-ui. The package provides `TabsRoot`, `TabsBar`, `TabsItem`, `TabsIndicator`, and an optional swipeable `TabsPanel`.
 
 ## Installation
 

--- a/packages/lynx-ui-tab-group/README_zh.md
+++ b/packages/lynx-ui-tab-group/README_zh.md
@@ -1,0 +1,53 @@
+# @lynx-js/lynx-ui-tab-group
+
+用于通过 lynx-ui 构建标签导航的可组合 Tab 原语。此软件包提供 `TabsRoot`、`TabsBar`、`TabsItem` 和 `TabsIndicator`。
+
+## 安装
+
+```bash
+pnpm add @lynx-js/lynx-ui
+```
+
+## 基础用法
+
+```tsx
+import { root } from '@lynx-js/react'
+import {
+  TabsBar,
+  TabsIndicator,
+  TabsItem,
+  TabsRoot,
+} from '@lynx-js/lynx-ui'
+import type { TabsData } from '@lynx-js/lynx-ui'
+import './index.css'
+
+const tabs: TabsData<string>[] = [
+  { tabItem: '首页', getTabKey: () => 'home' },
+  { tabItem: '个人资料', getTabKey: () => 'profile' },
+]
+
+export function App() {
+  return (
+    <TabsRoot>
+      <TabsBar
+        data={tabs}
+        renderTabItem={item => (
+          <TabsItem key={item.getTabKey()} tabKey={item.getTabKey()}>
+            <text>{item.tabItem}</text>
+          </TabsItem>
+        )}
+      >
+        <TabsIndicator />
+      </TabsBar>
+    </TabsRoot>
+  )
+}
+
+root.render(<App />)
+```
+
+完整示例请参阅 [TabGroup examples](https://github.com/lynx-family/lynx-ui/tree/main/apps/examples/TabGroup)。
+
+## 许可证
+
+Apache-2.0

--- a/packages/lynx-ui-tab-group/README_zh.md
+++ b/packages/lynx-ui-tab-group/README_zh.md
@@ -1,6 +1,6 @@
 # @lynx-js/lynx-ui-tab-group
 
-用于通过 lynx-ui 构建标签导航的可组合 Tab 原语。此软件包提供 `TabsRoot`、`TabsBar`、`TabsItem` 和 `TabsIndicator`。
+用于通过 lynx-ui 构建标签导航的可组合 Tab 原语。此软件包提供 `TabsRoot`、`TabsBar`、`TabsItem`、`TabsIndicator`，以及可选的可滑动 `TabsPanel`。
 
 ## 安装
 

--- a/packages/lynx-ui-tab-group/SKILL.md
+++ b/packages/lynx-ui-tab-group/SKILL.md
@@ -2,7 +2,7 @@
 
 ## Core Capabilities
 
-`@lynx-js/lynx-ui-tab-group` provides composable tab-navigation primitives: `TabsRoot`, `TabsBar`, `TabsItem`, and `TabsIndicator`.
+`@lynx-js/lynx-ui-tab-group` provides composable tab-navigation primitives: `TabsRoot`, `TabsBar`, `TabsItem`, `TabsIndicator`, and the optional swipeable `TabsPanel`.
 
 ## Minimal Usable Example
 
@@ -21,14 +21,17 @@ import type { TabsData } from '@lynx-js/lynx-ui'
 </TabsRoot>
 ```
 
+Add `TabsPanel` under the same `TabsRoot` when tab selection and swipeable content should stay synchronized.
+
 ## Recommended Prompt Formula
 
 Describe the tab-navigation scenario, the tab data and stable keys, the desired
-layout and visual treatment, and how content should be coordinated through callbacks.
+layout and visual treatment, and whether content should use the synchronized
+`TabsPanel` or be coordinated through callbacks.
 
 ## Best Practices
 
 - Give every item a stable, unique value from `getTabKey`.
 - Render `TabsIndicator` as a child of `TabsBar`.
-- Use `onTabChanged` to coordinate content rendered elsewhere.
+- Use `TabsPanel` for synchronized swipeable content, or `onTabChanged` to coordinate content rendered elsewhere.
 - Configure `indicatorAnimation` on `TabsRoot` for custom indicator motion.

--- a/packages/lynx-ui-tab-group/SKILL.md
+++ b/packages/lynx-ui-tab-group/SKILL.md
@@ -1,0 +1,34 @@
+# lynx-ui TabGroup SKILL
+
+## Core Capabilities
+
+`@lynx-js/lynx-ui-tab-group` provides composable tab-navigation primitives: `TabsRoot`, `TabsBar`, `TabsItem`, and `TabsIndicator`.
+
+## Minimal Usable Example
+
+```tsx
+import { TabsBar, TabsIndicator, TabsItem, TabsRoot } from '@lynx-js/lynx-ui'
+import type { TabsData } from '@lynx-js/lynx-ui'
+
+<TabsRoot>
+  <TabsBar data={tabs} renderTabItem={item => (
+    <TabsItem key={item.getTabKey()} tabKey={item.getTabKey()}>
+      <text>{item.tabItem}</text>
+    </TabsItem>
+  )}>
+    <TabsIndicator />
+  </TabsBar>
+</TabsRoot>
+```
+
+## Recommended Prompt Formula
+
+Describe the tab-navigation scenario, the tab data and stable keys, the desired
+layout and visual treatment, and how content should be coordinated through callbacks.
+
+## Best Practices
+
+- Give every item a stable, unique value from `getTabKey`.
+- Render `TabsIndicator` as a child of `TabsBar`.
+- Use `onTabChanged` to coordinate content rendered elsewhere.
+- Configure `indicatorAnimation` on `TabsRoot` for custom indicator motion.

--- a/packages/lynx-ui-tab-group/docs/APIReference.mdx
+++ b/packages/lynx-ui-tab-group/docs/APIReference.mdx
@@ -1,9 +1,6 @@
 import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 
-
 ### TabsRoot
-
-
 
 ### Properties
 <UIApiTable source={[
@@ -237,10 +234,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
   }
 ]}/>
 
-
 ### TabsBar
-
-
 
 ### Properties
 <UIApiTable source={[
@@ -1346,7 +1340,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
   },
   {
     "name": "onContentSizeChange",
-    "type": "(res: Record<string, unknown>) => void",
+    "type": "(res: {detail: {scrollHeight: number, scrollWidth: number}}) => void",
     "summary": [
       {
         "kind": "text",
@@ -1632,10 +1626,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
   }
 ]}/>
 
-
 ### TabItem
-
-
 
 <UIApiTable source={[
   {
@@ -1662,10 +1653,354 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
   }
 ]}/>
 
+### TabsPanel
+
+<UIApiTable source={[
+  {
+    "name": "bounces",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Enable the native spring effect where supported."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "在支持的平台启用原生回弹效果。"
+      }
+    ],
+    "defaultValue": "true",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "children",
+    "type": "ReactNode",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Direct ViewPagerItem elements. Arrays and conditional items are supported;\nfragments and wrapper components are not. Use stable keys for dynamic pages.\nSelection follows the numeric position after reordering; removed selections\nclamp to the last page. An empty pager has index 0 and sends no requests."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "直接使用 ViewPagerItem，支持数组和条件条目，不支持 Fragment 或包装组件。动态页面使用稳定 key。重排后按索引选择，删除后限制到最后一页，空列表索引为 0 且不发出请求。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "className",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "className"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "类名"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "enableScroll",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Enable horizontal swipe gestures."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "启用水平滑动手势。"
+      }
+    ],
+    "defaultValue": "true",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "initialSelectIndex",
+    "type": "number",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Initial page index. Later changes are ignored; use ref.selectTab to navigate."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "初始页面索引，后续修改不生效。使用 ref.selectTab 切换页面。"
+      }
+    ],
+    "defaultValue": "0",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "lazy",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Defer off-screen content until selected, preloaded, or about to appear.\nMounted content stays mounted until its keyed item is removed."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "延迟挂载屏外内容；选中、预加载或即将显示时挂载。已挂载内容保留到对应条目被移除。"
+      }
+    ],
+    "defaultValue": "true",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "MTOnOffsetChange",
+    "type": "(event: ViewPagerOffsetChangeEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Main-thread scroll progress handler, in page units. Use a main thread function."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "主线程滚动进度回调，以页面为单位，需使用主线程函数。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "MTOnPageChange",
+    "type": "(event: ViewPagerChangeEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Main-thread page completion handler. Use a main thread function."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "主线程页面切换完成回调，需使用主线程函数。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "MTOnPageWillChange",
+    "type": "(event: ViewPagerWillChangeEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Main-thread page transition handler. Use a main thread function."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "主线程页面即将切换回调，需使用主线程函数。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onOffsetChange",
+    "type": "(event: ViewPagerOffsetChangeEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Native scroll progress in page units: 0 to 1 between the first two pages,\nnot a pixel distance."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "原生滚动进度，以页面为单位。前两页之间为 0 到 1，并非像素距离。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onPageChange",
+    "type": "(event: ViewPagerChangeEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Native page completion event, including programmatic transitions."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "原生页面切换完成事件，包括命令式切换。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onPageWillChange",
+    "type": "(event: ViewPagerWillChangeEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Native event before a page transition completes."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "原生页面切换完成前事件。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "preloadCount",
+    "type": "number",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Number of neighboring pages to mount on each side of the selected page.\nNonnegative integer; ignored when lazy is false."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "选中页面两侧预加载的页面数，为非负整数。lazy 为 false 时忽略。"
+      }
+    ],
+    "defaultValue": "1",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "ref",
+    "type": "ForwardedRef",
+    "summary": [],
+    "summary_zh": [],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "style",
+    "type": "CSSProperties",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "style"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "样式"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "viewpagerProps",
+    "type": "Omit",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Native pager attributes not managed by the component, including id and\naccessibility attributes. Use the dedicated props for styles and events."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "组件未管理的原生属性，包括 id 和无障碍属性。样式和事件使用专用属性。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>
 
 ### TabsIndicator
-
-
 
 <UIApiTable source={[
   {
@@ -1758,13 +2093,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
   }
 ]}/>
 
-
-
-
 ## TabsRootRef
-
-
-
 <UIApiTable source={[
   {
     "name": "selectTab",
@@ -1775,6 +2104,32 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "isOption": false,
     "isSupportIOS": false,
     "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>
+
+## TabsPanelRef
+<UIApiTable source={[
+  {
+    "name": "selectTab",
+    "type": "(index: number, smooth?: boolean, success?: (result: unknown) => void, fail?: (result: unknown) => void) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Slide to a page through the native node ref. Animation defaults to true.\nIndexes are clamped to available pages. Empty pagers ignore requests.\nCompletion is reported through onPageChange; success confirms invocation."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "通过原生节点引用切换页面，默认使用动画。索引限制在有效范围内，空列表忽略请求。onPageChange 表示切换完成，success 表示调用成功。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
     "isSupportHarmony": false,
     "docTypeFallback": null
   }

--- a/packages/lynx-ui-tab-group/docs/APIReference.mdx
+++ b/packages/lynx-ui-tab-group/docs/APIReference.mdx
@@ -1,0 +1,1781 @@
+import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+
+
+### TabsRoot
+
+
+
+### Properties
+<UIApiTable source={[
+  {
+    "name": "children",
+    "type": "ReactNode",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "children"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "子节点"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "debugLog",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Display debug logs. Open it when you find a bug."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "显示调试日志。当您发现错误时，请打开此选项。"
+      }
+    ],
+    "defaultValue": "false",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "enableRTL",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Enable RTL layout."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "开启 RTL 布局。"
+      }
+    ],
+    "defaultValue": "false",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "indicatorAnimation",
+    "type": "TabsIndicatorAnimation",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "The animation configuration for the tab indicator when switching tabs."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "切换标签时指示器的动画配置。"
+      }
+    ],
+    "defaultValue": "{ type: 'spring', stiffness: 300, damping: 30, mass: 1 }",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "initialSelectIndex",
+    "type": "number",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "The index of the initial display. Please use "
+      },
+      {
+        "kind": "code",
+        "text": "`selectTab`"
+      },
+      {
+        "kind": "text",
+        "text": " for other updates."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "指定初始显示的索引。请使用 "
+      },
+      {
+        "kind": "code",
+        "text": "`selectTab`"
+      },
+      {
+        "kind": "text",
+        "text": " 进行其他更新。"
+      }
+    ],
+    "defaultValue": "0",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "selectBehavior",
+    "type": "smooth | instant",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Controls how the tab bar scrolls and how the indicator moves when a tab is\nselected. Use "
+      },
+      {
+        "kind": "code",
+        "text": "`'smooth'`"
+      },
+      {
+        "kind": "text",
+        "text": " to animate the transition, or "
+      },
+      {
+        "kind": "code",
+        "text": "`'instant'`"
+      },
+      {
+        "kind": "text",
+        "text": " to jump\nto the target tab without animation."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "控制选中标签时标签栏的滚动方式与指示器的移动方式。"
+      },
+      {
+        "kind": "code",
+        "text": "`'smooth'`"
+      },
+      {
+        "kind": "text",
+        "text": " 表示动画过渡，"
+      },
+      {
+        "kind": "code",
+        "text": "`'instant'`"
+      },
+      {
+        "kind": "text",
+        "text": " 表示直接跳转。"
+      }
+    ],
+    "defaultValue": "'smooth'",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>
+
+### Events
+<UIApiTable source={[
+  {
+    "name": "onClickItem",
+    "type": "(index: number) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Click callback"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "点击回调"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onTabChanged",
+    "type": "(index: number) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Tab change callback"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "标签页更改回调"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>
+
+
+### TabsBar
+
+
+
+### Properties
+<UIApiTable source={[
+  {
+    "name": "androidTouchSlop",
+    "type": "default | paging",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Android touch recognition mode. When inside a component that supports 'paging' mode, 'paging' must be enabled."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "Android 触摸识别模式，当处于支持 'paging' 模式的元件中时，需要开启 'paging' 模式。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": false,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "bounceable",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Enable bouncing effect"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "启用弹性效果"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "bounceableOptions",
+    "type": "boolean | {alwaysBouncing?: boolean, enableBounceEventInFling?: boolean, enableBounces: boolean, endBounceTriggerDistance?: number, estimatedHeight?: number, estimatedWidth?: number, lowerBounceItem?: any, onScrollToBounces?: (e: scrollToBouncesInfo) => void, singleSidedBounce?: upper | lower | both | iOSBounces | none, startBounceTriggerDistance?: number, upperBounceItem?: any, validAnimationVersion?: boolean}",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Props for bouncing effect"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "弹性效果的参数"
+      }
+    ],
+    "defaultValue": "{ enableBounces: true, singleSidedBounce: \"iOSBounces\" },",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "children",
+    "type": "ReactNode",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "children"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "子节点"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "className",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "className"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "类名"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "data",
+    "type": "TabsData[]",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "The data for the Tabs."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "Tabs 的数据。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": false,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "debugLog",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Display debug logs for bounce interactions."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "显示回弹交互的调试日志。"
+      }
+    ],
+    "defaultValue": "false",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "enableNewArch",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Enable the native "
+      },
+      {
+        "kind": "code",
+        "text": "`<scroll-view>`"
+      },
+      {
+        "kind": "text",
+        "text": " new architecture. When enabled, "
+      },
+      {
+        "kind": "code",
+        "text": "`bounceableOptions`"
+      },
+      {
+        "kind": "text",
+        "text": " uses native bounces on Android, iOS, and Harmony. Defaults to "
+      },
+      {
+        "kind": "code",
+        "text": "`true`"
+      },
+      {
+        "kind": "text",
+        "text": " on Lynx SDK 4.3 and newer, and "
+      },
+      {
+        "kind": "code",
+        "text": "`false`"
+      },
+      {
+        "kind": "text",
+        "text": " on earlier versions."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "启用原生 "
+      },
+      {
+        "kind": "code",
+        "text": "`<scroll-view>`"
+      },
+      {
+        "kind": "text",
+        "text": " 新架构。启用后，"
+      },
+      {
+        "kind": "code",
+        "text": "`bounceableOptions`"
+      },
+      {
+        "kind": "text",
+        "text": " 会在 Android、iOS 和 Harmony 上使用原生回弹。Lynx SDK 4.3 及以上版本默认为 "
+      },
+      {
+        "kind": "code",
+        "text": "`true`"
+      },
+      {
+        "kind": "text",
+        "text": "，更早版本默认为 "
+      },
+      {
+        "kind": "code",
+        "text": "`false`"
+      },
+      {
+        "kind": "text",
+        "text": "。"
+      }
+    ],
+    "defaultValue": "true on Lynx SDK >= 4.3; false otherwise",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "enableRTL",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Whether horizontal bounce direction should be mirrored in RTL mode."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "是否在 RTL 模式下镜像水平回弹方向。"
+      }
+    ],
+    "defaultValue": "false",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "enableScroll",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Enable scroll interaction."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "启用滚动。"
+      }
+    ],
+    "defaultValue": "true",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "enableScrollMonitor",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Enable scroll monitor."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "启用滚动监控。"
+      }
+    ],
+    "defaultValue": "false",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "estimatedItemStyle",
+    "type": "CSSProperties",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Estimated height and width of the items need to be set."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "需要设置 items 的预计高度和宽度。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "experimentalNestedScrollBackward",
+    "type": "selfOnly | selfFirst | parentFirst | parallel",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Adapts Harmony nested scroll behavior. 'selfOnly' scrolls only this component. 'selfFirst' scrolls this component first, then the parent after this component reaches a scroll boundary. 'parentFirst' scrolls the parent first, then this component after the parent reaches a scroll boundary. 'parallel' scrolls this component and the parent at the same time."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "适配 Harmony 的嵌套滚动行为。'selfOnly' 表示只自身滚动，不与父组件联动。'selfFirst' 表示自身先滚动，自身滚动到边界以后父组件滚动。'parentFirst' 表示父组件先滚动，父组件滚动到边界以后自身滚动。'parallel' 表示自身和父组件同时滚动。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "experimentalNestedScrollForward",
+    "type": "selfOnly | selfFirst | parentFirst | parallel",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Adapts Harmony nested scroll behavior. 'selfOnly' scrolls only this component. 'selfFirst' scrolls this component first, then the parent after this component reaches a scroll boundary. 'parentFirst' scrolls the parent first, then this component after the parent reaches a scroll boundary. 'parallel' scrolls this component and the parent at the same time."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "适配 Harmony 的嵌套滚动行为。'selfOnly' 表示只自身滚动，不与父组件联动。'selfFirst' 表示自身先滚动，自身滚动到边界以后父组件滚动。'parentFirst' 表示父组件先滚动，父组件滚动到边界以后自身滚动。'parallel' 表示自身和父组件同时滚动。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "exposureBottom",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "exposure-screen-margin-bottom"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "曝光屏幕下方边距"
+      }
+    ],
+    "defaultValue": "'10px'",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "exposureID",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "exposure-id for global exposure"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "用于全局曝光的 exposure-id"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "exposureLeft",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "exposure-screen-margin-left"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "曝光屏幕左侧边距"
+      }
+    ],
+    "defaultValue": "'10px'",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "exposureRight",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "exposure-screen-margin-right"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "曝光屏幕右侧边距"
+      }
+    ],
+    "defaultValue": "'10px'",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "exposureScene",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "exposure-scene for global exposure"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "用于全局曝光的 exposure-scene"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "exposureTop",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "exposure-screen-margin-top"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "曝光屏幕上方边距"
+      }
+    ],
+    "defaultValue": "'10px'",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "firstScreenItemCount",
+    "type": "number",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Estimated first screen item count for lazy rendering. Remaining children will complete rendering based on exposure. When this estimate is small, it may cause a blank screen phenomenon where some nodes exist on the first screen."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "懒加载时预计的第一页项数。剩余的子元素会基于曝光状态完成渲染。当此预估较小时，可能会导致第一屏出现空白现象。"
+      }
+    ],
+    "defaultValue": "1",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "iOSBounces",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Open the bouncing effect on iOS. If you want to use it on Android, please refer to the bounceableOption. If the bounceableOption is set, the iOSBounces property will be invalid."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "开启iOS上的回弹效果。如果想在安卓上使用，请参考bounceableOption。如果设置了bounceableOption，iOSBounces属性将失效。"
+      }
+    ],
+    "defaultValue": "true",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "lazy",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "When enabled, only the items that are about to enter the viewport are rendered, reducing initial load time and memory usage; remaining items are rendered as they approach visibility during scroll."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "启用懒渲染。只有当用户滚动到可见区域时，才会渲染 items，从而减少初始加载时间和内存使用。"
+      }
+    ],
+    "defaultValue": "true",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "lazyOptions",
+    "type": "LazyOptions",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "When enabled, only the items that are about to enter the viewport are rendered, reducing initial load time and memory usage; remaining items are rendered as they approach visibility during scroll."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "启用懒渲染。只有当用户滚动到可见区域时，才会渲染 items，从而减少初始加载时间和内存使用。"
+      }
+    ],
+    "defaultValue": "true",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "main-thread:gesture",
+    "type": "BaseGesture",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "If you want to use gesture, pass it here."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "如果想使用 gesture API，请传入该属性。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onUIAppear",
+    "type": "(e: CommonEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Exposure event for UI"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "UI 的曝光事件。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onUIDisappear",
+    "type": "(e: CommonEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Disappear event for UI"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "UI 的消失事件。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "renderTabItem",
+    "type": "(tabItem: TabsData) => ReactNode",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "The function used to render each tab item."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "用于渲染每一个 Tab 的函数。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "scene",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Be used to mark the exposure timing of lazy loading. Please ensure that it is unique throughout the page."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "用于标记懒加载的曝光时机。请确保页面中唯一。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "scrollMonitorTag",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "The tag for scroll monitor."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "滚动监控的标签。"
+      }
+    ],
+    "defaultValue": "false",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "scrollPropagationBehavior",
+    "type": "ScrollPropagationBehaviorOption",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Controls whether scroll events propagate to parent containers. For now, 'preventPropagate' needs to be used together with temporaryBlockScrollClass and temporaryBlockScrollTag on iOS."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "控制滚动事件是否向父级容器传递。'preventPropagate' 在 iOS 上暂时需与 temporaryBlockScrollClass 和 temporaryBlockScrollTag 配合使用。\n Currently, this property has limitations because its full functionality depends on a higher native SDK version: on iOS, "
+      },
+      {
+        "kind": "code",
+        "text": "`propagate`"
+      },
+      {
+        "kind": "text",
+        "text": " only works if both the parent and this component are set to"
+      },
+      {
+        "kind": "code",
+        "text": "` propagate`"
+      },
+      {
+        "kind": "text",
+        "text": " and "
+      },
+      {
+        "kind": "code",
+        "text": "`useRefactorList={true}`"
+      },
+      {
+        "kind": "text",
+        "text": " does not support 'propagate'. On Android, "
+      },
+      {
+        "kind": "code",
+        "text": "`preventPropagate`"
+      },
+      {
+        "kind": "text",
+        "text": " only functions when the parent is "
+      },
+      {
+        "kind": "code",
+        "text": "`x-swiper`"
+      },
+      {
+        "kind": "text",
+        "text": " or "
+      },
+      {
+        "kind": "code",
+        "text": "`x-viewpager-ng`"
+      },
+      {
+        "kind": "text",
+        "text": "."
+      }
+    ],
+    "defaultValue": "'native'",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "scrollviewId",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "The id of the scrollview."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "滚动视图的id。"
+      }
+    ],
+    "defaultValue": "\"scrollview\"",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "sticky",
+    "type": "ReactElement",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Sticky item, designed for "
+      },
+      {
+        "kind": "code",
+        "text": "`Tabs`"
+      },
+      {
+        "kind": "text",
+        "text": "."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "粘性元素，设计用于 "
+      },
+      {
+        "kind": "code",
+        "text": "`Tabs`"
+      },
+      {
+        "kind": "text",
+        "text": "。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "style",
+    "type": "CSSProperties",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "style"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "样式"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "tabsItemWrapperClass",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "The class apply to the internal container of child view inside scroll-view."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "应用于 scroll-view 内子视图的内部容器的类名。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "temporaryBlockScrollClass",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "The specific class name of the container that is blocked when 'scrollPropagationBehavior' is set to be 'preventPropagate', must be informed by the container provider. For now, 'preventPropagate' needs to be used together with temporaryBlockScrollClass and temporaryBlockScrollTag on iOS."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "当 scrollPropagationBehavior 设为 'preventPropagate' 时，被阻止滚动的容器的具体类名。'preventPropagate' 需与 temporaryBlockScrollClass 和 temporaryBlockScrollTag 配合使用。\nThis is a temporary props and will be deprecated on new Lynx SDK version."
+      }
+    ],
+    "defaultValue": "'BDXLynxViewPager'",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "temporaryBlockScrollTag",
+    "type": "number",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Used to specify the native container tag that is blocked when 'scrollPropagationBehavior' is set to be 'preventPropagate', corresponding to the Tag attribute of UIView. Needs to be specified by the native container provider. For now, 'preventPropagate' needs to be used together with temporaryBlockScrollClass and temporaryBlockScrollTag on iOS."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "用于指定当 scrollPropagationBehavior 设为 'preventPropagate' 时被阻止滚动的原生容器标签（对应 UIView 的 Tag 属性）。该值需由原生容器提供方指定，且 'preventPropagate' 必须与 temporaryBlockScrollClass 和 temporaryBlockScrollTag 配合使用。\nThis is a temporary props and will be deprecated on new Lynx SDK version."
+      }
+    ],
+    "defaultValue": "0",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "temporaryNestedScroll",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Android-only temporary flag to control nested scroll; maps to native 'enable-nested-scroll'. Android default value is true."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "仅 Android 生效的临时开关，用于控制嵌套滚动冲突；映射到原生属性 'enable-nested-scroll'。Android上默认开启。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": false,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "testing",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Testing Mode."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "测试模式"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>
+
+### Events
+<UIApiTable source={[
+  {
+    "name": "catchLongPress",
+    "type": "(e: EventHandler | undefined) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Same as onLongPress, but stops the event from propagating to parent elements."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "与 onLongPress 相同，但会阻止事件冒泡。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "catchTouchCancel",
+    "type": "(e: TouchEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Same as onTouchCancel, but stops the event from propagating to parent elements."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "与 onTouchCancel 相同，但会阻止事件冒泡。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "catchTouchEnd",
+    "type": "(e: TouchEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Same as onTouchEnd, but stops the event from propagating to parent elements."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "与 onTouchEnd 相同，但会阻止事件冒泡。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "catchTouchMove",
+    "type": "(e: TouchEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Same as onTouchMove, but stops the event from propagating to parent elements."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "与 onTouchMove 相同，但会阻止事件冒泡。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "catchTouchStart",
+    "type": "(e: TouchEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Same as onTouchStart, but stops the event from propagating to parent elements."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "与 onTouchStart 相同，但会阻止事件冒泡。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onContentSizeChange",
+    "type": "(res: Record<string, unknown>) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Being triggered when scrolling content changes."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "滚动内容变化时触发。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onLayoutChange",
+    "type": "(e: EventHandler | undefined) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Send when UI has changed viewport size."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "当 UI 视口大小改变时发送。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onLongPress",
+    "type": "(e: EventHandler | undefined) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Send when a touch-point is held on the UI for a period of time."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "当触摸点在 UI 上按住一段时间后发送。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onScroll",
+    "type": "(e: ScrollEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Being triggered when scrolling occurs."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "滚动时触发。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onScrollEnd",
+    "type": "(e: (e: ScrollEndEvent) => void | undefined) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Being triggered when scrolling stops."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "滚动停止时触发。"
+      }
+    ],
+    "defaultValue": "undefined",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onScrollToLower",
+    "type": "(e: (e: ScrollToLowerEvent) => void | undefined) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Being triggered when scrolling to lower."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "滚动到底部时触发。"
+      }
+    ],
+    "defaultValue": "undefined",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onScrollToUpper",
+    "type": "(e: (e: ScrollToUpperEvent) => void | undefined) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Being triggered when scrolling to upper."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "滚动到顶部时触发。"
+      }
+    ],
+    "defaultValue": "undefined",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onTap",
+    "type": "(e: EventHandler | undefined) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Send when a touch-point is tapped on the UI."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "当触摸点在 UI 上轻触时发送。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onTouchCancel",
+    "type": "(e: TouchEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Send when a touch event is interrupted or cancelled before it is completed."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "当触摸事件在完成前被中断或取消时发送。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onTouchEnd",
+    "type": "(e: TouchEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Send when a touch-point is removed from the UI."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "当触摸点从 UI 上移除时发送。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onTouchMove",
+    "type": "(e: TouchEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Send when a touch-point is moving on the UI."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "当触摸点在 UI 上移动时发送。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onTouchStart",
+    "type": "(e: TouchEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Send when a touch-point is placed on the UI."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "当触摸点放置在 UI 上时发送。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onWheel",
+    "type": "(e: CommonEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Send when a wheel event is triggered on the scroll-view."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "当 scroll-view 触发滚轮事件时发送。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>
+
+
+### TabItem
+
+
+
+<UIApiTable source={[
+  {
+    "name": "tabKey",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "The unique key of the tab item."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "Tab 项的唯一键。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": false,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  }
+]}/>
+
+
+### TabsIndicator
+
+
+
+<UIApiTable source={[
+  {
+    "name": "children",
+    "type": "ReactNode",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "children"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "子节点"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "className",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "className"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "类名"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "indicatorProps",
+    "type": "StandardProps",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Raw props passed to the indicator."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "TabsIndicator 的原始属性。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "style",
+    "type": "CSSProperties",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "style"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "样式"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  }
+]}/>
+
+
+
+
+## TabsRootRef
+
+
+
+<UIApiTable source={[
+  {
+    "name": "selectTab",
+    "type": "(index: number, smooth: boolean) => void",
+    "summary": [],
+    "summary_zh": [],
+    "defaultValue": "",
+    "isOption": false,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>

--- a/packages/lynx-ui-tab-group/docs/README.mdx
+++ b/packages/lynx-ui-tab-group/docs/README.mdx
@@ -1,0 +1,16 @@
+import { lynxUiIntros } from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-tab-group/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
+# `<TabGroup>`
+
+{lynxUiIntros['lynx-ui-tab-group']}
+
+:::info
+
+You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-tab-group) to understand how it works, and you're welcome to submit PRs to enhance its capabilities.
+
+:::
+
+<Introduction />
+<APIReference />

--- a/packages/lynx-ui-tab-group/docs/README.zh.mdx
+++ b/packages/lynx-ui-tab-group/docs/README.zh.mdx
@@ -1,0 +1,16 @@
+import Introduction from '../../introDocs/lynx-ui-tab-group/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
+
+# `<TabGroup>`
+
+{lynxUiIntrosZh['lynx-ui-tab-group']}
+
+:::info
+
+你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-tab-group)来了解它的运行原理，也欢迎大家提 PR 来丰富其能力。
+
+:::
+
+<Introduction />
+<APIReference />

--- a/packages/lynx-ui-tab-group/package.json
+++ b/packages/lynx-ui-tab-group/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@lynx-js/lynx-ui-common": "workspace:*",
     "@lynx-js/lynx-ui-scroll-view": "workspace:*",
+    "@lynx-js/lynx-ui-view-pager": "workspace:*",
     "@lynx-js/motion": "catalog:",
     "clsx": "catalog:"
   },

--- a/packages/lynx-ui-tab-group/package.json
+++ b/packages/lynx-ui-tab-group/package.json
@@ -1,16 +1,18 @@
 {
-  "name": "@lynx-js/lynx-ui",
+  "name": "@lynx-js/lynx-ui-tab-group",
   "version": "3.136.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-ui.git",
-    "directory": "packages/lynx-ui"
+    "directory": "packages/lynx-ui-tab-group"
   },
   "license": "Apache-2.0",
   "author": {
     "name": "The Lynx Authors"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css"
+  ],
   "type": "module",
   "main": "./dist/index.jsx",
   "module": "./dist/index.jsx",
@@ -30,29 +32,10 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@lynx-js/lynx-ui-button": "workspace:*",
-    "@lynx-js/lynx-ui-checkbox": "workspace:*",
     "@lynx-js/lynx-ui-common": "workspace:*",
-    "@lynx-js/lynx-ui-dialog": "workspace:*",
-    "@lynx-js/lynx-ui-draggable": "workspace:*",
-    "@lynx-js/lynx-ui-feed-list": "workspace:*",
-    "@lynx-js/lynx-ui-form": "workspace:*",
-    "@lynx-js/lynx-ui-input": "workspace:*",
-    "@lynx-js/lynx-ui-input-otp": "workspace:*",
-    "@lynx-js/lynx-ui-lazy-component": "workspace:*",
-    "@lynx-js/lynx-ui-list": "workspace:*",
-    "@lynx-js/lynx-ui-popover": "workspace:*",
-    "@lynx-js/lynx-ui-presence": "workspace:*",
-    "@lynx-js/lynx-ui-radio-group": "workspace:*",
     "@lynx-js/lynx-ui-scroll-view": "workspace:*",
-    "@lynx-js/lynx-ui-sheet": "workspace:*",
-    "@lynx-js/lynx-ui-slider": "workspace:*",
-    "@lynx-js/lynx-ui-sortable": "workspace:*",
-    "@lynx-js/lynx-ui-swipe-action": "workspace:*",
-    "@lynx-js/lynx-ui-swiper": "workspace:*",
-    "@lynx-js/lynx-ui-switch": "workspace:*",
-    "@lynx-js/lynx-ui-tab-group": "workspace:*",
-    "@lynx-js/lynx-ui-view-pager": "workspace:*"
+    "@lynx-js/motion": "catalog:",
+    "clsx": "catalog:"
   },
   "devDependencies": {
     "@lynx-js/react": "catalog:",

--- a/packages/lynx-ui-tab-group/rslib.config.ts
+++ b/packages/lynx-ui-tab-group/rslib.config.ts
@@ -1,0 +1,8 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from '@rslib/core'
+import { baseConfig } from '../../tools/configs/rslib.base.js'
+
+export default defineConfig(baseConfig)

--- a/packages/lynx-ui-tab-group/src/TabsBar.tsx
+++ b/packages/lynx-ui-tab-group/src/TabsBar.tsx
@@ -1,0 +1,69 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { runOnMainThread, useMemo } from '@lynx-js/react'
+
+import { log, useMemoizedFn } from '@lynx-js/lynx-ui-common'
+import { ScrollView } from '@lynx-js/lynx-ui-scroll-view'
+import { clsx } from 'clsx'
+
+import { TabsContext, useTabsRootContext } from './TabsContext'
+import type { TabsBarProps } from './types'
+
+import './index.css'
+
+export function TabsBar<T>(props: TabsBarProps<T>) {
+  const {
+    data,
+    children,
+    tabsItemWrapperClass,
+    renderTabItem,
+    ...scrollViewProps
+  } = props
+
+  const {
+    tabSelectIndex,
+    debugLog,
+  } = useTabsRootContext()
+
+  const tabKeys: string[] = useMemo(() => data.map(item => item.getTabKey()), [
+    data,
+  ])
+
+  const selectTab = useMemoizedFn((tabsKey: string) => {
+    const index = tabKeys.indexOf(tabsKey)
+    log(debugLog, '[lynx-ui tabs] selectTab', tabsKey, index)
+    runOnMainThread(() => {
+      'main thread'
+      tabSelectIndex.current.set(index)
+    })()
+  })
+
+  const tabsContextValue = useMemo(() => ({
+    selectTab,
+    tabKeyArray: tabKeys,
+  }), [selectTab, tabKeys])
+
+  // children: Indicator
+  // renderedChildren: TabItem
+  const renderedChildren = useMemo(
+    () => data.map(item => renderTabItem?.(item)),
+    [data, renderTabItem],
+  )
+
+  return (
+    <TabsContext.Provider value={tabsContextValue}>
+      <ScrollView
+        scrollOrientation='horizontal'
+        {...scrollViewProps}
+      >
+        <view
+          className={clsx('lynx-ui-tab-group__items', tabsItemWrapperClass)}
+        >
+          {children}
+          {renderedChildren}
+        </view>
+      </ScrollView>
+    </TabsContext.Provider>
+  )
+}

--- a/packages/lynx-ui-tab-group/src/TabsBar.tsx
+++ b/packages/lynx-ui-tab-group/src/TabsBar.tsx
@@ -22,6 +22,7 @@ export function TabsBar<T>(props: TabsBarProps<T>) {
   } = props
 
   const {
+    hasPanel,
     tabSelectIndex,
     debugLog,
   } = useTabsRootContext()
@@ -32,7 +33,7 @@ export function TabsBar<T>(props: TabsBarProps<T>) {
 
   const selectTab = useMemoizedFn((tabsKey: string) => {
     const index = tabKeys.indexOf(tabsKey)
-    log(debugLog, '[lynx-ui tabs] selectTab', tabsKey, index)
+    log(debugLog, '[lynx-ui tabs] selectTab', tabsKey, index, hasPanel)
     runOnMainThread(() => {
       'main thread'
       tabSelectIndex.current.set(index)

--- a/packages/lynx-ui-tab-group/src/TabsContext.tsx
+++ b/packages/lynx-ui-tab-group/src/TabsContext.tsx
@@ -19,6 +19,9 @@ interface TabsRootContextValue {
   indicatorAnimation?: TabsIndicatorAnimation
   initialSelectIndex?: number
 
+  hasPanel: MotionValueRef<boolean>
+  panelIndex: MotionValueRef<number>
+  panelOffset: MotionValueRef<number>
   tabSelectIndex: MotionValueRef<number>
   tabsWidthMapMT: MotionValueRef<Record<string, number>>
   tabRegistrationMapMT: MainThreadRef<Record<string, number>>

--- a/packages/lynx-ui-tab-group/src/TabsContext.tsx
+++ b/packages/lynx-ui-tab-group/src/TabsContext.tsx
@@ -1,0 +1,61 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { createContext, useContext } from '@lynx-js/react'
+import type { MainThreadRef } from '@lynx-js/react'
+
+import { noop } from '@lynx-js/lynx-ui-common'
+import type { MotionValue } from '@lynx-js/motion/mini'
+import type { MainThread } from '@lynx-js/types'
+
+import type { TabsIndicatorAnimation } from './types'
+
+type MotionValueRef<T> = MainThreadRef<MotionValue<T>>
+
+interface TabsRootContextValue {
+  debugLog: boolean
+  enableRTL: boolean
+  selectBehavior?: 'smooth' | 'instant'
+  indicatorAnimation?: TabsIndicatorAnimation
+  initialSelectIndex?: number
+
+  tabSelectIndex: MotionValueRef<number>
+  tabsWidthMapMT: MotionValueRef<Record<string, number>>
+  tabRegistrationMapMT: MainThreadRef<Record<string, number>>
+  indicatorOffsetMT: MotionValueRef<number>
+  indicatorElementMT: MainThreadRef<MainThread.Element | null>
+  hasRenderedIndicatorMT: MainThreadRef<boolean>
+  isFirstScreenSyncMT: MainThreadRef<boolean>
+  selectTarget: MotionValueRef<{ index: number, smooth: boolean }>
+
+  onClickItem?: (index: number) => void
+  onTabChanged?: (index: number) => void
+}
+
+export const TabsRootContext = createContext<TabsRootContextValue | null>(null)
+
+export function useTabsRootContext() {
+  const context = useContext(TabsRootContext)
+  if (!context) {
+    throw new Error('useTabsRootContext must be used within a TabsRoot')
+  }
+  return context
+}
+
+interface TabsContextValue {
+  selectTab: (tabKey: string) => void
+  tabKeyArray: string[]
+}
+
+export const TabsContext = createContext<TabsContextValue>({
+  selectTab: noop,
+  tabKeyArray: [],
+})
+
+export function useTabsContext() {
+  const context = useContext(TabsContext)
+  if (!context) {
+    throw new Error('useTabsContext must be used within a Tabs')
+  }
+  return context
+}

--- a/packages/lynx-ui-tab-group/src/TabsIndicator.tsx
+++ b/packages/lynx-ui-tab-group/src/TabsIndicator.tsx
@@ -33,11 +33,13 @@ export const TabsIndicator = (props: TabsIndicatorProps) => {
   } = indicatorProps ?? {}
   const { tabKeyArray } = useTabsContext()
   const {
+    panelOffset,
     tabSelectIndex,
     tabsWidthMapMT,
     indicatorOffsetMT,
     indicatorElementMT,
     hasRenderedIndicatorMT,
+    hasPanel,
     selectBehavior,
     indicatorAnimation,
     selectTarget,
@@ -113,6 +115,15 @@ export const TabsIndicator = (props: TabsIndicatorProps) => {
     )
   }
 
+  useMotionValueRefEvent(panelOffset, 'change', (offset) => {
+    'main thread'
+    mtsLog(debugLog, '[lynx-ui tabs] panelOffset', offset, tabKeyArray.length)
+    if (offset < 0 || offset > tabKeyArray.length - 1) {
+      return
+    }
+    syncIndicatorOffset(offset)
+  })
+
   useMotionValueRefEvent(tabsWidthMapMT, 'change', () => {
     'main thread'
     updateIndicatorAtOffset(offsetMotionRef.current.get())
@@ -130,13 +141,15 @@ export const TabsIndicator = (props: TabsIndicatorProps) => {
         return
       }
       const { index, smooth } = target
-      if (hasRenderedIndicatorMT.current && smooth) {
-        animateToTab(index)
-      } else {
-        syncIndicatorOffset(index)
+      if (!hasPanel.current.get()) {
+        if (hasRenderedIndicatorMT.current && smooth) {
+          animateToTab(index)
+        } else {
+          syncIndicatorOffset(index)
+        }
+        runOnBackground(onTabChangedJS)(index)
+        tabChangeHandledBySelectTargetMT.current = index
       }
-      runOnBackground(onTabChangedJS)(index)
-      tabChangeHandledBySelectTargetMT.current = index
     },
   )
 
@@ -146,18 +159,20 @@ export const TabsIndicator = (props: TabsIndicatorProps) => {
     if (index < 0 || index > tabKeyArray.length - 1) {
       return
     }
-    if (
-      hasRenderedIndicatorMT.current
-      && shouldAnimateIndicator(selectBehavior)
-    ) {
-      animateToTab(index)
-    } else {
-      syncIndicatorOffset(index)
-    }
-    if (tabChangeHandledBySelectTargetMT.current === index) {
-      tabChangeHandledBySelectTargetMT.current = -1
-    } else {
-      runOnBackground(onTabChangedJS)(index)
+    if (!hasPanel.current.get()) {
+      if (
+        hasRenderedIndicatorMT.current
+        && shouldAnimateIndicator(selectBehavior)
+      ) {
+        animateToTab(index)
+      } else {
+        syncIndicatorOffset(index)
+      }
+      if (tabChangeHandledBySelectTargetMT.current === index) {
+        tabChangeHandledBySelectTargetMT.current = -1
+      } else {
+        runOnBackground(onTabChangedJS)(index)
+      }
     }
   })
 

--- a/packages/lynx-ui-tab-group/src/TabsIndicator.tsx
+++ b/packages/lynx-ui-tab-group/src/TabsIndicator.tsx
@@ -1,0 +1,185 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import {
+  runOnBackground,
+  runOnMainThread,
+  useEffect,
+  useMainThreadRef,
+} from '@lynx-js/react'
+
+import { mtsLog } from '@lynx-js/lynx-ui-common'
+import { animate, useMotionValueRefEvent } from '@lynx-js/motion/mini'
+import { clsx } from 'clsx'
+
+import { useTabsContext, useTabsRootContext } from './TabsContext'
+import type { TabsIndicatorProps } from './types'
+import {
+  getIndicatorStyleProperties,
+  shouldAnimateIndicator,
+  toMiniAnimationOptions,
+} from './utils/tabsIndicatorAnimation'
+import { calculateIndicatorPosition } from './utils/tabsIndicatorGeometry'
+
+import './index.css'
+
+export const TabsIndicator = (props: TabsIndicatorProps) => {
+  const { style, className, indicatorProps, children } = props
+  const {
+    style: indicatorPropsStyle,
+    className: indicatorPropsClassName,
+    ...indicatorPropsWithoutStyle
+  } = indicatorProps ?? {}
+  const { tabKeyArray } = useTabsContext()
+  const {
+    tabSelectIndex,
+    tabsWidthMapMT,
+    indicatorOffsetMT,
+    indicatorElementMT,
+    hasRenderedIndicatorMT,
+    selectBehavior,
+    indicatorAnimation,
+    selectTarget,
+    onTabChanged,
+    debugLog,
+    enableRTL,
+  } = useTabsRootContext()
+
+  const offsetMotionRef = indicatorOffsetMT
+  const tabChangeHandledBySelectTargetMT = useMainThreadRef<number>(-1)
+
+  const updateIndicator = (params: { width: number, left: number }) => {
+    'main thread'
+    mtsLog(debugLog, '[lynx-ui tabs] update indicator', params)
+    indicatorElementMT.current?.setStyleProperties(
+      getIndicatorStyleProperties(params.width, params.left, enableRTL),
+    )
+  }
+
+  const calcFromOffset = (
+    offset: number,
+  ): { width: number, left: number } | undefined => {
+    'main thread'
+    return calculateIndicatorPosition(
+      offset,
+      tabKeyArray,
+      tabsWidthMapMT.current.get(),
+    )
+  }
+
+  const updateIndicatorAtOffset = (offset: number) => {
+    'main thread'
+    const indicatorPosition = calcFromOffset(offset)
+    if (!indicatorPosition) {
+      return
+    }
+    updateIndicator(indicatorPosition)
+    hasRenderedIndicatorMT.current = true
+  }
+
+  const updateIndicatorPosition = () => {
+    'main thread'
+    offsetMotionRef.current.stop()
+    updateIndicatorAtOffset(offsetMotionRef.current.get())
+  }
+
+  useMotionValueRefEvent(offsetMotionRef, 'change', (offset) => {
+    'main thread'
+    updateIndicatorAtOffset(offset)
+  })
+
+  const syncIndicatorOffset = (offset: number) => {
+    'main thread'
+    offsetMotionRef.current.stop()
+    offsetMotionRef.current.jump(offset)
+  }
+
+  const animateToTab = (toIndex: number) => {
+    'main thread'
+    offsetMotionRef.current.stop()
+    mtsLog(
+      debugLog,
+      '[lynx-ui tabs] animateToTab',
+      'fromIndex:',
+      offsetMotionRef.current.get(),
+      'toIndex:',
+      toIndex,
+    )
+    animate(
+      offsetMotionRef.current,
+      toIndex,
+      toMiniAnimationOptions(indicatorAnimation),
+    )
+  }
+
+  useMotionValueRefEvent(tabsWidthMapMT, 'change', () => {
+    'main thread'
+    updateIndicatorAtOffset(offsetMotionRef.current.get())
+  })
+
+  const onTabChangedJS = (index: number) => {
+    onTabChanged?.(index)
+  }
+  useMotionValueRefEvent(
+    selectTarget,
+    'change',
+    (target: { index: number, smooth: boolean }) => {
+      'main thread'
+      if (target.index < 0 || target.index >= tabKeyArray.length) {
+        return
+      }
+      const { index, smooth } = target
+      if (hasRenderedIndicatorMT.current && smooth) {
+        animateToTab(index)
+      } else {
+        syncIndicatorOffset(index)
+      }
+      runOnBackground(onTabChangedJS)(index)
+      tabChangeHandledBySelectTargetMT.current = index
+    },
+  )
+
+  useMotionValueRefEvent(tabSelectIndex, 'change', (index) => {
+    'main thread'
+    mtsLog(debugLog, '[lynx-ui tabs] tabSelectIndex', index, tabKeyArray.length)
+    if (index < 0 || index > tabKeyArray.length - 1) {
+      return
+    }
+    if (
+      hasRenderedIndicatorMT.current
+      && shouldAnimateIndicator(selectBehavior)
+    ) {
+      animateToTab(index)
+    } else {
+      syncIndicatorOffset(index)
+    }
+    if (tabChangeHandledBySelectTargetMT.current === index) {
+      tabChangeHandledBySelectTargetMT.current = -1
+    } else {
+      runOnBackground(onTabChangedJS)(index)
+    }
+  })
+
+  useEffect(() => {
+    runOnMainThread(() => {
+      'main thread'
+      updateIndicatorPosition()
+    })()
+  }, [enableRTL])
+
+  return (
+    <view
+      {...indicatorPropsWithoutStyle}
+      main-thread:ref={indicatorElementMT}
+      style={indicatorPropsStyle ?? style}
+      className={clsx(
+        'lynx-ui-tab-group__indicator',
+        indicatorPropsClassName,
+        className,
+      )}
+    >
+      {children}
+    </view>
+  )
+}

--- a/packages/lynx-ui-tab-group/src/TabsItem.tsx
+++ b/packages/lynx-ui-tab-group/src/TabsItem.tsx
@@ -1,0 +1,146 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import {
+  runOnMainThread,
+  useContext,
+  useEffect,
+  useMainThreadRef,
+  useMemo,
+} from '@lynx-js/react'
+
+import { mtsLog } from '@lynx-js/lynx-ui-common'
+import { useMotionValueRefEvent } from '@lynx-js/motion/mini'
+import type { LayoutChangeDetailEvent, MainThread } from '@lynx-js/types'
+
+import { TabsContext, useTabsRootContext } from './TabsContext'
+import type { TabItemProps } from './types'
+import { getIndicatorStyleProperties } from './utils/tabsIndicatorAnimation'
+import { calculateIndicatorPosition } from './utils/tabsIndicatorGeometry'
+
+let nextTabRegistrationId = 0
+
+export const TabsItem = (props: TabItemProps) => {
+  const { style, className, tabKey, children } = props
+  const { selectTab, tabKeyArray } = useContext(
+    TabsContext,
+  )
+  const {
+    tabsWidthMapMT,
+    tabRegistrationMapMT,
+    indicatorOffsetMT,
+    indicatorElementMT,
+    hasRenderedIndicatorMT,
+    isFirstScreenSyncMT,
+    onClickItem,
+    selectTarget,
+    debugLog,
+    enableRTL,
+    selectBehavior,
+  } = useTabsRootContext()
+  const MTSViewRef = useMainThreadRef<MainThread.Element>(null)
+  const tabRegistrationId = useMemo(() => nextTabRegistrationId++, [tabKey])
+
+  const scrollToCenterMT = (smooth = true) => {
+    'main thread'
+    MTSViewRef.current?.invoke('scrollIntoView', {
+      scrollIntoViewOptions: {
+        block: 'center',
+        inline: 'center',
+        ...(smooth ? { behavior: 'smooth' } : {}),
+      },
+    })
+  }
+
+  const scrollToCenterAfterInitialAlignmentMT = (smooth: boolean) => {
+    'main thread'
+    const shouldSmooth = !isFirstScreenSyncMT.current && smooth
+    scrollToCenterMT(shouldSmooth)
+  }
+
+  const onClick = () => {
+    runOnMainThread(scrollToCenterMT)(selectBehavior !== 'instant')
+    selectTab(tabKey)
+    onClickItem?.(tabKeyArray.indexOf(tabKey))
+  }
+
+  useMotionValueRefEvent(
+    selectTarget,
+    'change',
+    (target: { index: number, smooth: boolean }) => {
+      'main thread'
+      if (tabKey === tabKeyArray[target.index]) {
+        scrollToCenterAfterInitialAlignmentMT(target.smooth)
+      }
+    },
+  )
+
+  const updateIndicatorPositionMT = () => {
+    'main thread'
+    const indicatorPosition = calculateIndicatorPosition(
+      indicatorOffsetMT.current.get(),
+      tabKeyArray,
+      tabsWidthMapMT.current.get(),
+    )
+    if (!indicatorPosition) {
+      return
+    }
+
+    indicatorElementMT.current?.setStyleProperties(
+      getIndicatorStyleProperties(
+        indicatorPosition.width,
+        indicatorPosition.left,
+        enableRTL,
+      ),
+    )
+    hasRenderedIndicatorMT.current = true
+  }
+  const registerTabWidthMT = (width: number) => {
+    'main thread'
+    mtsLog(debugLog, '[lynx-ui tabs] registerTabWidthMT', tabKey, width)
+    tabsWidthMapMT.current.set({
+      ...tabsWidthMapMT.current.get(),
+      [tabKey]: width,
+    })
+    tabRegistrationMapMT.current[tabKey] = tabRegistrationId
+    updateIndicatorPositionMT()
+  }
+  const unregisterTabWidthMT = (key: string, registrationId: number) => {
+    'main thread'
+    if (tabRegistrationMapMT.current[key] !== registrationId) {
+      return
+    }
+    mtsLog(debugLog, '[lynx-ui tabs] unregisterTabWidthMT', key)
+    const nextValue = { ...tabsWidthMapMT.current.get() }
+    delete nextValue[key]
+    tabsWidthMapMT.current.set(nextValue)
+    delete tabRegistrationMapMT.current[key]
+  }
+
+  const onLayoutChange = (e: LayoutChangeDetailEvent<MainThread.Element>) => {
+    'main thread'
+    const width = e.detail?.width
+    if (typeof width !== 'number') {
+      return
+    }
+    registerTabWidthMT(width)
+  }
+
+  useEffect(() => {
+    return () => {
+      runOnMainThread(unregisterTabWidthMT)(tabKey, tabRegistrationId)
+    }
+  }, [tabKey, tabRegistrationId])
+
+  return (
+    <view
+      main-thread:ref={MTSViewRef}
+      bindtap={onClick}
+      className={className}
+      style={style}
+      main-thread:bindlayoutchange={onLayoutChange}
+    >
+      {children}
+    </view>
+  )
+}

--- a/packages/lynx-ui-tab-group/src/TabsItem.tsx
+++ b/packages/lynx-ui-tab-group/src/TabsItem.tsx
@@ -33,6 +33,7 @@ export const TabsItem = (props: TabItemProps) => {
     hasRenderedIndicatorMT,
     isFirstScreenSyncMT,
     onClickItem,
+    panelIndex,
     selectTarget,
     debugLog,
     enableRTL,
@@ -63,6 +64,14 @@ export const TabsItem = (props: TabItemProps) => {
     selectTab(tabKey)
     onClickItem?.(tabKeyArray.indexOf(tabKey))
   }
+
+  useMotionValueRefEvent(panelIndex, 'change', (index) => {
+    'main thread'
+    const panelSelectKey = tabKeyArray[index]
+    if (tabKey === panelSelectKey) {
+      scrollToCenterAfterInitialAlignmentMT(true)
+    }
+  })
 
   useMotionValueRefEvent(
     selectTarget,

--- a/packages/lynx-ui-tab-group/src/TabsPanel.tsx
+++ b/packages/lynx-ui-tab-group/src/TabsPanel.tsx
@@ -1,0 +1,127 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import {
+  forwardRef,
+  memo,
+  runOnBackground,
+  runOnMainThread,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from '@lynx-js/react'
+
+import { log, mtsLog } from '@lynx-js/lynx-ui-common'
+import { ViewPager } from '@lynx-js/lynx-ui-view-pager'
+import type {
+  ViewPagerChangeEvent,
+  ViewPagerOffsetChangeEvent,
+  ViewPagerProps,
+  ViewPagerRef,
+} from '@lynx-js/lynx-ui-view-pager'
+import { useMotionValueRefEvent } from '@lynx-js/motion/mini'
+
+import { useTabsRootContext } from './TabsContext'
+import type { TabsPanelProps, TabsPanelRef } from './types'
+
+export const TabsPanel = memo(
+  forwardRef<TabsPanelRef, TabsPanelProps>(function TabsPanel(
+    props: TabsPanelProps,
+    ref,
+  ) {
+    const {
+      debugLog,
+      initialSelectIndex,
+      panelIndex,
+      panelOffset,
+      tabSelectIndex,
+      hasPanel,
+      selectBehavior,
+      onTabChanged,
+      selectTarget,
+      isFirstScreenSyncMT,
+    } = useTabsRootContext()
+
+    const viewpagerRef = useRef<ViewPagerRef>(null)
+
+    useImperativeHandle(ref, () => ({
+      selectTab,
+    }))
+
+    const selectTab = (
+      index: number,
+      smooth?: boolean,
+      success?: (res: unknown) => void,
+      fail?: (res: unknown) => void,
+    ) => {
+      viewpagerRef.current?.selectTab(index, smooth, success, fail)
+    }
+
+    const setHasPanelMT = (has: boolean) => {
+      'main thread'
+      hasPanel.current.set(has)
+    }
+
+    // Make sure the Tabs know the ViewPager is mounted and cooperating
+    useEffect(() => {
+      runOnMainThread(setHasPanelMT)(true)
+      return () => {
+        runOnMainThread(setHasPanelMT)(false)
+      }
+    }, [])
+
+    const changeIndexMT: NonNullable<ViewPagerProps['MTOnPageWillChange']> = (
+      e,
+    ) => {
+      'main thread'
+      mtsLog(debugLog, '[lynx-ui tabs] changeIndex', e.detail.index)
+      panelIndex.current.set(e.detail.index)
+      props.MTOnPageWillChange?.(e)
+    }
+
+    const changeOffsetMT = (e: ViewPagerOffsetChangeEvent) => {
+      'main thread'
+      mtsLog(debugLog, '[lynx-ui tabs] changeOffset', e.detail.offset)
+      panelOffset.current.set(e.detail.offset)
+      props.MTOnOffsetChange?.(e)
+    }
+
+    const onPageChange = (e: ViewPagerChangeEvent) => {
+      log(debugLog, '[lynx-ui tabs] onPageChange', e.detail.index)
+      props.onPageChange?.(e)
+      onTabChanged?.(e.detail.index)
+    }
+
+    useMotionValueRefEvent(tabSelectIndex, 'change', (index) => {
+      'main thread'
+      const shouldSmooth = !isFirstScreenSyncMT.current
+        && selectBehavior === 'smooth'
+      runOnBackground(selectTab)(index, shouldSmooth)
+    })
+
+    useMotionValueRefEvent(
+      selectTarget,
+      'change',
+      (target: { index: number, smooth: boolean }) => {
+        'main thread'
+        const { index, smooth } = target
+        if (index < 0) return
+        runOnBackground(selectTab)(
+          index,
+          !isFirstScreenSyncMT.current && smooth,
+        )
+      },
+    )
+
+    return (
+      <ViewPager
+        {...props}
+        ref={viewpagerRef}
+        initialSelectIndex={initialSelectIndex}
+        onPageChange={onPageChange}
+        MTOnOffsetChange={changeOffsetMT}
+        MTOnPageWillChange={changeIndexMT}
+      />
+    )
+  }),
+)

--- a/packages/lynx-ui-tab-group/src/TabsRoot.tsx
+++ b/packages/lynx-ui-tab-group/src/TabsRoot.tsx
@@ -1,0 +1,129 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import {
+  forwardRef,
+  runOnMainThread,
+  useEffect,
+  useImperativeHandle,
+  useMainThreadRef,
+  useMemo,
+} from '@lynx-js/react'
+
+import { useMotionValueRef } from '@lynx-js/motion/mini'
+import type { MainThread } from '@lynx-js/types'
+
+import { TabsRootContext } from './TabsContext'
+import type { TabsRootProps, TabsRootRef } from './types'
+
+function useDataSubscript(initValue: number) {
+  const tabSelectIndex = useMotionValueRef<number>(initValue)
+  const tabsWidthMapMT = useMotionValueRef<Record<string, number>>({})
+  const tabRegistrationMapMT = useMainThreadRef<Record<string, number>>({})
+  const indicatorOffsetMT = useMotionValueRef<number>(initValue)
+  const indicatorElementMT = useMainThreadRef<MainThread.Element>(null)
+  const hasRenderedIndicatorMT = useMainThreadRef<boolean>(false)
+  const isFirstScreenSyncMT = useMainThreadRef<boolean>(true)
+  const selectTarget = useMotionValueRef<{ index: number, smooth: boolean }>({
+    index: -1,
+    smooth: false,
+  })
+
+  return {
+    tabSelectIndex,
+    tabsWidthMapMT,
+    tabRegistrationMapMT,
+    indicatorOffsetMT,
+    indicatorElementMT,
+    hasRenderedIndicatorMT,
+    isFirstScreenSyncMT,
+    selectTarget,
+  }
+}
+
+export const TabsRoot = forwardRef<TabsRootRef, TabsRootProps>((props, ref) => {
+  const {
+    initialSelectIndex = 0,
+    debugLog = false,
+    children,
+    onClickItem,
+    onTabChanged,
+    selectBehavior = 'smooth',
+    indicatorAnimation,
+    enableRTL = false,
+  } = props
+  const {
+    tabSelectIndex,
+    tabsWidthMapMT,
+    tabRegistrationMapMT,
+    indicatorOffsetMT,
+    indicatorElementMT,
+    hasRenderedIndicatorMT,
+    isFirstScreenSyncMT,
+    selectTarget,
+  } = useDataSubscript(initialSelectIndex)
+
+  const clearFirstScreenSyncMT = () => {
+    'main thread'
+    isFirstScreenSyncMT.current = false
+  }
+
+  useEffect(() => {
+    runOnMainThread(clearFirstScreenSyncMT)()
+  }, [])
+
+  const tabsRootContextValue = useMemo(
+    () => ({
+      debugLog,
+      enableRTL,
+      selectBehavior,
+      indicatorAnimation,
+      initialSelectIndex,
+      tabSelectIndex,
+      tabsWidthMapMT,
+      tabRegistrationMapMT,
+      indicatorOffsetMT,
+      indicatorElementMT,
+      hasRenderedIndicatorMT,
+      isFirstScreenSyncMT,
+      onTabChanged,
+      onClickItem,
+      selectTarget,
+    }),
+    [
+      debugLog,
+      enableRTL,
+      selectBehavior,
+      indicatorAnimation,
+      initialSelectIndex,
+      onClickItem,
+      onTabChanged,
+      tabSelectIndex,
+      tabsWidthMapMT,
+      tabRegistrationMapMT,
+      indicatorOffsetMT,
+      indicatorElementMT,
+      hasRenderedIndicatorMT,
+      isFirstScreenSyncMT,
+      selectTarget,
+    ],
+  )
+
+  const selectTabMT = (target: { index: number, smooth: boolean }) => {
+    'main thread'
+    selectTarget.current.set(target)
+    tabSelectIndex.current.set(target.index)
+  }
+
+  useImperativeHandle(ref, () => ({
+    selectTab: (index: number, smooth: boolean) => {
+      runOnMainThread(selectTabMT)({ index, smooth })
+    },
+  }))
+
+  return (
+    <TabsRootContext.Provider value={tabsRootContextValue}>
+      {children}
+    </TabsRootContext.Provider>
+  )
+})

--- a/packages/lynx-ui-tab-group/src/TabsRoot.tsx
+++ b/packages/lynx-ui-tab-group/src/TabsRoot.tsx
@@ -17,6 +17,9 @@ import { TabsRootContext } from './TabsContext'
 import type { TabsRootProps, TabsRootRef } from './types'
 
 function useDataSubscript(initValue: number) {
+  const hasPanel = useMotionValueRef<boolean>(false)
+  const panelOffset = useMotionValueRef<number>(initValue)
+  const panelIndex = useMotionValueRef<number>(initValue)
   const tabSelectIndex = useMotionValueRef<number>(initValue)
   const tabsWidthMapMT = useMotionValueRef<Record<string, number>>({})
   const tabRegistrationMapMT = useMainThreadRef<Record<string, number>>({})
@@ -30,6 +33,9 @@ function useDataSubscript(initValue: number) {
   })
 
   return {
+    hasPanel,
+    panelIndex,
+    panelOffset,
     tabSelectIndex,
     tabsWidthMapMT,
     tabRegistrationMapMT,
@@ -53,6 +59,8 @@ export const TabsRoot = forwardRef<TabsRootRef, TabsRootProps>((props, ref) => {
     enableRTL = false,
   } = props
   const {
+    panelIndex,
+    panelOffset,
     tabSelectIndex,
     tabsWidthMapMT,
     tabRegistrationMapMT,
@@ -60,6 +68,7 @@ export const TabsRoot = forwardRef<TabsRootRef, TabsRootProps>((props, ref) => {
     indicatorElementMT,
     hasRenderedIndicatorMT,
     isFirstScreenSyncMT,
+    hasPanel,
     selectTarget,
   } = useDataSubscript(initialSelectIndex)
 
@@ -79,6 +88,9 @@ export const TabsRoot = forwardRef<TabsRootRef, TabsRootProps>((props, ref) => {
       selectBehavior,
       indicatorAnimation,
       initialSelectIndex,
+      hasPanel,
+      panelIndex,
+      panelOffset,
       tabSelectIndex,
       tabsWidthMapMT,
       tabRegistrationMapMT,
@@ -96,8 +108,11 @@ export const TabsRoot = forwardRef<TabsRootRef, TabsRootProps>((props, ref) => {
       selectBehavior,
       indicatorAnimation,
       initialSelectIndex,
+      hasPanel,
       onClickItem,
       onTabChanged,
+      panelIndex,
+      panelOffset,
       tabSelectIndex,
       tabsWidthMapMT,
       tabRegistrationMapMT,

--- a/packages/lynx-ui-tab-group/src/index.css
+++ b/packages/lynx-ui-tab-group/src/index.css
@@ -1,0 +1,11 @@
+.lynx-ui-tab-group__items {
+  display: flex;
+  flex-direction: row;
+  position: relative;
+  z-index: 0;
+}
+
+.lynx-ui-tab-group__indicator {
+  bottom: 0px;
+  position: absolute;
+}

--- a/packages/lynx-ui-tab-group/src/index.tsx
+++ b/packages/lynx-ui-tab-group/src/index.tsx
@@ -4,6 +4,7 @@
 export { TabsRoot } from './TabsRoot'
 export { TabsBar } from './TabsBar'
 export { TabsItem } from './TabsItem'
+export { TabsPanel } from './TabsPanel'
 export { TabsIndicator } from './TabsIndicator'
 
 export type {
@@ -11,6 +12,8 @@ export type {
   TabsData,
   TabsIndicatorAnimation,
   TabsIndicatorProps,
+  TabsPanelProps,
+  TabsPanelRef,
   TabsRootProps,
   TabsBarProps,
   TabsRootRef,

--- a/packages/lynx-ui-tab-group/src/index.tsx
+++ b/packages/lynx-ui-tab-group/src/index.tsx
@@ -1,0 +1,17 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+export { TabsRoot } from './TabsRoot'
+export { TabsBar } from './TabsBar'
+export { TabsItem } from './TabsItem'
+export { TabsIndicator } from './TabsIndicator'
+
+export type {
+  TabItemProps,
+  TabsData,
+  TabsIndicatorAnimation,
+  TabsIndicatorProps,
+  TabsRootProps,
+  TabsBarProps,
+  TabsRootRef,
+} from './types'

--- a/packages/lynx-ui-tab-group/src/types/index.docs.ts
+++ b/packages/lynx-ui-tab-group/src/types/index.docs.ts
@@ -1,10 +1,11 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { ReactNode } from '@lynx-js/react'
+import type { ForwardedRef, ReactNode } from '@lynx-js/react'
 
 import type { ComponentBasicProps } from '@lynx-js/lynx-ui-common'
 import type { ScrollViewProps } from '@lynx-js/lynx-ui-scroll-view'
+import type { ViewPagerProps, ViewPagerRef } from '@lynx-js/lynx-ui-view-pager'
 import type { StandardProps } from '@lynx-js/types'
 
 export interface TabsIndicatorAnimationSpring {
@@ -200,6 +201,12 @@ export interface TabItemProps extends StandardProps {
    * @Harmony
    */
   tabKey: string
+}
+
+export interface TabsPanelRef extends ViewPagerRef {}
+
+export interface TabsPanelProps extends Omit<ViewPagerProps, 'ref'> {
+  ref?: ForwardedRef<TabsPanelRef>
 }
 
 export interface TabsIndicatorProps extends ComponentBasicProps {

--- a/packages/lynx-ui-tab-group/src/types/index.docs.ts
+++ b/packages/lynx-ui-tab-group/src/types/index.docs.ts
@@ -1,0 +1,222 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { ReactNode } from '@lynx-js/react'
+
+import type { ComponentBasicProps } from '@lynx-js/lynx-ui-common'
+import type { ScrollViewProps } from '@lynx-js/lynx-ui-scroll-view'
+import type { StandardProps } from '@lynx-js/types'
+
+export interface TabsIndicatorAnimationSpring {
+  /**
+   * Use a spring transition for indicator motion.
+   * @zh 使用弹簧过渡驱动指示器动画。
+   */
+  type?: 'spring'
+  /**
+   * The spring stiffness of the indicator motion.
+   * @zh 指示器动画的弹簧刚度。
+   */
+  stiffness?: number
+  /**
+   * The spring damping of the indicator motion.
+   * @zh 指示器动画的弹簧阻尼。
+   */
+  damping?: number
+  /**
+   * The spring mass of the indicator motion.
+   * @zh 指示器动画的弹簧质量。
+   */
+  mass?: number
+  /**
+   * The initial velocity of the spring animation.
+   * @zh 弹簧动画的初始速度。
+   */
+  velocity?: number
+}
+
+export interface TabsIndicatorAnimationTween {
+  /**
+   * Use a tween transition for indicator motion.
+   * @zh 使用补间过渡驱动指示器动画。
+   */
+  type: 'tween'
+  /**
+   * The tween duration in milliseconds.
+   * @zh 补间动画时长，单位为毫秒。
+   */
+  duration?: number
+  /**
+   * The easing function of the tween animation.
+   * @zh 补间动画的缓动函数。
+   */
+  ease?: (t: number) => number
+}
+
+export type TabsIndicatorAnimation =
+  | TabsIndicatorAnimationSpring
+  | TabsIndicatorAnimationTween
+
+export interface TabsRootProps {
+  /**
+   * The index of the initial display. Please use `selectTab` for other updates.
+   * @zh 指定初始显示的索引。请使用 `selectTab` 进行其他更新。
+   * @defaultValue 0
+   * @Android
+   * @iOS
+   */
+  initialSelectIndex?: number
+  /**
+   * children
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh 子节点
+   */
+  children?: ReactNode
+  /**
+   * Controls how the tab bar scrolls and how the indicator moves when a tab is
+   * selected. Use `'smooth'` to animate the transition, or `'instant'` to jump
+   * to the target tab without animation.
+   * @zh 控制选中标签时标签栏的滚动方式与指示器的移动方式。`'smooth'` 表示动画过渡，`'instant'` 表示直接跳转。
+   * @defaultValue 'smooth'
+   * @Android
+   * @iOS
+   */
+  selectBehavior?: 'smooth' | 'instant'
+  /**
+   * The animation configuration for the tab indicator when switching tabs.
+   * @zh 切换标签时指示器的动画配置。
+   * @defaultValue { type: 'spring', stiffness: 300, damping: 30, mass: 1 }
+   * @Android
+   * @iOS
+   * @Harmony
+   */
+  indicatorAnimation?: TabsIndicatorAnimation
+
+  /**
+   * Click callback
+   * @zh 点击回调
+   * @eventProperty
+   * @Android
+   * @iOS
+   */
+  onClickItem?: (index: number) => void
+  /**
+   * Tab change callback
+   * @zh 标签页更改回调
+   * @eventProperty
+   * @Android
+   * @iOS
+   */
+  onTabChanged?: (index: number) => void
+
+  /**
+   * Display debug logs. Open it when you find a bug.
+   * @zh 显示调试日志。当您发现错误时，请打开此选项。
+   * @defaultValue false
+   * @iOS
+   * @Android
+   * @Harmony
+   */
+  debugLog?: boolean
+
+  /**
+   * Enable RTL layout.
+   * @zh 开启 RTL 布局。
+   * @defaultValue false
+   * @iOS
+   * @Android
+   * @Harmony
+   */
+  enableRTL?: boolean
+}
+
+export interface TabsRootRef {
+  selectTab: (index: number, smooth: boolean) => void
+}
+
+export interface TabsData<T> {
+  /**
+   * A function that returns the unique key for every Tab.
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh 返回每个 Tab 项的唯一键的函数。
+   */
+  getTabKey: () => string
+  /**
+   * The original data item for the Tab.
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh 用于渲染 Tab 的原始数据项。
+   */
+  tabItem: T
+}
+
+export interface TabsBarProps<T>
+  extends Omit<ScrollViewProps, 'children' | 'horizontal' | 'scrollOrientation'>
+{
+  /**
+   * The class apply to the internal container of child view inside scroll-view.
+   * @zh 应用于 scroll-view 内子视图的内部容器的类名。
+   * @Android
+   * @iOS
+   */
+  tabsItemWrapperClass?: string
+  /**
+   * The data for the Tabs.
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh Tabs 的数据。
+   */
+  data: TabsData<T>[]
+  /**
+   * children
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh 子节点
+   */
+  children?: ReactNode
+  /**
+   * The function used to render each tab item.
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh 用于渲染每一个 Tab 的函数。
+   */
+  renderTabItem?: (tabItem: TabsData<T>) => ReactNode
+}
+
+export interface TabItemProps extends StandardProps {
+  /**
+   * The unique key of the tab item.
+   * @zh Tab 项的唯一键。
+   * @Android
+   * @iOS
+   * @Harmony
+   */
+  tabKey: string
+}
+
+export interface TabsIndicatorProps extends ComponentBasicProps {
+  /**
+   * Raw props passed to the indicator.
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh TabsIndicator 的原始属性。
+   */
+  indicatorProps?: StandardProps
+  /**
+   * children
+   * @Android
+   * @iOS
+   * @Harmony
+   * @zh 子节点
+   */
+  children?: ReactNode
+}

--- a/packages/lynx-ui-tab-group/src/types/index.ts
+++ b/packages/lynx-ui-tab-group/src/types/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+export type * from './index.docs'

--- a/packages/lynx-ui-tab-group/src/utils/tabsIndicatorAnimation.ts
+++ b/packages/lynx-ui-tab-group/src/utils/tabsIndicatorAnimation.ts
@@ -1,0 +1,109 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { AnimationOptions, Easing } from '@lynx-js/motion/mini'
+
+import type { TabsIndicatorAnimation, TabsRootProps } from '../types'
+
+export interface TabsIndicatorAnimationSpringResolved {
+  type: 'spring'
+  stiffness: number
+  damping: number
+  mass: number
+  velocity?: number
+}
+
+export interface TabsIndicatorAnimationTweenResolved {
+  type: 'tween'
+  duration: number
+  ease?: Easing
+}
+
+export type ResolvedTabsIndicatorAnimation =
+  | TabsIndicatorAnimationSpringResolved
+  | TabsIndicatorAnimationTweenResolved
+
+export const DEFAULT_TABS_INDICATOR_TWEEN_DURATION = 250
+export const DEFAULT_TABS_INDICATOR_ANIMATION:
+  TabsIndicatorAnimationSpringResolved = {
+    type: 'spring',
+    stiffness: 300,
+    damping: 30,
+    mass: 1,
+  }
+
+export function resolveTabsIndicatorAnimation(
+  animation?: TabsIndicatorAnimation,
+): ResolvedTabsIndicatorAnimation {
+  'main thread'
+  if (!animation) {
+    return DEFAULT_TABS_INDICATOR_ANIMATION
+  }
+
+  if (animation.type === 'tween') {
+    return {
+      type: 'tween',
+      duration: animation.duration ?? DEFAULT_TABS_INDICATOR_TWEEN_DURATION,
+      ease: animation.ease,
+    }
+  }
+
+  return {
+    type: 'spring',
+    stiffness: animation.stiffness ?? 300,
+    damping: animation.damping ?? 30,
+    mass: animation.mass ?? 1,
+    velocity: animation.velocity,
+  }
+}
+
+export function toMiniAnimationOptions(
+  animation?: TabsIndicatorAnimation,
+): AnimationOptions {
+  'main thread'
+  const resolvedAnimation = resolveTabsIndicatorAnimation(animation)
+
+  if (resolvedAnimation.type === 'tween') {
+    return {
+      duration: resolvedAnimation.duration / 1000,
+      ease: resolvedAnimation.ease,
+    }
+  }
+
+  return {
+    type: 'spring',
+    stiffness: resolvedAnimation.stiffness,
+    damping: resolvedAnimation.damping,
+    mass: resolvedAnimation.mass,
+    velocity: resolvedAnimation.velocity,
+  }
+}
+
+export function shouldAnimateIndicator(
+  selectBehavior: TabsRootProps['selectBehavior'],
+) {
+  'main thread'
+  return selectBehavior === 'smooth'
+}
+
+export function getIndicatorStyleProperties(
+  width: number,
+  left: number,
+  enableRTL: boolean,
+) {
+  'main thread'
+  if (enableRTL) {
+    return {
+      width: `${width}px`,
+      right: `${left}px`,
+      left: '',
+    }
+  }
+
+  return {
+    width: `${width}px`,
+    left: `${left}px`,
+    right: '',
+  }
+}

--- a/packages/lynx-ui-tab-group/src/utils/tabsIndicatorGeometry.test.ts
+++ b/packages/lynx-ui-tab-group/src/utils/tabsIndicatorGeometry.test.ts
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, it } from 'vitest'
+
+import { calculateIndicatorPosition } from './tabsIndicatorGeometry'
+
+describe('calculateIndicatorPosition', () => {
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'returns undefined for a non-finite offset: %s',
+    offset => {
+      expect(
+        calculateIndicatorPosition(offset, ['first'], { first: 100 }),
+      ).toBeUndefined()
+    },
+  )
+})

--- a/packages/lynx-ui-tab-group/src/utils/tabsIndicatorGeometry.ts
+++ b/packages/lynx-ui-tab-group/src/utils/tabsIndicatorGeometry.ts
@@ -1,0 +1,50 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export function calculateIndicatorPosition(
+  offset: number,
+  tabKeyArray: string[],
+  tabsWidthMap: Record<string, number>,
+): { width: number, left: number } | undefined {
+  'main thread'
+  const maxIndex = tabKeyArray.length - 1
+  if (maxIndex < 0) {
+    return undefined
+  }
+
+  if (!Number.isFinite(offset)) {
+    return undefined
+  }
+
+  const boundedOffset = Math.max(0, Math.min(offset, maxIndex))
+  const leftIdx = Math.floor(boundedOffset)
+  const rightIdx = Math.ceil(boundedOffset)
+
+  for (let i = 0; i <= rightIdx; i++) {
+    if (typeof tabsWidthMap[tabKeyArray[i]] !== 'number') {
+      return undefined
+    }
+  }
+
+  let leftTotalWidth = 0
+  for (let i = 0; i < leftIdx; i++) {
+    leftTotalWidth += tabsWidthMap[tabKeyArray[i]] ?? 0
+  }
+
+  if (leftIdx === rightIdx) {
+    return {
+      width: tabsWidthMap[tabKeyArray[leftIdx]] ?? 0,
+      left: leftTotalWidth,
+    }
+  }
+
+  const currentProgressPercent = boundedOffset - leftIdx
+  const widthL = tabsWidthMap[tabKeyArray[leftIdx]] ?? 0
+  const widthR = tabsWidthMap[tabKeyArray[rightIdx]] ?? 0
+
+  return {
+    width: widthL + currentProgressPercent * (widthR - widthL),
+    left: leftTotalWidth + currentProgressPercent * widthL,
+  }
+}

--- a/packages/lynx-ui-tab-group/tsconfig.docs.json
+++ b/packages/lynx-ui-tab-group/tsconfig.docs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tools/configs/tsconfig.docs.json",
+  "include": [
+    "src",
+    "dist/types/index.docs.d.ts"
+  ]
+}

--- a/packages/lynx-ui-tab-group/tsconfig.json
+++ b/packages/lynx-ui-tab-group/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tools/configs/tsconfig.lib.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+  },
+  "include": [
+    "src",
+  ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
+}

--- a/packages/lynx-ui-tab-group/vitest.config.ts
+++ b/packages/lynx-ui-tab-group/vitest.config.ts
@@ -1,0 +1,12 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    name: 'lynx-ui-tab-group',
+  },
+})

--- a/packages/lynx-ui-view-pager/CHANGELOG.md
+++ b/packages/lynx-ui-view-pager/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lynx-js/lynx-ui-view-pager
+
+## 3.136.0
+
+### Minor Changes
+
+- Add the ViewPager component.

--- a/packages/lynx-ui-view-pager/LICENSE
+++ b/packages/lynx-ui-view-pager/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/lynx-ui-view-pager/README.md
+++ b/packages/lynx-ui-view-pager/README.md
@@ -1,0 +1,28 @@
+# @lynx-js/lynx-ui-view-pager
+
+A page-snapped horizontal content navigator for ReactLynx with optional off-screen lazy rendering.
+
+## Installation
+
+```bash
+pnpm add @lynx-js/lynx-ui
+```
+
+The standalone package is also available as `@lynx-js/lynx-ui-view-pager`.
+
+## Usage
+
+```tsx
+import { ViewPager } from '@lynx-js/lynx-ui'
+
+<ViewPager style={{ width: '100%', height: '400px' }}>
+  <view style={{ width: '100%', height: '100%' }} />
+  <view style={{ width: '100%', height: '100%' }} />
+</ViewPager>
+```
+
+[View the examples](https://github.com/lynx-family/lynx-ui/tree/main/apps/examples/ViewPager)
+
+## License
+
+[lynx-ui](https://github.com/lynx-family/lynx-ui) is licensed under the [Apache License 2.0](./LICENSE).

--- a/packages/lynx-ui-view-pager/README.md
+++ b/packages/lynx-ui-view-pager/README.md
@@ -13,11 +13,11 @@ The standalone package is also available as `@lynx-js/lynx-ui-view-pager`.
 ## Usage
 
 ```tsx
-import { ViewPager } from '@lynx-js/lynx-ui'
+import { ViewPager, ViewPagerItem } from '@lynx-js/lynx-ui'
 
 <ViewPager style={{ width: '100%', height: '400px' }}>
-  <view style={{ width: '100%', height: '100%' }} />
-  <view style={{ width: '100%', height: '100%' }} />
+  <ViewPagerItem><text>Page</text></ViewPagerItem>
+  <ViewPagerItem><text>Page</text></ViewPagerItem>
 </ViewPager>
 ```
 

--- a/packages/lynx-ui-view-pager/README_zh.md
+++ b/packages/lynx-ui-view-pager/README_zh.md
@@ -1,0 +1,28 @@
+# @lynx-js/lynx-ui-view-pager
+
+适用于 ReactLynx 的分页横向内容导航组件，支持屏外页面懒加载。
+
+## 安装
+
+```bash
+pnpm add @lynx-js/lynx-ui
+```
+
+也可以单独安装 `@lynx-js/lynx-ui-view-pager`。
+
+## 使用
+
+```tsx
+import { ViewPager } from '@lynx-js/lynx-ui'
+
+<ViewPager style={{ width: '100%', height: '400px' }}>
+  <view style={{ width: '100%', height: '100%' }} />
+  <view style={{ width: '100%', height: '100%' }} />
+</ViewPager>
+```
+
+[查看示例](https://github.com/lynx-family/lynx-ui/tree/main/apps/examples/ViewPager)
+
+## 许可证
+
+[lynx-ui](https://github.com/lynx-family/lynx-ui) 基于 [Apache License 2.0](./LICENSE) 许可发布。

--- a/packages/lynx-ui-view-pager/README_zh.md
+++ b/packages/lynx-ui-view-pager/README_zh.md
@@ -13,11 +13,11 @@ pnpm add @lynx-js/lynx-ui
 ## 使用
 
 ```tsx
-import { ViewPager } from '@lynx-js/lynx-ui'
+import { ViewPager, ViewPagerItem } from '@lynx-js/lynx-ui'
 
 <ViewPager style={{ width: '100%', height: '400px' }}>
-  <view style={{ width: '100%', height: '100%' }} />
-  <view style={{ width: '100%', height: '100%' }} />
+  <ViewPagerItem><text>Page</text></ViewPagerItem>
+  <ViewPagerItem><text>Page</text></ViewPagerItem>
 </ViewPager>
 ```
 

--- a/packages/lynx-ui-view-pager/SKILL.md
+++ b/packages/lynx-ui-view-pager/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: ViewPager
+description: Build horizontally swipeable, page-snapped content with optional lazy rendering and imperative page selection.
+---
+
+# lynx-ui-view-pager SKILL
+
+Use `ViewPager` when content should occupy one page at a time and users should move between pages with a horizontal swipe.
+
+## Minimal usable example
+
+```tsx
+import { ViewPager } from '@lynx-js/lynx-ui'
+
+export function Pages() {
+  return (
+    <ViewPager style={{ width: '100%', height: '400px' }}>
+      <view style={{ width: '100%', height: '100%' }} />
+      <view style={{ width: '100%', height: '100%' }} />
+    </ViewPager>
+  )
+}
+```
+
+## Usage guidance
+
+- Give the pager an explicit width and height.
+- Give every child page `width: '100%'` and `height: '100%'`.
+- Set `viewpagerId` only when another system needs a stable selector; omitted IDs are generated per instance.
+- Use `lazyOptions` to tune or disable off-screen lazy rendering.
+- Use a ref and `selectTab(index, smooth)` for imperative page changes.
+- Avoid absolute or fixed positioning inside pages unless the content intentionally attaches to the page root.
+
+## Recommended Prompt Formula
+
+When asking an AI agent to build with `ViewPager`, include:
+
+- **Scenario**: Describe the pages and why users swipe between them.
+- **Sizing**: Specify the pager dimensions and make every child fill the pager.
+- **Navigation**: State whether swiping, imperative `selectTab`, or both are required.
+- **Instances**: Provide an explicit `viewpagerId` only when another system needs a stable selector; otherwise the component generates one.
+- **Lazy rendering**: State whether to keep the default behavior, disable it, or customize `scene` and exposure margins through `lazyOptions`.

--- a/packages/lynx-ui-view-pager/SKILL.md
+++ b/packages/lynx-ui-view-pager/SKILL.md
@@ -1,22 +1,25 @@
 ---
-name: ViewPager
-description: Build horizontally swipeable, page-snapped content with optional lazy rendering and imperative page selection.
+name: view-pager
+description: Build horizontally swipeable, page-snapped content with composable pages, lazy mounting, and imperative navigation.
 ---
 
 # lynx-ui-view-pager SKILL
 
-Use `ViewPager` when content should occupy one page at a time and users should move between pages with a horizontal swipe.
+Use `ViewPager` for horizontal paging and `ViewPagerItem` for each native page container.
 
 ## Minimal usable example
 
 ```tsx
-import { ViewPager } from '@lynx-js/lynx-ui'
+import { useRef } from '@lynx-js/react'
+import { ViewPager, ViewPagerItem } from '@lynx-js/lynx-ui'
+import type { ViewPagerRef } from '@lynx-js/lynx-ui'
 
 export function Pages() {
+  const pager = useRef<ViewPagerRef>(null)
   return (
-    <ViewPager style={{ width: '100%', height: '400px' }}>
-      <view style={{ width: '100%', height: '100%' }} />
-      <view style={{ width: '100%', height: '100%' }} />
+    <ViewPager ref={pager} style={{ height: '400px' }}>
+      <ViewPagerItem key='first'><text>First page</text></ViewPagerItem>
+      <ViewPagerItem key='second'><text>Second page</text></ViewPagerItem>
     </ViewPager>
   )
 }
@@ -24,19 +27,17 @@ export function Pages() {
 
 ## Usage guidance
 
-- Give the pager an explicit width and height.
-- Give every child page `width: '100%'` and `height: '100%'`.
-- Set `viewpagerId` only when another system needs a stable selector; omitted IDs are generated per instance.
-- Use `lazyOptions` to tune or disable off-screen lazy rendering.
-- Use a ref and `selectTab(index, smooth)` for imperative page changes.
-- Avoid absolute or fixed positioning inside pages unless the content intentionally attaches to the page root.
+- Give the pager an explicit height. The structural CSS supplies full-width horizontal paging.
+- Use direct `ViewPagerItem` children. Arrays and conditional items are supported; fragments and wrapper components are not.
+- Give dynamic items stable keys. Keys preserve mounted content; selection follows the numeric position after reordering. Removing the selected last page clamps selection to the new last page.
+- Set `initialSelectIndex` for initial selection. Later changes to it are ignored. Navigate with `ref.current?.selectTab(index, smooth)`; animation defaults to true.
+- Use `onPageChange(event)` to observe completion, including native swipes. The imperative success callback confirms invocation, not animation completion.
+- No IDs or exposure scenes are needed. Optional external IDs belong in `viewpagerProps`.
+- Lazy mounting defaults to the selected page and one neighbor on either side. Use `preloadCount={0}` to mount only the selected page and transition destination, or `lazy={false}` to mount all pages. Mounted content remains mounted until its keyed item is removed.
+- Style each item through `className` and `style`; use `.ui-selected` for selection styling. Render-prop children receive `{ index, selected }`.
+- Put native accessibility attributes in `viewpagerProps` or `itemProps`. Use the dedicated component props for root styles and events.
+- Offset events contain page progress, not pixels: the first transition runs from 0 to 1. Main-thread event handlers must be main thread functions.
 
 ## Recommended Prompt Formula
 
-When asking an AI agent to build with `ViewPager`, include:
-
-- **Scenario**: Describe the pages and why users swipe between them.
-- **Sizing**: Specify the pager dimensions and make every child fill the pager.
-- **Navigation**: State whether swiping, imperative `selectTab`, or both are required.
-- **Instances**: Provide an explicit `viewpagerId` only when another system needs a stable selector; otherwise the component generates one.
-- **Lazy rendering**: State whether to keep the default behavior, disable it, or customize `scene` and exposure margins through `lazyOptions`.
+Specify the pager dimensions, page content and stable keys, initial selection, navigation controls, and whether all content or only nearby pages should mount initially. Describe per-page styling and accessibility labels separately from navigation behavior.

--- a/packages/lynx-ui-view-pager/__tests__/ViewPager.test.tsx
+++ b/packages/lynx-ui-view-pager/__tests__/ViewPager.test.tsx
@@ -1,0 +1,198 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// cspell:ignore willchange
+
+import { createRef, useState } from '@lynx-js/react'
+
+import {
+  act,
+  createEvent,
+  fireEvent,
+  render,
+} from '@lynx-js/react/testing-library'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ViewPager, ViewPagerItem } from '../src'
+import type { ViewPagerRef } from '../src'
+
+function pages(prefix = '') {
+  return ['A', 'B', 'C'].map(label => (
+    <ViewPagerItem key={label}>
+      <text>{`${prefix}${label}`}</text>
+    </ViewPagerItem>
+  ))
+}
+
+function pageEvent(
+  element: Element,
+  name: string,
+  index: number,
+  isDragged: boolean,
+) {
+  const event = createEvent(`bindEvent:${name}`, element)
+  Object.assign(event, {
+    eventType: 'bindEvent',
+    eventName: name,
+    detail: { index, isDragged },
+  })
+  fireEvent(element, event)
+}
+
+const invoke = vi.fn(() => ({ exec: vi.fn() }))
+
+beforeEach(() => {
+  invoke.mockClear()
+  // ReactLynx renders real components; only the unimplemented native method is mocked.
+  const prototype = Object.getPrototypeOf(
+    lynx.createSelectorQuery().selectUniqueID(0),
+  )
+  vi.spyOn(prototype, 'invoke').mockImplementation(invoke)
+})
+
+describe('ViewPager', () => {
+  it('renders native item children and forwards item accessibility and styling', () => {
+    const { container } = render(
+      <ViewPager lazy={false}>
+        <ViewPagerItem
+          className='custom'
+          itemProps={{ 'accessibility-label': 'Page A' }}
+        >
+          {({ index, selected }) => <text>{`${index}:${selected}`}</text>}
+        </ViewPagerItem>
+      </ViewPager>,
+    )
+    const pager = container.querySelector('viewpager')!
+    expect(pager.hasAttribute('id')).toBe(false)
+    expect(pager.children).toHaveLength(1)
+    expect(pager.firstElementChild?.tagName.toLowerCase()).toBe(
+      'viewpager-item',
+    )
+    expect(pager.firstElementChild?.className).toContain('ui-selected')
+    expect(pager.firstElementChild?.className).toContain('custom')
+    expect(pager.firstElementChild?.getAttribute('accessibility-label')).toBe(
+      'Page A',
+    )
+  })
+
+  it('keeps two lazy pagers independent and honors initialSelectIndex only on mount', () => {
+    const ref = createRef<ViewPagerRef>()
+    function Pair({ initial }: { initial: number }) {
+      return (
+        <view>
+          <ViewPager ref={ref} initialSelectIndex={initial} preloadCount={0}>
+            {pages('first-')}
+          </ViewPager>
+          <ViewPager preloadCount={0}>{pages('second-')}</ViewPager>
+        </view>
+      )
+    }
+    const { queryByText, rerender } = render(<Pair initial={1} />)
+    expect(queryByText('first-B')).not.toBeNull()
+    expect(queryByText('first-A')).toBeNull()
+    expect(queryByText('second-B')).toBeNull()
+    act(() => ref.current?.selectTab(2, false))
+    expect(queryByText('first-C')).not.toBeNull()
+    expect(queryByText('first-B')).not.toBeNull()
+    expect(queryByText('second-C')).toBeNull()
+    rerender(<Pair initial={0} />)
+    expect(queryByText('first-A')).toBeNull()
+  })
+
+  it('invokes the native ref and updates selected state only on completion', () => {
+    const ref = createRef<ViewPagerRef>()
+    const onPageChange = vi.fn()
+    const success = vi.fn()
+    const fail = vi.fn()
+    const { container } = render(
+      <ViewPager ref={ref} onPageChange={onPageChange}>{pages()}</ViewPager>,
+    )
+    act(() => ref.current?.selectTab(2, false, success, fail))
+    expect(invoke).toHaveBeenCalledWith({
+      method: 'selectTab',
+      params: { index: 2, smooth: false },
+      success,
+      fail,
+    })
+    const pager = container.querySelector('viewpager')!
+    expect(pager.children[0]?.className).toContain('ui-selected')
+    pageEvent(pager, 'change', 2, false)
+    expect(onPageChange).toHaveBeenCalledTimes(1)
+    expect(pager.children[2]?.className).toContain('ui-selected')
+  })
+
+  it('loads a swipe destination before completion and reports swipe events', () => {
+    const onPageWillChange = vi.fn()
+    const onPageChange = vi.fn()
+    const { container, queryByText } = render(
+      <ViewPager
+        preloadCount={0}
+        onPageWillChange={onPageWillChange}
+        onPageChange={onPageChange}
+      >
+        {pages()}
+      </ViewPager>,
+    )
+    const pager = container.querySelector('viewpager')!
+    expect(queryByText('B')).toBeNull()
+    pageEvent(pager, 'willchange', 1, true)
+    expect(queryByText('B')).not.toBeNull()
+    expect(onPageWillChange).toHaveBeenCalledTimes(1)
+    pageEvent(pager, 'change', 1, true)
+    expect(onPageChange).toHaveBeenCalledTimes(1)
+    expect(pager.children[1]?.className).toContain('ui-selected')
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('preserves mounted page state through navigation and keyed reordering', () => {
+    function Counter() {
+      const [count, setCount] = useState(0)
+      return (
+        <text bindtap={() => setCount(value => value + 1)}>
+          {`Count ${count}`}
+        </text>
+      )
+    }
+    const ref = createRef<ViewPagerRef>()
+    const a = (
+      <ViewPagerItem key='a'>
+        <Counter />
+      </ViewPagerItem>
+    )
+    const b = (
+      <ViewPagerItem key='b'>
+        <text>Other</text>
+      </ViewPagerItem>
+    )
+    const { getByText, rerender } = render(
+      <ViewPager ref={ref} preloadCount={0}>{[a, b]}</ViewPager>,
+    )
+    fireEvent.tap(getByText('Count 0'))
+    act(() => ref.current?.selectTab(1, false))
+    expect(getByText('Count 1')).toBeDefined()
+    rerender(<ViewPager ref={ref} preloadCount={0}>{[b, a]}</ViewPager>)
+    expect(getByText('Count 1')).toBeDefined()
+  })
+
+  it('clamps selection after removal and ignores empty-pager requests', () => {
+    const ref = createRef<ViewPagerRef>()
+    const onPageChange = vi.fn()
+    const { container, rerender } = render(
+      <ViewPager ref={ref} initialSelectIndex={2} onPageChange={onPageChange}>
+        {pages()}
+      </ViewPager>,
+    )
+    rerender(
+      <ViewPager ref={ref} onPageChange={onPageChange}>
+        {pages().slice(0, 1)}
+      </ViewPager>,
+    )
+    expect(container.querySelector('viewpager-item')?.className).toContain(
+      'ui-selected',
+    )
+    rerender(<ViewPager ref={ref} onPageChange={onPageChange} />)
+    act(() => ref.current?.selectTab(10))
+    expect(onPageChange).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lynx-ui-view-pager/__tests__/utils.test.ts
+++ b/packages/lynx-ui-view-pager/__tests__/utils.test.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, it } from 'vitest'
+
+import { createViewPagerId, resolveLazyOptions } from '../src/utils'
+
+describe('ViewPager utilities', () => {
+  it('creates a distinct fallback id for each instance', () => {
+    expect(createViewPagerId()).not.toBe(createViewPagerId())
+  })
+
+  it('resolves partial lazy options per field', () => {
+    expect(resolveLazyOptions({
+      enableLazy: true,
+      scene: 'feed',
+      estimatedItemStyle: {},
+    }, {})).toEqual({
+      enableLazy: true,
+      scene: 'feed',
+      exposureLeft: '50px',
+      exposureRight: '50px',
+    })
+  })
+
+  it('uses deprecated props only when lazy options omit a field', () => {
+    expect(resolveLazyOptions(undefined, {
+      scene: 'legacy',
+      exposureLeft: '20px',
+      exposureRight: '30px',
+    })).toEqual({
+      enableLazy: true,
+      scene: 'legacy',
+      exposureLeft: '20px',
+      exposureRight: '30px',
+    })
+  })
+
+  it('keeps lazy rendering disabled', () => {
+    expect(resolveLazyOptions({ enableLazy: false }, {})).toMatchObject({
+      enableLazy: false,
+    })
+  })
+})

--- a/packages/lynx-ui-view-pager/__tests__/utils.test.ts
+++ b/packages/lynx-ui-view-pager/__tests__/utils.test.ts
@@ -4,42 +4,17 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { createViewPagerId, resolveLazyOptions } from '../src/utils'
+import { normalizeIndex } from '../src/utils'
 
-describe('ViewPager utilities', () => {
-  it('creates a distinct fallback id for each instance', () => {
-    expect(createViewPagerId()).not.toBe(createViewPagerId())
-  })
-
-  it('resolves partial lazy options per field', () => {
-    expect(resolveLazyOptions({
-      enableLazy: true,
-      scene: 'feed',
-      estimatedItemStyle: {},
-    }, {})).toEqual({
-      enableLazy: true,
-      scene: 'feed',
-      exposureLeft: '50px',
-      exposureRight: '50px',
-    })
-  })
-
-  it('uses deprecated props only when lazy options omit a field', () => {
-    expect(resolveLazyOptions(undefined, {
-      scene: 'legacy',
-      exposureLeft: '20px',
-      exposureRight: '30px',
-    })).toEqual({
-      enableLazy: true,
-      scene: 'legacy',
-      exposureLeft: '20px',
-      exposureRight: '30px',
-    })
-  })
-
-  it('keeps lazy rendering disabled', () => {
-    expect(resolveLazyOptions({ enableLazy: false }, {})).toMatchObject({
-      enableLazy: false,
-    })
+describe('page selection bounds', () => {
+  it.each([
+    [-1, 3, 0],
+    [100, 3, 2],
+    [1.9, 3, 1],
+    [Number.NaN, 3, 0],
+    [Number.POSITIVE_INFINITY, 3, 0],
+    [2, 0, 0],
+  ])('normalizes %s for %s pages to %s', (index, count, expected) => {
+    expect(normalizeIndex(index, count)).toBe(expected)
   })
 })

--- a/packages/lynx-ui-view-pager/docs/APIReference.mdx
+++ b/packages/lynx-ui-view-pager/docs/APIReference.mdx
@@ -1,0 +1,649 @@
+import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+
+## ViewPagerProps
+
+### Properties
+<UIApiTable source={[
+  {
+    "name": "bounces",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Enable iOS bounces spring effect"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "启用 iOS 弹性效果"
+      }
+    ],
+    "defaultValue": "true",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "children",
+    "type": "ReactElement[]",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Children, which is ViewPagerItems."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "子元素, 即 ViewPagerItems。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "className",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "className"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "类名"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "enableScroll",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Enable horizontal scroll."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "启用水平滚动。"
+      }
+    ],
+    "defaultValue": "true",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "exposureLeft",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "exposure-screen-margin-left"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "曝光屏幕左边距"
+      }
+    ],
+    "defaultValue": "'50px'",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "exposureRight",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "exposure-screen-margin-right"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "曝光屏幕右边距"
+      }
+    ],
+    "defaultValue": "'50px'",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "initialSelectIndex",
+    "type": "number",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Specify the index of the initial display. Please use "
+      },
+      {
+        "kind": "code",
+        "text": "`selectTab`"
+      },
+      {
+        "kind": "text",
+        "text": " for other updates."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "指定初始显示的索引。请使用 "
+      },
+      {
+        "kind": "code",
+        "text": "`selectTab`"
+      },
+      {
+        "kind": "text",
+        "text": " 进行其他更新。"
+      }
+    ],
+    "defaultValue": "0",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "lazyOptions",
+    "type": "LazyOptions",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Enable lazy rendering for off-screen pages."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "启用屏外页面的懒加载渲染。"
+      }
+    ],
+    "defaultValue": "{ enableLazy: true, scene: 'viewpager', exposureLeft: '50px', exposureRight: '50px' }",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "ref",
+    "type": "ForwardedRef",
+    "summary": [],
+    "summary_zh": [],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": false,
+    "isSupportAndroid": false,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "scene",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Be used to mark the exposure timing of lazy loading. Please ensure that it is unique throughout the page."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "用于标记懒加载的曝光时间。请确保在整个页面中唯一。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "selectIndexAfterDataSourceChanged",
+    "type": "number",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Specify the index after datasource changed. Please use "
+      },
+      {
+        "kind": "code",
+        "text": "`selectTab`"
+      },
+      {
+        "kind": "text",
+        "text": " for other updates."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "数据源改变后指定的索引。请使用 "
+      },
+      {
+        "kind": "code",
+        "text": "`selectTab`"
+      },
+      {
+        "kind": "text",
+        "text": " 进行其他更新。"
+      }
+    ],
+    "defaultValue": "0",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "style",
+    "type": "CSSProperties",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Style for "
+      },
+      {
+        "kind": "code",
+        "text": "`viewpager`"
+      },
+      {
+        "kind": "text",
+        "text": ". Changing its layout with style is unrecommended."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "code",
+        "text": "`viewpager`"
+      },
+      {
+        "kind": "text",
+        "text": " 的样式。不建议通过样式改变其布局。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "viewpagerId",
+    "type": "string",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "The id of the "
+      },
+      {
+        "kind": "code",
+        "text": "`viewpager`"
+      },
+      {
+        "kind": "text",
+        "text": ". It is used to select the element. When omitted, ViewPager generates a unique id for the instance."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "code",
+        "text": "`viewpager`"
+      },
+      {
+        "kind": "text",
+        "text": " 的 ID，用于选择该元素。省略时，ViewPager 会为当前实例生成唯一 ID。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "viewpagerItemStyle",
+    "type": "CSSProperties",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Style for "
+      },
+      {
+        "kind": "code",
+        "text": "`viewpager-item`"
+      },
+      {
+        "kind": "text",
+        "text": "."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "code",
+        "text": "`viewpager-item`"
+      },
+      {
+        "kind": "text",
+        "text": " 的样式。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "viewpagerProps",
+    "type": "Partial",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Additional props that will be passed through to the underlying "
+      },
+      {
+        "kind": "code",
+        "text": "`viewpager`"
+      },
+      {
+        "kind": "text",
+        "text": " element."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "将被直接传递到底层 "
+      },
+      {
+        "kind": "code",
+        "text": "`viewpager`"
+      },
+      {
+        "kind": "text",
+        "text": " 元素的额外属性。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>
+
+### Events
+<UIApiTable source={[
+  {
+    "name": "MTOnOffsetChange",
+    "type": "(e: {detail: {offset: number}}) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "ViewPager scrolled. The handler should be a main thread event."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "ViewPager 滚动。该事件处理函数应在主线程中执行。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "MTOnPageChange",
+    "type": "(e: {detail: {index: number, isDragged: boolean}}) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Viewpager page did changed. The handler should be a main thread event."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "Viewpager 页面已改变。该事件处理函数应在主线程中执行。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "MTOnPageWillChange",
+    "type": "(e: {detail: {index: number, isDragged: boolean}}) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Viewpager page will be changed. The handler should be a main thread event."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "Viewpager 页面将要改变。该事件处理函数应在主线程中执行。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onOffsetChange",
+    "type": "(e: {detail: {offset: number}}) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "ViewPager scrolled."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "ViewPager 滚动。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onPageChange",
+    "type": "(e: {detail: {index: number, isDragged: boolean}}) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Viewpager page did changed."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "Viewpager 页面已改变。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onPageWillChange",
+    "type": "(e: {detail: {index: number, isDragged: boolean}}) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Viewpager page will be changed."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "Viewpager 页面将要改变。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  }
+]}/>
+
+### ViewPagerChangeEvent
+
+<UIApiTable source={[
+  {
+    "name": "index",
+    "type": "number",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Current index"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "当前索引"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": false,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "isDragged",
+    "type": "boolean",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "If being dragged"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "是否被拖动"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": false,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>
+
+### ViewPagerOffsetChangeEvent
+
+<UIApiTable source={[
+  {
+    "name": "offset",
+    "type": "number",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "The scrolling offset, in px"
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "滚动偏移量，以像素为单位"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": false,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>
+
+## ViewPagerRef
+<UIApiTable source={[
+  {
+    "name": "selectTab",
+    "type": "(index: number, smooth: boolean, success?: (res: unknown) => void, fail?: (res: unknown) => void) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Slide to the specified page."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "滑动到指定页面。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  }
+]}/>

--- a/packages/lynx-ui-view-pager/docs/APIReference.mdx
+++ b/packages/lynx-ui-view-pager/docs/APIReference.mdx
@@ -1,8 +1,7 @@
-import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
+import { UIApiTable, ClassRenderPropTable, ClassRenderPropPreamble } from "@lynx-ui/index";
 
-## ViewPagerProps
+### ViewPager
 
-### Properties
 <UIApiTable source={[
   {
     "name": "bounces",
@@ -10,35 +9,35 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "summary": [
       {
         "kind": "text",
-        "text": "Enable iOS bounces spring effect"
+        "text": "Enable the native spring effect where supported."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "启用 iOS 弹性效果"
+        "text": "在支持的平台启用原生回弹效果。"
       }
     ],
     "defaultValue": "true",
     "isOption": true,
     "isSupportIOS": true,
-    "isSupportAndroid": false,
+    "isSupportAndroid": true,
     "isSupportHarmony": false,
     "docTypeFallback": null
   },
   {
     "name": "children",
-    "type": "ReactElement[]",
+    "type": "ReactNode",
     "summary": [
       {
         "kind": "text",
-        "text": "Children, which is ViewPagerItems."
+        "text": "Direct ViewPagerItem elements. Arrays and conditional items are supported;\nfragments and wrapper components are not. Use stable keys for dynamic pages.\nSelection follows the numeric position after reordering; removed selections\nclamp to the last page. An empty pager has index 0 and sends no requests."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "子元素, 即 ViewPagerItems。"
+        "text": "直接使用 ViewPagerItem，支持数组和条件条目，不支持 Fragment 或包装组件。动态页面使用稳定 key。重排后按索引选择，删除后限制到最后一页，空列表索引为 0 且不发出请求。"
       }
     ],
     "defaultValue": "",
@@ -76,13 +75,13 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "summary": [
       {
         "kind": "text",
-        "text": "Enable horizontal scroll."
+        "text": "Enable horizontal swipe gestures."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "启用水平滚动。"
+        "text": "启用水平滑动手势。"
       }
     ],
     "defaultValue": "true",
@@ -93,103 +92,43 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "docTypeFallback": null
   },
   {
-    "name": "exposureLeft",
-    "type": "string",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "exposure-screen-margin-left"
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "曝光屏幕左边距"
-      }
-    ],
-    "defaultValue": "'50px'",
-    "isOption": true,
-    "isSupportIOS": true,
-    "isSupportAndroid": true,
-    "isSupportHarmony": true,
-    "docTypeFallback": null
-  },
-  {
-    "name": "exposureRight",
-    "type": "string",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "exposure-screen-margin-right"
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "曝光屏幕右边距"
-      }
-    ],
-    "defaultValue": "'50px'",
-    "isOption": true,
-    "isSupportIOS": true,
-    "isSupportAndroid": true,
-    "isSupportHarmony": true,
-    "docTypeFallback": null
-  },
-  {
     "name": "initialSelectIndex",
     "type": "number",
     "summary": [
       {
         "kind": "text",
-        "text": "Specify the index of the initial display. Please use "
-      },
-      {
-        "kind": "code",
-        "text": "`selectTab`"
-      },
-      {
-        "kind": "text",
-        "text": " for other updates."
+        "text": "Initial page index. Later changes are ignored; use ref.selectTab to navigate."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "指定初始显示的索引。请使用 "
-      },
-      {
-        "kind": "code",
-        "text": "`selectTab`"
-      },
-      {
-        "kind": "text",
-        "text": " 进行其他更新。"
+        "text": "初始页面索引，后续修改不生效。使用 ref.selectTab 切换页面。"
       }
     ],
     "defaultValue": "0",
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": true,
+    "isSupportHarmony": false,
     "docTypeFallback": null
   },
   {
-    "name": "lazyOptions",
-    "type": "LazyOptions",
+    "name": "lazy",
+    "type": "boolean",
     "summary": [
       {
         "kind": "text",
-        "text": "Enable lazy rendering for off-screen pages."
+        "text": "Defer off-screen content until selected, preloaded, or about to appear.\nMounted content stays mounted until its keyed item is removed."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "启用屏外页面的懒加载渲染。"
+        "text": "延迟挂载屏外内容；选中、预加载或即将显示时挂载。已挂载内容保留到对应条目被移除。"
       }
     ],
-    "defaultValue": "{ enableLazy: true, scene: 'viewpager', exposureLeft: '50px', exposureRight: '50px' }",
+    "defaultValue": "true",
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
@@ -197,30 +136,18 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "docTypeFallback": null
   },
   {
-    "name": "ref",
-    "type": "ForwardedRef",
-    "summary": [],
-    "summary_zh": [],
-    "defaultValue": "",
-    "isOption": true,
-    "isSupportIOS": false,
-    "isSupportAndroid": false,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
-  },
-  {
-    "name": "scene",
-    "type": "string",
+    "name": "MTOnOffsetChange",
+    "type": "(event: ViewPagerOffsetChangeEvent) => void",
     "summary": [
       {
         "kind": "text",
-        "text": "Be used to mark the exposure timing of lazy loading. Please ensure that it is unique throughout the page."
+        "text": "Main-thread scroll progress handler, in page units. Use a main thread function."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "用于标记懒加载的曝光时间。请确保在整个页面中唯一。"
+        "text": "主线程滚动进度回调，以页面为单位，需使用主线程函数。"
       }
     ],
     "defaultValue": "",
@@ -231,37 +158,131 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "docTypeFallback": null
   },
   {
-    "name": "selectIndexAfterDataSourceChanged",
+    "name": "MTOnPageChange",
+    "type": "(event: ViewPagerChangeEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Main-thread page completion handler. Use a main thread function."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "主线程页面切换完成回调，需使用主线程函数。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "MTOnPageWillChange",
+    "type": "(event: ViewPagerWillChangeEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Main-thread page transition handler. Use a main thread function."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "主线程页面即将切换回调，需使用主线程函数。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onOffsetChange",
+    "type": "(event: ViewPagerOffsetChangeEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Native scroll progress in page units: 0 to 1 between the first two pages,\nnot a pixel distance."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "原生滚动进度，以页面为单位。前两页之间为 0 到 1，并非像素距离。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onPageChange",
+    "type": "(event: ViewPagerChangeEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Native page completion event, including programmatic transitions."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "原生页面切换完成事件，包括命令式切换。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "onPageWillChange",
+    "type": "(event: ViewPagerWillChangeEvent) => void",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Native event before a page transition completes."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "原生页面切换完成前事件。"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": false,
+    "docTypeFallback": null
+  },
+  {
+    "name": "preloadCount",
     "type": "number",
     "summary": [
       {
         "kind": "text",
-        "text": "Specify the index after datasource changed. Please use "
-      },
-      {
-        "kind": "code",
-        "text": "`selectTab`"
-      },
-      {
-        "kind": "text",
-        "text": " for other updates."
+        "text": "Number of neighboring pages to mount on each side of the selected page.\nNonnegative integer; ignored when lazy is false."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "数据源改变后指定的索引。请使用 "
-      },
-      {
-        "kind": "code",
-        "text": "`selectTab`"
-      },
-      {
-        "kind": "text",
-        "text": " 进行其他更新。"
+        "text": "选中页面两侧预加载的页面数，为非负整数。lazy 为 false 时忽略。"
       }
     ],
-    "defaultValue": "0",
+    "defaultValue": "1",
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
@@ -274,131 +295,35 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "summary": [
       {
         "kind": "text",
-        "text": "Style for "
-      },
-      {
-        "kind": "code",
-        "text": "`viewpager`"
-      },
-      {
-        "kind": "text",
-        "text": ". Changing its layout with style is unrecommended."
+        "text": "style"
       }
     ],
     "summary_zh": [
       {
-        "kind": "code",
-        "text": "`viewpager`"
-      },
-      {
         "kind": "text",
-        "text": " 的样式。不建议通过样式改变其布局。"
+        "text": "样式"
       }
     ],
     "defaultValue": "",
     "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
-  },
-  {
-    "name": "viewpagerId",
-    "type": "string",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "The id of the "
-      },
-      {
-        "kind": "code",
-        "text": "`viewpager`"
-      },
-      {
-        "kind": "text",
-        "text": ". It is used to select the element. When omitted, ViewPager generates a unique id for the instance."
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "code",
-        "text": "`viewpager`"
-      },
-      {
-        "kind": "text",
-        "text": " 的 ID，用于选择该元素。省略时，ViewPager 会为当前实例生成唯一 ID。"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": true,
-    "isSupportIOS": true,
-    "isSupportAndroid": true,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
-  },
-  {
-    "name": "viewpagerItemStyle",
-    "type": "CSSProperties",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "Style for "
-      },
-      {
-        "kind": "code",
-        "text": "`viewpager-item`"
-      },
-      {
-        "kind": "text",
-        "text": "."
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "code",
-        "text": "`viewpager-item`"
-      },
-      {
-        "kind": "text",
-        "text": " 的样式。"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": true,
-    "isSupportIOS": true,
-    "isSupportAndroid": true,
-    "isSupportHarmony": false,
+    "isSupportHarmony": true,
     "docTypeFallback": null
   },
   {
     "name": "viewpagerProps",
-    "type": "Partial",
+    "type": "Omit",
     "summary": [
       {
         "kind": "text",
-        "text": "Additional props that will be passed through to the underlying "
-      },
-      {
-        "kind": "code",
-        "text": "`viewpager`"
-      },
-      {
-        "kind": "text",
-        "text": " element."
+        "text": "Native pager attributes not managed by the component, including id and\naccessibility attributes. Use the dedicated props for styles and events."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "将被直接传递到底层 "
-      },
-      {
-        "kind": "code",
-        "text": "`viewpager`"
-      },
-      {
-        "kind": "text",
-        "text": " 元素的额外属性。"
+        "text": "组件未管理的原生属性，包括 id 和无障碍属性。样式和事件使用专用属性。"
       }
     ],
     "defaultValue": "",
@@ -410,21 +335,44 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
   }
 ]}/>
 
-### Events
+### ViewPagerItem
+
 <UIApiTable source={[
   {
-    "name": "MTOnOffsetChange",
-    "type": "(e: {detail: {offset: number}}) => void",
+    "name": "className",
+    "type": "string",
     "summary": [
       {
         "kind": "text",
-        "text": "ViewPager scrolled. The handler should be a main thread event."
+        "text": "className"
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "ViewPager 滚动。该事件处理函数应在主线程中执行。"
+        "text": "类名"
+      }
+    ],
+    "defaultValue": "",
+    "isOption": true,
+    "isSupportIOS": true,
+    "isSupportAndroid": true,
+    "isSupportHarmony": true,
+    "docTypeFallback": null
+  },
+  {
+    "name": "itemProps",
+    "type": "Omit",
+    "summary": [
+      {
+        "kind": "text",
+        "text": "Native item attributes, including accessibility properties."
+      }
+    ],
+    "summary_zh": [
+      {
+        "kind": "text",
+        "text": "原生页面容器属性，包括无障碍属性。"
       }
     ],
     "defaultValue": "",
@@ -435,106 +383,18 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "docTypeFallback": null
   },
   {
-    "name": "MTOnPageChange",
-    "type": "(e: {detail: {index: number, isDragged: boolean}}) => void",
+    "name": "style",
+    "type": "CSSProperties",
     "summary": [
       {
         "kind": "text",
-        "text": "Viewpager page did changed. The handler should be a main thread event."
+        "text": "style"
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "Viewpager 页面已改变。该事件处理函数应在主线程中执行。"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": true,
-    "isSupportIOS": true,
-    "isSupportAndroid": true,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
-  },
-  {
-    "name": "MTOnPageWillChange",
-    "type": "(e: {detail: {index: number, isDragged: boolean}}) => void",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "Viewpager page will be changed. The handler should be a main thread event."
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "Viewpager 页面将要改变。该事件处理函数应在主线程中执行。"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": true,
-    "isSupportIOS": true,
-    "isSupportAndroid": true,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
-  },
-  {
-    "name": "onOffsetChange",
-    "type": "(e: {detail: {offset: number}}) => void",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "ViewPager scrolled."
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "ViewPager 滚动。"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": true,
-    "isSupportIOS": true,
-    "isSupportAndroid": true,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
-  },
-  {
-    "name": "onPageChange",
-    "type": "(e: {detail: {index: number, isDragged: boolean}}) => void",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "Viewpager page did changed."
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "Viewpager 页面已改变。"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": true,
-    "isSupportIOS": true,
-    "isSupportAndroid": true,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
-  },
-  {
-    "name": "onPageWillChange",
-    "type": "(e: {detail: {index: number, isDragged: boolean}}) => void",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "Viewpager page will be changed."
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "Viewpager 页面将要改变。"
+        "text": "样式"
       }
     ],
     "defaultValue": "",
@@ -546,79 +406,48 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
   }
 ]}/>
 
-### ViewPagerChangeEvent
-
 <UIApiTable source={[
   {
-    "name": "index",
-    "type": "number",
+    "name": "children",
+    "type": "ReactNode | [object Object]",
     "summary": [
       {
         "kind": "text",
-        "text": "Current index"
+        "text": "Page content or a function receiving selection state."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "当前索引"
+        "text": "页面内容或接收选择状态的渲染函数。"
       }
     ],
     "defaultValue": "",
-    "isOption": false,
+    "isOption": true,
     "isSupportIOS": true,
     "isSupportAndroid": true,
     "isSupportHarmony": false,
-    "docTypeFallback": null
-  },
-  {
-    "name": "isDragged",
-    "type": "boolean",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "If being dragged"
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "是否被拖动"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": false,
-    "isSupportIOS": true,
-    "isSupportAndroid": true,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
+    "docTypeFallback": {
+      "tag": "@docTypeFallback",
+      "content": [
+        {
+          "kind": "text",
+          "text": "ReactNode | ((status: ViewPagerItemRenderProps) => ReactNode)"
+        }
+      ]
+    }
   }
 ]}/>
-
-### ViewPagerOffsetChangeEvent
-
-<UIApiTable source={[
+<ClassRenderPropPreamble />
+<ClassRenderPropTable source={[
   {
-    "name": "offset",
-    "type": "number",
-    "summary": [
-      {
-        "kind": "text",
-        "text": "The scrolling offset, in px"
-      }
-    ],
-    "summary_zh": [
-      {
-        "kind": "text",
-        "text": "滚动偏移量，以像素为单位"
-      }
-    ],
-    "defaultValue": "",
-    "isOption": false,
-    "isSupportIOS": true,
-    "isSupportAndroid": true,
-    "isSupportHarmony": false,
-    "docTypeFallback": null
+    "className": "ui-selected",
+    "Render Prop": "selected",
+    "item": {
+      "type": "boolean",
+      "description": "Whether this is the selected page.\nApplied to the selected page container.",
+      "description_zh": "是否为选中页面。\n应用于选中页面容器。"
+    }
   }
 ]}/>
 
@@ -626,17 +455,17 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
 <UIApiTable source={[
   {
     "name": "selectTab",
-    "type": "(index: number, smooth: boolean, success?: (res: unknown) => void, fail?: (res: unknown) => void) => void",
+    "type": "(index: number, smooth?: boolean, success?: (result: unknown) => void, fail?: (result: unknown) => void) => void",
     "summary": [
       {
         "kind": "text",
-        "text": "Slide to the specified page."
+        "text": "Slide to a page through the native node ref. Animation defaults to true.\nIndexes are clamped to available pages. Empty pagers ignore requests.\nCompletion is reported through onPageChange; success confirms invocation."
       }
     ],
     "summary_zh": [
       {
         "kind": "text",
-        "text": "滑动到指定页面。"
+        "text": "通过原生节点引用切换页面，默认使用动画。索引限制在有效范围内，空列表忽略请求。onPageChange 表示切换完成，success 表示调用成功。"
       }
     ],
     "defaultValue": "",

--- a/packages/lynx-ui-view-pager/docs/README.mdx
+++ b/packages/lynx-ui-view-pager/docs/README.mdx
@@ -1,0 +1,16 @@
+import { lynxUiIntros } from '../../lynx-ui-intros';
+import Introduction from '../../introDocs/lynx-ui-view-pager/Introduction.mdx';
+import APIReference from './APIReference.mdx';
+
+# `<ViewPager>`
+
+{lynxUiIntros['lynx-ui-view-pager']}
+
+:::info
+
+You can check the [source code](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-view-pager) to understand how it works, and you're welcome to submit PRs to enhance its capabilities.
+
+:::
+
+<Introduction />
+<APIReference />

--- a/packages/lynx-ui-view-pager/docs/README.zh.mdx
+++ b/packages/lynx-ui-view-pager/docs/README.zh.mdx
@@ -1,0 +1,16 @@
+import Introduction from '../../introDocs/lynx-ui-view-pager/Introduction.zh.mdx';
+import APIReference from './APIReference.mdx';
+import { lynxUiIntrosZh } from '../../lynx-ui-intros';
+
+# `<ViewPager>`
+
+{lynxUiIntrosZh['lynx-ui-view-pager']}
+
+:::info
+
+你可以查看[源码](https://github.com/lynx-family/lynx-ui/tree/main/packages/lynx-ui-view-pager)来了解它的运行原理，也欢迎大家提 PR 来丰富其能力。
+
+:::
+
+<Introduction />
+<APIReference />

--- a/packages/lynx-ui-view-pager/package.json
+++ b/packages/lynx-ui-view-pager/package.json
@@ -1,16 +1,18 @@
 {
-  "name": "@lynx-js/lynx-ui",
+  "name": "@lynx-js/lynx-ui-view-pager",
   "version": "3.136.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-ui.git",
-    "directory": "packages/lynx-ui"
+    "directory": "packages/lynx-ui-view-pager"
   },
   "license": "Apache-2.0",
   "author": {
     "name": "The Lynx Authors"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css"
+  ],
   "type": "module",
   "main": "./dist/index.jsx",
   "module": "./dist/index.jsx",
@@ -30,28 +32,9 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@lynx-js/lynx-ui-button": "workspace:*",
-    "@lynx-js/lynx-ui-checkbox": "workspace:*",
     "@lynx-js/lynx-ui-common": "workspace:*",
-    "@lynx-js/lynx-ui-dialog": "workspace:*",
-    "@lynx-js/lynx-ui-draggable": "workspace:*",
-    "@lynx-js/lynx-ui-feed-list": "workspace:*",
-    "@lynx-js/lynx-ui-form": "workspace:*",
-    "@lynx-js/lynx-ui-input": "workspace:*",
-    "@lynx-js/lynx-ui-input-otp": "workspace:*",
     "@lynx-js/lynx-ui-lazy-component": "workspace:*",
-    "@lynx-js/lynx-ui-list": "workspace:*",
-    "@lynx-js/lynx-ui-popover": "workspace:*",
-    "@lynx-js/lynx-ui-presence": "workspace:*",
-    "@lynx-js/lynx-ui-radio-group": "workspace:*",
-    "@lynx-js/lynx-ui-scroll-view": "workspace:*",
-    "@lynx-js/lynx-ui-sheet": "workspace:*",
-    "@lynx-js/lynx-ui-slider": "workspace:*",
-    "@lynx-js/lynx-ui-sortable": "workspace:*",
-    "@lynx-js/lynx-ui-swipe-action": "workspace:*",
-    "@lynx-js/lynx-ui-swiper": "workspace:*",
-    "@lynx-js/lynx-ui-switch": "workspace:*",
-    "@lynx-js/lynx-ui-view-pager": "workspace:*"
+    "clsx": "catalog:"
   },
   "devDependencies": {
     "@lynx-js/react": "catalog:",

--- a/packages/lynx-ui-view-pager/package.json
+++ b/packages/lynx-ui-view-pager/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "@lynx-js/lynx-ui-common": "workspace:*",
-    "@lynx-js/lynx-ui-lazy-component": "workspace:*",
     "clsx": "catalog:"
   },
   "devDependencies": {
@@ -41,6 +40,7 @@
     "@lynx-js/types": "catalog:",
     "@rslib/core": "catalog:",
     "@types/react": "catalog:",
+    "jsdom": "catalog:",
     "typescript": "catalog:"
   },
   "peerDependencies": {

--- a/packages/lynx-ui-view-pager/rslib.config.ts
+++ b/packages/lynx-ui-view-pager/rslib.config.ts
@@ -1,0 +1,8 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from '@rslib/core'
+import { baseConfig } from '../../tools/configs/rslib.base.js'
+
+export default defineConfig(baseConfig)

--- a/packages/lynx-ui-view-pager/src/index.tsx
+++ b/packages/lynx-ui-view-pager/src/index.tsx
@@ -1,0 +1,170 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import {
+  forwardRef,
+  memo,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from '@lynx-js/react'
+import type { ForwardedRef } from '@lynx-js/react'
+
+import { LazyComponent } from '@lynx-js/lynx-ui-lazy-component'
+import { clsx } from 'clsx'
+
+import './styles.css'
+
+import type {
+  ViewPagerChangeEvent,
+  ViewPagerOffsetChangeEvent,
+  ViewPagerProps,
+  ViewPagerRef,
+  ViewPager as ViewPagerType,
+} from './types'
+import { createViewPagerId, resolveLazyOptions } from './utils'
+
+const mainThreadEventPropMap = {
+  MTOnOffsetChange: 'main-thread:bindoffsetchange',
+  MTOnPageWillChange: 'main-thread:bindwillchange',
+  MTOnPageChange: 'main-thread:bindchange',
+} satisfies Partial<Record<keyof ViewPagerProps, string>>
+
+export type {
+  ViewPagerOffsetChangeEvent,
+  ViewPagerChangeEvent,
+  ViewPagerProps,
+  ViewPagerRef,
+}
+
+export const ViewPager = memo(
+  forwardRef(ViewPagerImpl),
+) as ViewPagerType
+
+function ViewPagerImpl(props: ViewPagerProps, ref: ForwardedRef<ViewPagerRef>) {
+  const {
+    style,
+    viewpagerItemStyle,
+    viewpagerId: viewpagerIdProp,
+    bounces = true,
+    className,
+    viewpagerProps,
+    enableScroll = true,
+    selectIndexAfterDataSourceChanged = 0,
+    // use undefined instead of 0, to resolve the conflict with selectIndexAfterDataSourceChanged
+    initialSelectIndex = undefined,
+    children,
+    lazyOptions,
+    scene: legacyScene,
+    exposureLeft: legacyExposureLeft,
+    exposureRight: legacyExposureRight,
+    onPageChange,
+    onOffsetChange,
+    onPageWillChange,
+  } = props
+  const [generatedViewPagerId] = useState(createViewPagerId)
+  const viewpagerId = viewpagerIdProp ?? generatedViewPagerId
+  const initialSelectIndexValue = useRef<number | undefined>(initialSelectIndex)
+  const {
+    enableLazy,
+    scene,
+    exposureLeft,
+    exposureRight,
+  } = resolveLazyOptions(lazyOptions, {
+    scene: legacyScene,
+    exposureLeft: legacyExposureLeft,
+    exposureRight: legacyExposureRight,
+  })
+  const keepItemView = exposureLeft !== '0px' || exposureRight !== '0px'
+
+  const mainThreadEvents: Record<string, unknown> = {}
+  for (const key of Object.keys(mainThreadEventPropMap)) {
+    const typedKey = key as keyof typeof mainThreadEventPropMap
+    const mappedEventName = mainThreadEventPropMap[typedKey]
+    const eventHandler = props[typedKey]
+    if (mappedEventName && eventHandler !== undefined) {
+      mainThreadEvents[mappedEventName] = eventHandler
+    }
+  }
+
+  const selectTab = (
+    index: number,
+    smooth: boolean,
+    success?: (res: unknown) => void,
+    fail?: (res: unknown) => void,
+  ) => {
+    lynx
+      .createSelectorQuery()
+      .select(`#${viewpagerId}`)
+      .invoke({
+        method: 'selectTab',
+        params: {
+          index,
+          smooth,
+        },
+        success(res) {
+          success?.(res)
+        },
+        fail(res) {
+          fail?.(res)
+        },
+      })
+      .exec()
+  }
+  useImperativeHandle(
+    ref,
+    () => ({
+      selectTab,
+    }),
+    [selectTab],
+  )
+  return (
+    <viewpager
+      {...(viewpagerProps ?? {})}
+      {...mainThreadEvents}
+      className={clsx('lynx-ui-view-pager__root', className)}
+      id={viewpagerId}
+      bindchange={(e) => {
+        // Add an event callback to make sure the old version of Lynx Android can trigger the `global-bind` event
+        onPageChange?.(e)
+      }}
+      bindwillchange={onPageWillChange}
+      align-width={true}
+      bindoffsetchange={onOffsetChange}
+      bounces={bounces}
+      select-index={initialSelectIndexValue.current
+        ?? selectIndexAfterDataSourceChanged}
+      initial-select-index={initialSelectIndexValue.current}
+      style={{ width: '100%', height: '100%', ...style }}
+      keep-item-view={keepItemView}
+      allow-horizontal-gesture={enableScroll}
+      enable-scroll={enableScroll}
+    >
+      {children?.map((item, index) => (
+        <viewpager-item
+          className='lynx-ui-view-pager__item'
+          key={item.key ?? index}
+          style={viewpagerItemStyle}
+        >
+          {enableLazy
+              && index
+                !== (initialSelectIndexValue.current
+                  ?? selectIndexAfterDataSourceChanged)
+            ? (
+              <LazyComponent
+                scene={scene}
+                estimatedStyle={{ width: '100%', height: '100%' }}
+                pid={`pid_${index}`}
+                left={exposureLeft}
+                right={exposureRight}
+              >
+                {item}
+              </LazyComponent>
+            )
+            : item}
+        </viewpager-item>
+      ))}
+    </viewpager>
+  )
+}

--- a/packages/lynx-ui-view-pager/src/index.tsx
+++ b/packages/lynx-ui-view-pager/src/index.tsx
@@ -3,168 +3,169 @@
 // LICENSE file in the root directory of this source tree.
 
 import {
+  createContext,
   forwardRef,
-  memo,
+  isValidElement,
+  useContext,
+  useEffect,
   useImperativeHandle,
   useRef,
   useState,
 } from '@lynx-js/react'
-import type { ForwardedRef } from '@lynx-js/react'
+import type { ForwardedRef, ReactElement, ReactNode } from '@lynx-js/react'
 
-import { LazyComponent } from '@lynx-js/lynx-ui-lazy-component'
+import type { NodesRef } from '@lynx-js/types'
 import { clsx } from 'clsx'
 
 import './styles.css'
 
 import type {
-  ViewPagerChangeEvent,
-  ViewPagerOffsetChangeEvent,
+  ViewPagerItemProps,
+  ViewPagerItemRenderProps,
+  ViewPagerItemUIVariants,
   ViewPagerProps,
   ViewPagerRef,
-  ViewPager as ViewPagerType,
 } from './types'
-import { createViewPagerId, resolveLazyOptions } from './utils'
+import { normalizeIndex } from './utils'
 
-const mainThreadEventPropMap = {
-  MTOnOffsetChange: 'main-thread:bindoffsetchange',
-  MTOnPageWillChange: 'main-thread:bindwillchange',
-  MTOnPageChange: 'main-thread:bindchange',
-} satisfies Partial<Record<keyof ViewPagerProps, string>>
+export type * from './types'
 
-export type {
-  ViewPagerOffsetChangeEvent,
-  ViewPagerChangeEvent,
-  ViewPagerProps,
-  ViewPagerRef,
+const ItemContext = createContext<
+  (ViewPagerItemRenderProps & { shouldMount: boolean }) | null
+>(null)
+
+// Providers preserve keyed page identity without adding native wrapper nodes.
+function collectPages(children: ReactNode): ReactElement[] {
+  if (Array.isArray(children)) {
+    return children.flatMap((child: ReactNode) => collectPages(child))
+  }
+  if (children == null || typeof children === 'boolean') return []
+  if (!isValidElement(children) || children.type !== ViewPagerItem) {
+    throw new Error('ViewPager children must be ViewPagerItem elements.')
+  }
+  return [children]
 }
 
-export const ViewPager = memo(
-  forwardRef(ViewPagerImpl),
-) as ViewPagerType
+export const ViewPager = forwardRef(ViewPagerImpl)
 
 function ViewPagerImpl(props: ViewPagerProps, ref: ForwardedRef<ViewPagerRef>) {
   const {
-    style,
-    viewpagerItemStyle,
-    viewpagerId: viewpagerIdProp,
-    bounces = true,
+    children,
+    initialSelectIndex = 0,
     className,
+    style,
     viewpagerProps,
     enableScroll = true,
-    selectIndexAfterDataSourceChanged = 0,
-    // use undefined instead of 0, to resolve the conflict with selectIndexAfterDataSourceChanged
-    initialSelectIndex = undefined,
-    children,
-    lazyOptions,
-    scene: legacyScene,
-    exposureLeft: legacyExposureLeft,
-    exposureRight: legacyExposureRight,
+    bounces = true,
+    lazy = true,
+    preloadCount = 1,
     onPageChange,
-    onOffsetChange,
     onPageWillChange,
+    onOffsetChange,
+    MTOnPageChange,
+    MTOnPageWillChange,
+    MTOnOffsetChange,
   } = props
-  const [generatedViewPagerId] = useState(createViewPagerId)
-  const viewpagerId = viewpagerIdProp ?? generatedViewPagerId
-  const initialSelectIndexValue = useRef<number | undefined>(initialSelectIndex)
-  const {
-    enableLazy,
-    scene,
-    exposureLeft,
-    exposureRight,
-  } = resolveLazyOptions(lazyOptions, {
-    scene: legacyScene,
-    exposureLeft: legacyExposureLeft,
-    exposureRight: legacyExposureRight,
-  })
-  const keepItemView = exposureLeft !== '0px' || exposureRight !== '0px'
+  const pages = collectPages(children)
+  const initialIndex = useRef(initialSelectIndex)
+  const [activeIndex, setActiveIndex] = useState(initialIndex.current)
+  const selectedIndex = normalizeIndex(activeIndex, pages.length)
+  const nativeRef = useRef<NodesRef>(null)
+  const [destination, setDestination] = useState<number | null>(null)
 
-  const mainThreadEvents: Record<string, unknown> = {}
-  for (const key of Object.keys(mainThreadEventPropMap)) {
-    const typedKey = key as keyof typeof mainThreadEventPropMap
-    const mappedEventName = mainThreadEventPropMap[typedKey]
-    const eventHandler = props[typedKey]
-    if (mappedEventName && eventHandler !== undefined) {
-      mainThreadEvents[mappedEventName] = eventHandler
-    }
-  }
-
-  const selectTab = (
-    index: number,
-    smooth: boolean,
-    success?: (res: unknown) => void,
-    fail?: (res: unknown) => void,
-  ) => {
-    lynx
-      .createSelectorQuery()
-      .select(`#${viewpagerId}`)
-      .invoke({
+  useImperativeHandle(ref, () => ({
+    selectTab(next, smooth, success, fail) {
+      if (pages.length === 0) return
+      const target = normalizeIndex(next, pages.length)
+      setDestination(target)
+      nativeRef.current?.invoke({
         method: 'selectTab',
-        params: {
-          index,
-          smooth,
-        },
-        success(res) {
-          success?.(res)
-        },
-        fail(res) {
-          fail?.(res)
-        },
-      })
-      .exec()
-  }
-  useImperativeHandle(
-    ref,
-    () => ({
-      selectTab,
-    }),
-    [selectTab],
-  )
+        params: { index: target, smooth: smooth ?? true },
+        success,
+        fail,
+      }).exec()
+    },
+  }))
+
+  useEffect(() => {
+    if (pages.length > 0 && activeIndex !== selectedIndex) {
+      setActiveIndex(selectedIndex)
+    }
+  }, [activeIndex, selectedIndex, pages.length])
+
+  const preload = Number.isFinite(preloadCount)
+    ? Math.max(0, Math.trunc(preloadCount))
+    : 1
+
   return (
     <viewpager
-      {...(viewpagerProps ?? {})}
-      {...mainThreadEvents}
+      {...viewpagerProps}
+      ref={nativeRef}
       className={clsx('lynx-ui-view-pager__root', className)}
-      id={viewpagerId}
-      bindchange={(e) => {
-        // Add an event callback to make sure the old version of Lynx Android can trigger the `global-bind` event
-        onPageChange?.(e)
-      }}
-      bindwillchange={onPageWillChange}
+      style={style}
+      initial-select-index={normalizeIndex(initialIndex.current, pages.length)}
+      select-index={selectedIndex}
       align-width={true}
-      bindoffsetchange={onOffsetChange}
-      bounces={bounces}
-      select-index={initialSelectIndexValue.current
-        ?? selectIndexAfterDataSourceChanged}
-      initial-select-index={initialSelectIndexValue.current}
-      style={{ width: '100%', height: '100%', ...style }}
-      keep-item-view={keepItemView}
-      allow-horizontal-gesture={enableScroll}
       enable-scroll={enableScroll}
+      allow-horizontal-gesture={enableScroll}
+      bounces={bounces}
+      bindchange={(event) => {
+        setActiveIndex(normalizeIndex(event.detail.index, pages.length))
+        setDestination(null)
+        onPageChange?.(event)
+      }}
+      bindwillchange={(event) => {
+        setDestination(normalizeIndex(event.detail.index, pages.length))
+        onPageWillChange?.(event)
+      }}
+      bindoffsetchange={onOffsetChange}
+      main-thread:bindchange={MTOnPageChange}
+      main-thread:bindwillchange={MTOnPageWillChange}
+      main-thread:bindoffsetchange={MTOnOffsetChange}
     >
-      {children?.map((item, index) => (
-        <viewpager-item
-          className='lynx-ui-view-pager__item'
-          key={item.key ?? index}
-          style={viewpagerItemStyle}
+      {pages.map((page, pageIndex) => (
+        <ItemContext.Provider
+          key={page.key ?? pageIndex}
+          value={{
+            index: pageIndex,
+            selected: pageIndex === selectedIndex,
+            shouldMount: !lazy
+              || Math.abs(pageIndex - selectedIndex) <= preload
+              || pageIndex === destination,
+          }}
         >
-          {enableLazy
-              && index
-                !== (initialSelectIndexValue.current
-                  ?? selectIndexAfterDataSourceChanged)
-            ? (
-              <LazyComponent
-                scene={scene}
-                estimatedStyle={{ width: '100%', height: '100%' }}
-                pid={`pid_${index}`}
-                left={exposureLeft}
-                right={exposureRight}
-              >
-                {item}
-              </LazyComponent>
-            )
-            : item}
-        </viewpager-item>
+          {page}
+        </ItemContext.Provider>
       ))}
     </viewpager>
+  )
+}
+
+export function ViewPagerItem(props: ViewPagerItemProps): ReactElement {
+  const context = useContext(ItemContext)
+  if (!context) throw new Error('ViewPagerItem must be inside ViewPager.')
+  const { index, selected, shouldMount } = context
+  const [mounted, setMounted] = useState(shouldMount)
+  useEffect(() => {
+    if (shouldMount) setMounted(true)
+  }, [shouldMount])
+  const variants: ViewPagerItemUIVariants = { 'ui-selected': selected }
+  const { children, className, style, itemProps } = props
+
+  let content: ReactNode = null
+  if (mounted || shouldMount) {
+    content = typeof children === 'function'
+      ? children({ index, selected })
+      : children
+  }
+
+  return (
+    <viewpager-item
+      {...itemProps}
+      className={clsx('lynx-ui-view-pager__item', variants, className)}
+      style={style}
+    >
+      {content}
+    </viewpager-item>
   )
 }

--- a/packages/lynx-ui-view-pager/src/styles.css
+++ b/packages/lynx-ui-view-pager/src/styles.css
@@ -1,0 +1,11 @@
+.lynx-ui-view-pager__root {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+}
+
+.lynx-ui-view-pager__item {
+  display: flex;
+  width: 100%;
+  flex-shrink: 0;
+}

--- a/packages/lynx-ui-view-pager/src/types/index.docs.ts
+++ b/packages/lynx-ui-view-pager/src/types/index.docs.ts
@@ -1,0 +1,226 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { ForwardedRef, ReactElement } from '@lynx-js/react'
+
+import type { ComponentBasicProps, LazyOptions } from '@lynx-js/lynx-ui-common'
+import type {
+  CSSProperties,
+  ViewPagerProps as NativeViewPagerProps,
+} from '@lynx-js/types'
+
+export type ViewPager = (props: ViewPagerProps) => ReactElement
+
+export interface ViewPagerRef {
+  /**
+   * Slide to the specified page.
+   * @zh 滑动到指定页面。
+   * @Android
+   * @iOS
+   */
+  selectTab: (
+    /**
+     * The index to be scrolled to.
+     * @zh 要滚动到的索引。
+     * @Android
+     * @iOS
+     */
+    index: number,
+    /**
+     * If a animation effect needed.
+     * @zh 是否需要动画效果。
+     * @Android
+     * @iOS
+     */
+    smooth: boolean,
+    success?: (res: unknown) => void,
+    fail?: (res: unknown) => void,
+  ) => void
+}
+
+export interface ViewPagerProps extends ComponentBasicProps {
+  ref?: ForwardedRef<ViewPagerRef>
+  /**
+   * Enable lazy rendering for off-screen pages.
+   * @zh 启用屏外页面的懒加载渲染。
+   * @defaultValue `{ enableLazy: true, scene: 'viewpager', exposureLeft: '50px', exposureRight: '50px' }`
+   * @Android
+   * @iOS
+   */
+  lazyOptions?: LazyOptions
+  /**
+   * Be used to mark the exposure timing of lazy loading. Please ensure that it is unique throughout the page.
+   * @zh 用于标记懒加载的曝光时间。请确保在整个页面中唯一。
+   * @Android
+   * @iOS
+   * @deprecated Please use `lazyOptions` instead.
+   */
+  scene?: string
+  /**
+   * The id of the `viewpager`. It is used to select the element. When omitted, ViewPager generates a unique id for the instance.
+   * @zh `viewpager` 的 ID，用于选择该元素。省略时，ViewPager 会为当前实例生成唯一 ID。
+   * @Android
+   * @iOS
+   */
+  viewpagerId?: string
+  /**
+   * Style for `viewpager`. Changing its layout with style is unrecommended.
+   * @zh `viewpager` 的样式。不建议通过样式改变其布局。
+   * @Android
+   * @iOS
+   */
+  style?: CSSProperties
+  /**
+   * Style for `viewpager-item`.
+   * @zh `viewpager-item` 的样式。
+   * @Android
+   * @iOS
+   */
+  viewpagerItemStyle?: CSSProperties
+  /**
+   * Specify the index after datasource changed. Please use `selectTab` for other updates.
+   * @zh 数据源改变后指定的索引。请使用 `selectTab` 进行其他更新。
+   * @defaultValue 0
+   * @Android
+   * @iOS
+   * @deprecated Please use `initialSelectIndex` instead
+   */
+  selectIndexAfterDataSourceChanged?: number
+  /**
+   * Specify the index of the initial display. Please use `selectTab` for other updates.
+   * @zh 指定初始显示的索引。请使用 `selectTab` 进行其他更新。
+   * @defaultValue 0
+   * @Android
+   * @iOS
+   * @Harmony
+   * @since 2.17
+   */
+  initialSelectIndex?: number
+  /**
+   * Enable iOS bounces spring effect
+   * @zh 启用 iOS 弹性效果
+   * @defaultValue true
+   * @iOS
+   */
+  bounces?: boolean
+  /**
+   * Additional props that will be passed through to the underlying `viewpager` element.
+   * @zh 将被直接传递到底层 `viewpager` 元素的额外属性。
+   * @iOS
+   * @Android
+   */
+  viewpagerProps?: Partial<NativeViewPagerProps>
+  /**
+   * exposure-screen-margin-left
+   * @zh 曝光屏幕左边距
+   * @defaultValue '50px'
+   * @Android
+   * @iOS
+   * @Harmony
+   * @deprecated Please use 'lazyOptions' instead.
+   */
+  exposureLeft?: string
+  /**
+   * exposure-screen-margin-right
+   * @zh 曝光屏幕右边距
+   * @defaultValue '50px'
+   * @Android
+   * @iOS
+   * @Harmony
+   * @deprecated Please use 'lazyOptions' instead.
+   */
+  exposureRight?: string
+  /**
+   * ViewPager scrolled.
+   * @zh ViewPager 滚动。
+   * @eventProperty
+   * @Android
+   * @iOS
+   */
+  onOffsetChange?: (e: { detail: ViewPagerOffsetChangeEvent }) => void
+  /**
+   * ViewPager scrolled. The handler should be a main thread event.
+   * @zh ViewPager 滚动。该事件处理函数应在主线程中执行。
+   * @eventProperty
+   * @Android
+   * @iOS
+   */
+  MTOnOffsetChange?: (e: { detail: ViewPagerOffsetChangeEvent }) => void
+  /**
+   * Viewpager page will be changed.
+   * @zh Viewpager 页面将要改变。
+   * @eventProperty
+   * @Android
+   * @iOS
+   * @Harmony
+   * @since 2.17
+   */
+  onPageWillChange?: (e: { detail: ViewPagerChangeEvent }) => void
+  /**
+   * Viewpager page will be changed. The handler should be a main thread event.
+   * @zh Viewpager 页面将要改变。该事件处理函数应在主线程中执行。
+   * @eventProperty
+   * @Android
+   * @iOS
+   */
+  MTOnPageWillChange?: (e: { detail: ViewPagerChangeEvent }) => void
+  /**
+   * Viewpager page did changed.
+   * @zh Viewpager 页面已改变。
+   * @eventProperty
+   * @Android
+   * @iOS
+   */
+  onPageChange?: (e: { detail: ViewPagerChangeEvent }) => void
+  /**
+   * Viewpager page did changed. The handler should be a main thread event.
+   * @zh Viewpager 页面已改变。该事件处理函数应在主线程中执行。
+   * @eventProperty
+   * @Android
+   * @iOS
+   */
+  MTOnPageChange?: (e: { detail: ViewPagerChangeEvent }) => void
+  /**
+   * Enable horizontal scroll.
+   * @zh 启用水平滚动。
+   * @defaultValue true
+   * @Android
+   * @iOS
+   */
+  enableScroll?: boolean
+  /**
+   * Children, which is ViewPagerItems.
+   * @zh 子元素, 即 ViewPagerItems。
+   * @Android
+   * @iOS
+   */
+  children?: ReactElement[]
+}
+
+export interface ViewPagerChangeEvent {
+  /**
+   * Current index
+   * @zh 当前索引
+   * @Android
+   * @iOS
+   */
+  index: number
+  /**
+   * If being dragged
+   * @zh 是否被拖动
+   * @Android
+   * @iOS
+   */
+  isDragged: boolean
+}
+
+export interface ViewPagerOffsetChangeEvent {
+  /**
+   * The scrolling offset, in px
+   * @zh 滚动偏移量，以像素为单位
+   * @Android
+   * @iOS
+   */
+  offset: number
+}

--- a/packages/lynx-ui-view-pager/src/types/index.docs.ts
+++ b/packages/lynx-ui-view-pager/src/types/index.docs.ts
@@ -2,225 +2,202 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { ForwardedRef, ReactElement } from '@lynx-js/react'
+import type { ReactNode } from '@lynx-js/react'
 
-import type { ComponentBasicProps, LazyOptions } from '@lynx-js/lynx-ui-common'
+import type { ComponentBasicProps } from '@lynx-js/lynx-ui-common'
 import type {
-  CSSProperties,
+  ViewPagerItemProps as NativeViewPagerItemProps,
   ViewPagerProps as NativeViewPagerProps,
+  ViewPagerChangeEvent,
+  ViewPagerOffsetChangeEvent,
+  ViewPagerWillChangeEvent,
 } from '@lynx-js/types'
 
-export type ViewPager = (props: ViewPagerProps) => ReactElement
+export type { ViewPagerChangeEvent, ViewPagerOffsetChangeEvent }
 
 export interface ViewPagerRef {
   /**
-   * Slide to the specified page.
-   * @zh 滑动到指定页面。
+   * Slide to a page through the native node ref. Animation defaults to true.
+   * Indexes are clamped to available pages. Empty pagers ignore requests.
+   * Completion is reported through onPageChange; success confirms invocation.
+   * @zh 通过原生节点引用切换页面，默认使用动画。索引限制在有效范围内，空列表忽略请求。onPageChange 表示切换完成，success 表示调用成功。
    * @Android
    * @iOS
    */
   selectTab: (
-    /**
-     * The index to be scrolled to.
-     * @zh 要滚动到的索引。
-     * @Android
-     * @iOS
-     */
     index: number,
-    /**
-     * If a animation effect needed.
-     * @zh 是否需要动画效果。
-     * @Android
-     * @iOS
-     */
-    smooth: boolean,
-    success?: (res: unknown) => void,
-    fail?: (res: unknown) => void,
+    smooth?: boolean,
+    success?: (result: unknown) => void,
+    fail?: (result: unknown) => void,
   ) => void
 }
 
 export interface ViewPagerProps extends ComponentBasicProps {
-  ref?: ForwardedRef<ViewPagerRef>
   /**
-   * Enable lazy rendering for off-screen pages.
-   * @zh 启用屏外页面的懒加载渲染。
-   * @defaultValue `{ enableLazy: true, scene: 'viewpager', exposureLeft: '50px', exposureRight: '50px' }`
-   * @Android
-   * @iOS
-   */
-  lazyOptions?: LazyOptions
-  /**
-   * Be used to mark the exposure timing of lazy loading. Please ensure that it is unique throughout the page.
-   * @zh 用于标记懒加载的曝光时间。请确保在整个页面中唯一。
-   * @Android
-   * @iOS
-   * @deprecated Please use `lazyOptions` instead.
-   */
-  scene?: string
-  /**
-   * The id of the `viewpager`. It is used to select the element. When omitted, ViewPager generates a unique id for the instance.
-   * @zh `viewpager` 的 ID，用于选择该元素。省略时，ViewPager 会为当前实例生成唯一 ID。
-   * @Android
-   * @iOS
-   */
-  viewpagerId?: string
-  /**
-   * Style for `viewpager`. Changing its layout with style is unrecommended.
-   * @zh `viewpager` 的样式。不建议通过样式改变其布局。
-   * @Android
-   * @iOS
-   */
-  style?: CSSProperties
-  /**
-   * Style for `viewpager-item`.
-   * @zh `viewpager-item` 的样式。
-   * @Android
-   * @iOS
-   */
-  viewpagerItemStyle?: CSSProperties
-  /**
-   * Specify the index after datasource changed. Please use `selectTab` for other updates.
-   * @zh 数据源改变后指定的索引。请使用 `selectTab` 进行其他更新。
+   * Initial page index. Later changes are ignored; use ref.selectTab to navigate.
    * @defaultValue 0
+   * @zh 初始页面索引，后续修改不生效。使用 ref.selectTab 切换页面。
    * @Android
    * @iOS
-   * @deprecated Please use `initialSelectIndex` instead
-   */
-  selectIndexAfterDataSourceChanged?: number
-  /**
-   * Specify the index of the initial display. Please use `selectTab` for other updates.
-   * @zh 指定初始显示的索引。请使用 `selectTab` 进行其他更新。
-   * @defaultValue 0
-   * @Android
-   * @iOS
-   * @Harmony
-   * @since 2.17
    */
   initialSelectIndex?: number
   /**
-   * Enable iOS bounces spring effect
-   * @zh 启用 iOS 弹性效果
+   * Defer off-screen content until selected, preloaded, or about to appear.
+   * Mounted content stays mounted until its keyed item is removed.
    * @defaultValue true
-   * @iOS
-   */
-  bounces?: boolean
-  /**
-   * Additional props that will be passed through to the underlying `viewpager` element.
-   * @zh 将被直接传递到底层 `viewpager` 元素的额外属性。
-   * @iOS
-   * @Android
-   */
-  viewpagerProps?: Partial<NativeViewPagerProps>
-  /**
-   * exposure-screen-margin-left
-   * @zh 曝光屏幕左边距
-   * @defaultValue '50px'
-   * @Android
-   * @iOS
-   * @Harmony
-   * @deprecated Please use 'lazyOptions' instead.
-   */
-  exposureLeft?: string
-  /**
-   * exposure-screen-margin-right
-   * @zh 曝光屏幕右边距
-   * @defaultValue '50px'
-   * @Android
-   * @iOS
-   * @Harmony
-   * @deprecated Please use 'lazyOptions' instead.
-   */
-  exposureRight?: string
-  /**
-   * ViewPager scrolled.
-   * @zh ViewPager 滚动。
-   * @eventProperty
+   * @zh 延迟挂载屏外内容；选中、预加载或即将显示时挂载。已挂载内容保留到对应条目被移除。
    * @Android
    * @iOS
    */
-  onOffsetChange?: (e: { detail: ViewPagerOffsetChangeEvent }) => void
+  lazy?: boolean
   /**
-   * ViewPager scrolled. The handler should be a main thread event.
-   * @zh ViewPager 滚动。该事件处理函数应在主线程中执行。
-   * @eventProperty
+   * Number of neighboring pages to mount on each side of the selected page.
+   * Nonnegative integer; ignored when lazy is false.
+   * @defaultValue 1
+   * @zh 选中页面两侧预加载的页面数，为非负整数。lazy 为 false 时忽略。
    * @Android
    * @iOS
    */
-  MTOnOffsetChange?: (e: { detail: ViewPagerOffsetChangeEvent }) => void
+  preloadCount?: number
   /**
-   * Viewpager page will be changed.
-   * @zh Viewpager 页面将要改变。
-   * @eventProperty
-   * @Android
-   * @iOS
-   * @Harmony
-   * @since 2.17
-   */
-  onPageWillChange?: (e: { detail: ViewPagerChangeEvent }) => void
-  /**
-   * Viewpager page will be changed. The handler should be a main thread event.
-   * @zh Viewpager 页面将要改变。该事件处理函数应在主线程中执行。
-   * @eventProperty
-   * @Android
-   * @iOS
-   */
-  MTOnPageWillChange?: (e: { detail: ViewPagerChangeEvent }) => void
-  /**
-   * Viewpager page did changed.
-   * @zh Viewpager 页面已改变。
-   * @eventProperty
-   * @Android
-   * @iOS
-   */
-  onPageChange?: (e: { detail: ViewPagerChangeEvent }) => void
-  /**
-   * Viewpager page did changed. The handler should be a main thread event.
-   * @zh Viewpager 页面已改变。该事件处理函数应在主线程中执行。
-   * @eventProperty
-   * @Android
-   * @iOS
-   */
-  MTOnPageChange?: (e: { detail: ViewPagerChangeEvent }) => void
-  /**
-   * Enable horizontal scroll.
-   * @zh 启用水平滚动。
+   * Enable horizontal swipe gestures.
    * @defaultValue true
+   * @zh 启用水平滑动手势。
    * @Android
    * @iOS
    */
   enableScroll?: boolean
   /**
-   * Children, which is ViewPagerItems.
-   * @zh 子元素, 即 ViewPagerItems。
+   * Enable the native spring effect where supported.
+   * @defaultValue true
+   * @zh 在支持的平台启用原生回弹效果。
    * @Android
    * @iOS
    */
-  children?: ReactElement[]
+  bounces?: boolean
+  /**
+   * Native pager attributes not managed by the component, including id and
+   * accessibility attributes. Use the dedicated props for styles and events.
+   * @zh 组件未管理的原生属性，包括 id 和无障碍属性。样式和事件使用专用属性。
+   * @Android
+   * @iOS
+   */
+  viewpagerProps?: Omit<
+    NativeViewPagerProps,
+    | 'children'
+    | 'ref'
+    | 'className'
+    | 'style'
+    | 'initial-select-index'
+    | 'select-index'
+    | 'align-width'
+    | 'enable-scroll'
+    | 'allow-horizontal-gesture'
+    | 'bounces'
+    | 'keep-item-view'
+    | 'bindchange'
+    | 'bindwillchange'
+    | 'bindoffsetchange'
+    | 'main-thread:bindchange'
+    | 'main-thread:bindwillchange'
+    | 'main-thread:bindoffsetchange'
+  >
+  /**
+   * Native page completion event, including programmatic transitions.
+   * @zh 原生页面切换完成事件，包括命令式切换。
+   * @Android
+   * @iOS
+   */
+  onPageChange?: (event: ViewPagerChangeEvent) => void
+  /**
+   * Native event before a page transition completes.
+   * @zh 原生页面切换完成前事件。
+   * @Android
+   * @iOS
+   */
+  onPageWillChange?: (event: ViewPagerWillChangeEvent) => void
+  /**
+   * Native scroll progress in page units: 0 to 1 between the first two pages,
+   * not a pixel distance.
+   * @zh 原生滚动进度，以页面为单位。前两页之间为 0 到 1，并非像素距离。
+   * @Android
+   * @iOS
+   */
+  onOffsetChange?: (event: ViewPagerOffsetChangeEvent) => void
+  /**
+   * Main-thread page completion handler. Use a main thread function.
+   * @zh 主线程页面切换完成回调，需使用主线程函数。
+   * @Android
+   * @iOS
+   */
+  MTOnPageChange?: (event: ViewPagerChangeEvent) => void
+  /**
+   * Main-thread page transition handler. Use a main thread function.
+   * @zh 主线程页面即将切换回调，需使用主线程函数。
+   * @Android
+   * @iOS
+   */
+  MTOnPageWillChange?: (event: ViewPagerWillChangeEvent) => void
+  /**
+   * Main-thread scroll progress handler, in page units. Use a main thread function.
+   * @zh 主线程滚动进度回调，以页面为单位，需使用主线程函数。
+   * @Android
+   * @iOS
+   */
+  MTOnOffsetChange?: (event: ViewPagerOffsetChangeEvent) => void
+  /**
+   * Direct ViewPagerItem elements. Arrays and conditional items are supported;
+   * fragments and wrapper components are not. Use stable keys for dynamic pages.
+   * Selection follows the numeric position after reordering; removed selections
+   * clamp to the last page. An empty pager has index 0 and sends no requests.
+   * @zh 直接使用 ViewPagerItem，支持数组和条件条目，不支持 Fragment 或包装组件。动态页面使用稳定 key。重排后按索引选择，删除后限制到最后一页，空列表索引为 0 且不发出请求。
+   * @Android
+   * @iOS
+   */
+  children?: ReactNode
 }
 
-export interface ViewPagerChangeEvent {
+export interface ViewPagerItemRenderProps {
   /**
-   * Current index
-   * @zh 当前索引
+   * Zero-based position in the pager.
+   * @zh 页面从零开始的索引。
    * @Android
    * @iOS
    */
   index: number
   /**
-   * If being dragged
-   * @zh 是否被拖动
+   * Whether this is the selected page.
+   * @zh 是否为选中页面。
    * @Android
    * @iOS
    */
-  isDragged: boolean
+  selected: boolean
 }
 
-export interface ViewPagerOffsetChangeEvent {
+export interface ViewPagerItemProps extends ComponentBasicProps {
   /**
-   * The scrolling offset, in px
-   * @zh 滚动偏移量，以像素为单位
+   * Native item attributes, including accessibility properties.
+   * @zh 原生页面容器属性，包括无障碍属性。
    * @Android
    * @iOS
    */
-  offset: number
+  itemProps?: Omit<NativeViewPagerItemProps, 'children' | 'className' | 'style'>
+  /**
+   * Page content or a function receiving selection state.
+   * @zh 页面内容或接收选择状态的渲染函数。
+   * @docTypeFallback ReactNode | ((status: ViewPagerItemRenderProps) => ReactNode)
+   * @Android
+   * @iOS
+   */
+  children?: ReactNode | ((status: ViewPagerItemRenderProps) => ReactNode)
+}
+
+export interface ViewPagerItemUIVariants {
+  /**
+   * Applied to the selected page container.
+   * @zh 应用于选中页面容器。
+   * @Android
+   * @iOS
+   */
+  'ui-selected'?: boolean
 }

--- a/packages/lynx-ui-view-pager/src/types/index.ts
+++ b/packages/lynx-ui-view-pager/src/types/index.ts
@@ -1,0 +1,5 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export type * from './index.docs'

--- a/packages/lynx-ui-view-pager/src/utils.ts
+++ b/packages/lynx-ui-view-pager/src/utils.ts
@@ -1,0 +1,47 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { LazyOptions } from '@lynx-js/lynx-ui-common'
+
+type ExposureMargin = `${number}px` | `${number}rpx`
+
+interface LegacyLazyOptions {
+  scene?: string
+  exposureLeft?: string
+  exposureRight?: string
+}
+
+interface ResolvedLazyOptions {
+  enableLazy: boolean
+  scene: string
+  exposureLeft: ExposureMargin
+  exposureRight: ExposureMargin
+}
+
+let globalViewPagerId = 0
+
+export function createViewPagerId(): string {
+  return `lynx-ui-view-pager-${globalViewPagerId++}`
+}
+
+export function resolveLazyOptions(
+  lazyOptions: LazyOptions | undefined,
+  legacyOptions: LegacyLazyOptions,
+): ResolvedLazyOptions {
+  const enableLazy = lazyOptions?.enableLazy ?? true
+  const enabledOptions = lazyOptions?.enableLazy === true
+    ? lazyOptions
+    : undefined
+
+  return {
+    enableLazy,
+    scene: enabledOptions?.scene ?? legacyOptions.scene ?? 'viewpager',
+    exposureLeft: (enabledOptions?.exposureLeft
+      ?? legacyOptions.exposureLeft
+      ?? '50px') as ExposureMargin,
+    exposureRight: (enabledOptions?.exposureRight
+      ?? legacyOptions.exposureRight
+      ?? '50px') as ExposureMargin,
+  }
+}

--- a/packages/lynx-ui-view-pager/src/utils.ts
+++ b/packages/lynx-ui-view-pager/src/utils.ts
@@ -2,46 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { LazyOptions } from '@lynx-js/lynx-ui-common'
-
-type ExposureMargin = `${number}px` | `${number}rpx`
-
-interface LegacyLazyOptions {
-  scene?: string
-  exposureLeft?: string
-  exposureRight?: string
-}
-
-interface ResolvedLazyOptions {
-  enableLazy: boolean
-  scene: string
-  exposureLeft: ExposureMargin
-  exposureRight: ExposureMargin
-}
-
-let globalViewPagerId = 0
-
-export function createViewPagerId(): string {
-  return `lynx-ui-view-pager-${globalViewPagerId++}`
-}
-
-export function resolveLazyOptions(
-  lazyOptions: LazyOptions | undefined,
-  legacyOptions: LegacyLazyOptions,
-): ResolvedLazyOptions {
-  const enableLazy = lazyOptions?.enableLazy ?? true
-  const enabledOptions = lazyOptions?.enableLazy === true
-    ? lazyOptions
-    : undefined
-
-  return {
-    enableLazy,
-    scene: enabledOptions?.scene ?? legacyOptions.scene ?? 'viewpager',
-    exposureLeft: (enabledOptions?.exposureLeft
-      ?? legacyOptions.exposureLeft
-      ?? '50px') as ExposureMargin,
-    exposureRight: (enabledOptions?.exposureRight
-      ?? legacyOptions.exposureRight
-      ?? '50px') as ExposureMargin,
-  }
+export function normalizeIndex(index: number, count: number): number {
+  if (!Number.isFinite(index) || count === 0) return 0
+  return Math.min(Math.max(Math.trunc(index), 0), count - 1)
 }

--- a/packages/lynx-ui-view-pager/tsconfig.docs.json
+++ b/packages/lynx-ui-view-pager/tsconfig.docs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tools/configs/tsconfig.docs.json",
+  "include": [
+    "src",
+    "dist/types/index.docs.d.ts"
+  ]
+}

--- a/packages/lynx-ui-view-pager/tsconfig.json
+++ b/packages/lynx-ui-view-pager/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tools/configs/tsconfig.lib.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+  },
+  "include": [
+    "src",
+  ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+  ],
+}

--- a/packages/lynx-ui-view-pager/vitest.config.ts
+++ b/packages/lynx-ui-view-pager/vitest.config.ts
@@ -1,0 +1,12 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['__tests__/**/*.test.ts'],
+    name: 'lynx-ui-view-pager',
+  },
+})

--- a/packages/lynx-ui-view-pager/vitest.config.ts
+++ b/packages/lynx-ui-view-pager/vitest.config.ts
@@ -2,11 +2,15 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { defineConfig } from 'vitest/config'
+import { createVitestConfig } from '@lynx-js/react/testing-library/vitest-config'
+import { defineConfig, mergeConfig } from 'vitest/config'
 
-export default defineConfig({
-  test: {
-    include: ['__tests__/**/*.test.ts'],
-    name: 'lynx-ui-view-pager',
-  },
-})
+export default mergeConfig(
+  createVitestConfig(),
+  defineConfig({
+    test: {
+      include: ['__tests__/**/*.test.{ts,tsx}'],
+      name: 'lynx-ui-view-pager',
+    },
+  }),
+)

--- a/packages/lynx-ui/src/index.tsx
+++ b/packages/lynx-ui/src/index.tsx
@@ -256,6 +256,15 @@ export type {
   SwitchRenderProps,
 } from '@lynx-js/lynx-ui-switch'
 
+// view-pager
+export { ViewPager } from '@lynx-js/lynx-ui-view-pager'
+export type {
+  ViewPagerChangeEvent,
+  ViewPagerOffsetChangeEvent,
+  ViewPagerProps,
+  ViewPagerRef,
+} from '@lynx-js/lynx-ui-view-pager'
+
 export {
   SheetRoot,
   SheetContent,

--- a/packages/lynx-ui/src/index.tsx
+++ b/packages/lynx-ui/src/index.tsx
@@ -256,6 +256,23 @@ export type {
   SwitchRenderProps,
 } from '@lynx-js/lynx-ui-switch'
 
+// tab-group
+export {
+  TabsRoot,
+  TabsBar,
+  TabsItem,
+  TabsIndicator,
+} from '@lynx-js/lynx-ui-tab-group'
+export type {
+  TabItemProps,
+  TabsData,
+  TabsIndicatorAnimation,
+  TabsIndicatorProps,
+  TabsRootProps,
+  TabsBarProps,
+  TabsRootRef,
+} from '@lynx-js/lynx-ui-tab-group'
+
 // view-pager
 export { ViewPager, ViewPagerItem } from '@lynx-js/lynx-ui-view-pager'
 export type {

--- a/packages/lynx-ui/src/index.tsx
+++ b/packages/lynx-ui/src/index.tsx
@@ -257,9 +257,12 @@ export type {
 } from '@lynx-js/lynx-ui-switch'
 
 // view-pager
-export { ViewPager } from '@lynx-js/lynx-ui-view-pager'
+export { ViewPager, ViewPagerItem } from '@lynx-js/lynx-ui-view-pager'
 export type {
   ViewPagerChangeEvent,
+  ViewPagerItemProps,
+  ViewPagerItemRenderProps,
+  ViewPagerItemUIVariants,
   ViewPagerOffsetChangeEvent,
   ViewPagerProps,
   ViewPagerRef,

--- a/packages/lynx-ui/src/index.tsx
+++ b/packages/lynx-ui/src/index.tsx
@@ -261,6 +261,7 @@ export {
   TabsRoot,
   TabsBar,
   TabsItem,
+  TabsPanel,
   TabsIndicator,
 } from '@lynx-js/lynx-ui-tab-group'
 export type {
@@ -268,6 +269,8 @@ export type {
   TabsData,
   TabsIndicatorAnimation,
   TabsIndicatorProps,
+  TabsPanelProps,
+  TabsPanelRef,
   TabsRootProps,
   TabsBarProps,
   TabsRootRef,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -828,6 +828,34 @@ importers:
         specifier: catalog:tailwind
         version: 3.4.17
 
+  apps/examples/ViewPager:
+    dependencies:
+      '@lynx-js/luna-styles':
+        specifier: workspace:*
+        version: link:../../../luna/packages/luna-styles
+      '@lynx-js/lynx-ui':
+        specifier: workspace:*
+        version: link:../../../packages/lynx-ui
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.123.1(@lynx-js/types@4.1.0)(@types/react@18.3.28)
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.6.0(@lynx-js/rspeedy@0.16.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.106.2(postcss@8.5.14)))
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.18.1(@lynx-js/lynx-core@0.1.4)(@lynx-js/react@0.123.1(@lynx-js/types@4.1.0)(@types/react@18.3.28))(tslib@2.8.1)
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.16.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.106.2(postcss@8.5.14))
+      '@lynx-js/types':
+        specifier: 'catalog:'
+        version: 4.1.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.28
+
   luna/examples/luna-design-system:
     dependencies:
       '@lynx-js/luna-core':
@@ -1362,6 +1390,9 @@ importers:
       '@lynx-js/lynx-ui-switch':
         specifier: workspace:*
         version: link:../lynx-ui-switch
+      '@lynx-js/lynx-ui-view-pager':
+        specifier: workspace:*
+        version: link:../lynx-ui-view-pager
     devDependencies:
       '@lynx-js/react':
         specifier: 'catalog:'
@@ -1963,6 +1994,34 @@ importers:
       '@lynx-js/react-use':
         specifier: 'catalog:'
         version: 0.2.2(@lynx-js/react@0.123.1(@lynx-js/types@4.1.0)(@types/react@18.3.28))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      clsx:
+        specifier: 'catalog:'
+        version: 2.1.1
+    devDependencies:
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.123.1(@lynx-js/types@4.1.0)(@types/react@18.3.28)
+      '@lynx-js/types':
+        specifier: 'catalog:'
+        version: 4.1.0
+      '@rslib/core':
+        specifier: 'catalog:'
+        version: 0.23.2(core-js@3.47.0)(typescript@5.9.3)
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.28
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
+  packages/lynx-ui-view-pager:
+    dependencies:
+      '@lynx-js/lynx-ui-common':
+        specifier: workspace:*
+        version: link:../lynx-ui-common
+      '@lynx-js/lynx-ui-lazy-component':
+        specifier: workspace:*
+        version: link:../lynx-ui-lazy-component
       clsx:
         specifier: 'catalog:'
         version: 2.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2053,6 +2053,9 @@ importers:
       '@lynx-js/lynx-ui-scroll-view':
         specifier: workspace:*
         version: link:../lynx-ui-scroll-view
+      '@lynx-js/lynx-ui-view-pager':
+        specifier: workspace:*
+        version: link:../lynx-ui-view-pager
       '@lynx-js/motion':
         specifier: 'catalog:'
         version: 0.0.3(@lynx-js/react@0.123.1(@lynx-js/types@4.1.0)(@types/react@18.3.28))(@lynx-js/types@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2019,9 +2019,6 @@ importers:
       '@lynx-js/lynx-ui-common':
         specifier: workspace:*
         version: link:../lynx-ui-common
-      '@lynx-js/lynx-ui-lazy-component':
-        specifier: workspace:*
-        version: link:../lynx-ui-lazy-component
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -2038,6 +2035,9 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.28
+      jsdom:
+        specifier: 'catalog:'
+        version: 25.0.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -828,6 +828,34 @@ importers:
         specifier: catalog:tailwind
         version: 3.4.17
 
+  apps/examples/TabGroup:
+    dependencies:
+      '@lynx-js/luna-styles':
+        specifier: workspace:*
+        version: link:../../../luna/packages/luna-styles
+      '@lynx-js/lynx-ui':
+        specifier: workspace:*
+        version: link:../../../packages/lynx-ui
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.123.1(@lynx-js/types@4.1.0)(@types/react@18.3.28)
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.6.0(@lynx-js/rspeedy@0.16.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.106.2(postcss@8.5.14)))
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.18.1(@lynx-js/lynx-core@0.1.4)(@lynx-js/react@0.123.1(@lynx-js/types@4.1.0)(@types/react@18.3.28))(tslib@2.8.1)
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.16.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.106.2(postcss@8.5.14))
+      '@lynx-js/types':
+        specifier: 'catalog:'
+        version: 4.1.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.28
+
   apps/examples/ViewPager:
     dependencies:
       '@lynx-js/luna-styles':
@@ -1390,6 +1418,9 @@ importers:
       '@lynx-js/lynx-ui-switch':
         specifier: workspace:*
         version: link:../lynx-ui-switch
+      '@lynx-js/lynx-ui-tab-group':
+        specifier: workspace:*
+        version: link:../lynx-ui-tab-group
       '@lynx-js/lynx-ui-view-pager':
         specifier: workspace:*
         version: link:../lynx-ui-view-pager
@@ -1994,6 +2025,37 @@ importers:
       '@lynx-js/react-use':
         specifier: 'catalog:'
         version: 0.2.2(@lynx-js/react@0.123.1(@lynx-js/types@4.1.0)(@types/react@18.3.28))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      clsx:
+        specifier: 'catalog:'
+        version: 2.1.1
+    devDependencies:
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.123.1(@lynx-js/types@4.1.0)(@types/react@18.3.28)
+      '@lynx-js/types':
+        specifier: 'catalog:'
+        version: 4.1.0
+      '@rslib/core':
+        specifier: 'catalog:'
+        version: 0.23.2(core-js@3.47.0)(typescript@5.9.3)
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.28
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
+  packages/lynx-ui-tab-group:
+    dependencies:
+      '@lynx-js/lynx-ui-common':
+        specifier: workspace:*
+        version: link:../lynx-ui-common
+      '@lynx-js/lynx-ui-scroll-view':
+        specifier: workspace:*
+        version: link:../lynx-ui-scroll-view
+      '@lynx-js/motion':
+        specifier: 'catalog:'
+        version: 0.0.3(@lynx-js/react@0.123.1(@lynx-js/types@4.1.0)(@types/react@18.3.28))(@lynx-js/types@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -6144,9 +6206,6 @@ packages:
 
   motion-dom@12.23.12:
     resolution: {integrity: sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==}
-
-  motion-dom@12.39.0:
-    resolution: {integrity: sha512-Xn7aAcGDhco/JZTXOub64UmaYn73C6J1Po7Fk+8EvkJsNGTqfhon6UJY53vJKXW5v5Zl8HrYsVxv6oPXeGoGLQ==}
 
   motion-dom@12.43.0:
     resolution: {integrity: sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==}
@@ -11125,7 +11184,7 @@ snapshots:
 
   framer-motion@12.34.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      motion-dom: 12.39.0
+      motion-dom: 12.43.0
       motion-utils: 12.39.0
       tslib: 2.8.1
     optionalDependencies:
@@ -11858,10 +11917,6 @@ snapshots:
   minipass@7.1.3: {}
 
   motion-dom@12.23.12:
-    dependencies:
-      motion-utils: 12.23.6
-
-  motion-dom@12.39.0:
     dependencies:
       motion-utils: 12.39.0
 

--- a/tools/skill-lynx-ui/component-routing.json
+++ b/tools/skill-lynx-ui/component-routing.json
@@ -99,6 +99,11 @@
       "label": "Switch",
       "useWhen": "The UI needs an immediate binary on/off setting.",
       "avoidWhen": "The interaction represents form selection or an indeterminate state; use Checkbox."
+    },
+    "view-pager": {
+      "label": "ViewPager",
+      "useWhen": "The UI needs page-snapped horizontal content navigation with optional lazy rendering.",
+      "avoidWhen": "The UI needs a looping carousel with custom transition behavior; use Swiper."
     }
   },
   "excludedComponents": {

--- a/tools/skill-lynx-ui/component-routing.json
+++ b/tools/skill-lynx-ui/component-routing.json
@@ -100,6 +100,11 @@
       "useWhen": "The UI needs an immediate binary on/off setting.",
       "avoidWhen": "The interaction represents form selection or an indeterminate state; use Checkbox."
     },
+    "tab-group": {
+      "label": "TabGroup",
+      "useWhen": "The UI needs coordinated tab navigation with selectable items and an animated indicator.",
+      "avoidWhen": "The UI needs carousel-style content paging; use Swiper."
+    },
     "view-pager": {
       "label": "ViewPager",
       "useWhen": "The UI needs page-snapped horizontal content navigation with optional lazy rendering.",

--- a/tools/typedoc/index.ts
+++ b/tools/typedoc/index.ts
@@ -79,6 +79,13 @@ const primitivesConfig: Record<string, string[]> = {
     'InputOTP',
     'InputOTPSlot',
   ],
+  'lynx-ui-tab-group': [
+    'TabsRoot',
+    'TabsBar',
+    'TabsItem',
+    'TabItem',
+    'TabsIndicator',
+  ],
 }
 export async function runTypeDocForPackage(
   entryPoints: string | string[],

--- a/tools/typedoc/index.ts
+++ b/tools/typedoc/index.ts
@@ -25,6 +25,7 @@ const excludedPath = [
 ]
 
 const primitivesConfig: Record<string, string[]> = {
+  'lynx-ui-view-pager': ['ViewPager', 'ViewPagerItem'],
   'lynx-ui-button': ['Button'],
   'lynx-ui-switch': [
     'Switch',

--- a/tools/typedoc/index.ts
+++ b/tools/typedoc/index.ts
@@ -84,6 +84,7 @@ const primitivesConfig: Record<string, string[]> = {
     'TabsBar',
     'TabsItem',
     'TabItem',
+    'TabsPanel',
     'TabsIndicator',
   ],
 }

--- a/tools/typedoc/tpl-data.ts
+++ b/tools/typedoc/tpl-data.ts
@@ -280,7 +280,10 @@ const doCalcSingleParam = (
   isZhContext: boolean,
   currentPkgName?: string,
 ) => {
-  return `${p.name}: ${doTypeCalc(p.type, isZhContext, currentPkgName)}`
+  const optionalMarker = p?.flags?.isOptional ? '?' : ''
+  return `${p.name}${optionalMarker}: ${
+    doTypeCalc(p.type, isZhContext, currentPkgName)
+  }`
 }
 
 const doCalcParams = (
@@ -320,6 +323,14 @@ const doCalcReflectionType = (
       return `(${doCalcParams(parameters, isZhContext, currentPkgName)}) => ${
         doSingleTypeCalc(type, isZhContext, currentPkgName)
       }`
+    }
+
+    if (declaration.children) {
+      return doCalcObjectLiteralType(
+        declaration.children,
+        isZhContext,
+        currentPkgName,
+      )
     }
 
     return 'Record<string, unknown>'

--- a/tools/typedoc/tpl-data.ts
+++ b/tools/typedoc/tpl-data.ts
@@ -169,12 +169,14 @@ function tryInlineReferenceType(
 
   const pkgName = typeof targetPackage === 'string'
     ? targetPackage
-    : currentPkgName
+    : (typeof t?.package === 'string'
+      ? t.package
+      : currentPkgName)
 
   const isExternalPackage = typeof pkgName === 'string'
     && pkgName.startsWith('@lynx-js/lynx-ui-')
     && pkgName !== '@lynx-js/lynx-ui-common'
-  if (!isExternalPackage) return null
+  if (!isExternalPackage || pkgName === currentPkgName) return null
 
   const ctx = getExternalTypeContext(pkgName, isZhContext)
   if (!ctx) return null
@@ -262,13 +264,27 @@ const doSingleTypeCalc = (
         return inlined ?? name
       }
       case 'array':
-        return `${t.elementType.name}[]`
+        return `${doTypeCalc(t.elementType, isZhContext, currentPkgName)}[]`
       case 'literal':
         return t.value
       case 'templateLiteral':
         return t.head + t.tail?.map((ti: any) => ti?.[1]).join(',')
+      case 'union':
+        return doCalcUnionType(t.types, isZhContext, currentPkgName)
+      case 'intersection':
+        return t.types
+          .map((type: any) =>
+            doSingleTypeCalc(type, isZhContext, currentPkgName)
+          )
+          .join(' & ')
+      case 'reflection':
+        return doCalcReflectionType(
+          t.declaration,
+          isZhContext,
+          currentPkgName,
+        )
       default:
-        return t
+        return name ?? 'unknown'
     }
   } catch (e) {
     throw e
@@ -350,15 +366,21 @@ const doTypeCalc = (t: any, isZhContext: boolean, currentPkgName?: string) => {
         return inlined ?? name
       }
       case 'array':
-        return `${t.elementType.name}[]`
+        return `${doTypeCalc(t.elementType, isZhContext, currentPkgName)}[]`
       case 'templateLiteral':
         return t.head + t.tail?.map((ti: any) => ti?.[1]).join(',')
       case 'union':
         return doCalcUnionType(types, isZhContext, currentPkgName)
+      case 'intersection':
+        return types
+          .map((type: any) =>
+            doSingleTypeCalc(type, isZhContext, currentPkgName)
+          )
+          .join(' & ')
       case 'reflection':
         return doCalcReflectionType(declaration, isZhContext, currentPkgName)
       default:
-        return t
+        return name ?? 'unknown'
     }
   } catch (e) {
     console.log(e)
@@ -461,12 +483,13 @@ const doGetChildren = (
   childrenRoot: Record<string, unknown>[],
   flag: string,
   currentPkgName?: string,
+  excludeInherited = false,
 ): any[] => {
   return groupsRoot?.map((g: any) => {
     const { title, children } = g
-    const targetChildren = childrenRoot.filter((c: any) =>
-      children.includes(c.id)
-    )
+    const targetChildren = childrenRoot
+      .filter((c: any) => children.includes(c.id))
+      .filter((c: any) => !excludeInherited || !c.flags?.isInherited)
 
     const formatChildren = targetChildren.map((f: any) => {
       if (f.groups && f.children) {
@@ -475,6 +498,7 @@ const doGetChildren = (
           f.children as Record<string, unknown>[],
           flag + '#',
           currentPkgName,
+          excludeInherited,
         )
       }
 
@@ -551,6 +575,7 @@ const doGenDocData = async (
                 ra.children as Record<string, unknown>[],
                 rootFlag + '##',
                 currentPkgName,
+                ra.name === 'TabItemProps',
               ),
             }
           }),

--- a/tools/typedoc/tpl.ts
+++ b/tools/typedoc/tpl.ts
@@ -692,6 +692,13 @@ const doGenTplWithData = async (
     )
   }
 
+  content = `${
+    content
+      .replace(/^\s+$/gmu, '')
+      .replace(/\n{3,}/gu, '\n\n')
+      .trimEnd()
+  }\n`
+
   fs.writeFileSync(savePath, content)
 }
 

--- a/tools/typedoc/tpl.ts
+++ b/tools/typedoc/tpl.ts
@@ -449,7 +449,7 @@ function genProps(data: any, hasMultipleProps?: boolean, isZh?: boolean) {
   context = `
 ${
     hasMultipleProps
-      ? `### ${title.replace(/props$/i, '').trim()} `
+      ? `### ${title.replace(/props$/i, '').trim()}`
       : `## ${title}`
   }
     ${comments ? comments : ''}


### PR DESCRIPTION
Adds `TabsPanel` to synchronize tab selection, the animated indicator, and swipeable ViewPager content, with a runnable example using `ViewPagerItem`.

Depends on #277 (ViewPager) and #273 (standalone tab navigation). The branch is based on `feat/view-pager` so only the ViewPager-dependent follow-up is stacked there; the shared TabGroup prerequisite is retained in the branch until #273 lands.

Closes #272 after both prerequisites land.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Introduce composable `TabGroup` primitives for tab navigation and animated indicators.
- Synchronize `TabsPanel` with `ViewPager` for swipeable content.
- Export `TabGroup` APIs from `lynx-ui`.
- Provide API documentation, skills guidance, and runnable examples.
- Configure package metadata, changelogs, release changesets, and documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->