### PR TITLE
docs(skill): add checkbox form radio and switch guides

### DIFF
--- a/.changeset/add-component-skill-guides.md
+++ b/.changeset/add-component-skill-guides.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/skill-lynx-ui': patch
+---
+
+Add usage guides for Checkbox, Form, RadioGroup, and Switch.

--- a/packages/lynx-ui-checkbox/SKILL.md
+++ b/packages/lynx-ui-checkbox/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: lynx-ui-checkbox
+description: Build headless controlled, uncontrolled, disabled, and indeterminate checkboxes with custom Lynx content and state-aware styling.
+---
+
+# lynx-ui Checkbox SKILL
+
+Use `Checkbox` when a boolean choice needs press behavior and state management but the product owns the visual design. Import it from `@lynx-js/lynx-ui` in OSS applications.
+
+## Core Capabilities
+
+- Supports controlled (`checked`) and uncontrolled (`defaultChecked`) state.
+- Supports checked, unchecked, indeterminate, pressed, and disabled states.
+- Exposes `CheckboxIndicator` for conditionally mounted check or mixed-state marks.
+- Accepts plain children or a render function that receives the current state.
+- Passes raw Lynx view props, such as hit slop, through `checkboxProps`.
+
+## AI Coding Guide
+
+### Minimal Usable Example
+
+```tsx
+import { useState } from '@lynx-js/react'
+import { Checkbox, CheckboxIndicator } from '@lynx-js/lynx-ui'
+
+function AgreementCheckbox() {
+  const [checked, setChecked] = useState(false)
+
+  return (
+    <Checkbox
+      className='agreement-checkbox'
+      checked={checked}
+      onChange={setChecked}
+    >
+      <CheckboxIndicator className='agreement-checkbox__indicator'>
+        <text>✓</text>
+      </CheckboxIndicator>
+      <text>I agree to the terms</text>
+    </Checkbox>
+  )
+}
+```
+
+### Recommended Prompt Formula
+
+> Checkbox purpose + controlled or uncontrolled state + checked/mixed/disabled appearance + hit area + change behavior.
+
+## Use Cases & Best Practices
+
+- Use `checked` with `onChange` when application state is authoritative. Use `defaultChecked` only for self-managed state.
+- Put the label inside `Checkbox` when the entire row should be pressable. Use `checkboxProps` for raw view behavior such as an expanded hit area.
+- Style state with `ui-checked`, `ui-indeterminate`, `ui-active`, and `ui-disabled`, or use render-function children for state-dependent content.
+- `CheckboxIndicator` mounts its children only while checked or indeterminate. Set `forceMount` when exit animation or layout stability requires the mark to remain mounted.
+- When `indeterminate` is true, the next press resolves the value to `true`; the parent still owns the `indeterminate` prop.
+
+```tsx
+<Checkbox
+  checked={allSelected}
+  indeterminate={someSelected && !allSelected}
+  onChange={checked => setSelected(checked ? allIds : [])}
+>
+  <CheckboxIndicator className='select-all__indicator'>
+    {someSelected && !allSelected ? <text>−</text> : <text>✓</text>}
+  </CheckboxIndicator>
+  <text>Select all</text>
+</Checkbox>
+```
+
+Reference examples: `apps/examples/Checkbox/Basic` and `Indeterminate`.
+
+## FAQ
+
+### Why does a controlled checkbox not change after tapping it?
+
+`onChange` reports the next value; update the state passed to `checked` in that callback.
+
+### Why is the indicator content absent while unchecked?
+
+That is the default slot behavior. Use `forceMount` when the content must always exist and hide it with state-aware CSS instead.
+
+## Sub components
+
+- `Checkbox`: Owns press behavior and checked-state semantics.
+- `CheckboxIndicator`: Renders the custom check or indeterminate mark.

--- a/packages/lynx-ui-form/SKILL.md
+++ b/packages/lynx-ui-form/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: lynx-ui-form
+description: Compose Lynx forms that collect Input, TextArea, RadioGroup, Checkbox, and Switch values and submit a single values object.
+---
+
+# lynx-ui Form SKILL
+
+Use `Form` to centralize values from supported lynx-ui controls without manually wiring each field into a separate state object. Import from `@lynx-js/lynx-ui` in OSS applications.
+
+## Core Capabilities
+
+- `FormRoot` owns a `Record<string, unknown>` keyed by field names.
+- `FormField` adapts `Input`, `TextArea`, `RadioGroupRoot`, `Checkbox`, and `Switch` to the form context.
+- `onChanged` receives the complete values object after a registered field changes.
+- `FormSubmitButton` submits the current snapshot through the root and/or button callback.
+- Fields unregister their value when they unmount.
+
+## AI Coding Guide
+
+### Minimal Usable Example
+
+```tsx
+import {
+  CheckboxIndicator,
+  FormField,
+  FormRoot,
+  FormSubmitButton,
+} from '@lynx-js/lynx-ui'
+
+function ProfileForm() {
+  return (
+    <FormRoot
+      initialValues={{ displayName: '', notifications: true }}
+      onSubmit={values => saveProfile(values)}
+    >
+      <FormField as='Input' name='displayName' className='profile-form__input' />
+      <FormField as='Checkbox' name='notifications' className='profile-form__check'>
+        <CheckboxIndicator><text>✓</text></CheckboxIndicator>
+        <text>Enable notifications</text>
+      </FormField>
+      <FormSubmitButton className='profile-form__submit'>
+        <text>Save</text>
+      </FormSubmitButton>
+    </FormRoot>
+  )
+}
+```
+
+### Recommended Prompt Formula
+
+> Field names and control types + initial values + change observation + validation strategy + submit behavior.
+
+## Use Cases & Best Practices
+
+- Give every `FormField` a unique, stable `name`; that string is the key in submitted values.
+- Put defaults in `FormRoot.initialValues`. It initializes the form once; changing the prop later is not a reset API.
+- Let `FormField` own the adapted control's value wiring. Do not pass the omitted value/default/change props that conflict with form ownership.
+- `Form` collects values but does not provide schema validation or error rendering. Validate in business logic and render errors explicitly.
+- Choose either `FormRoot.onSubmit` for form-level submission or `FormSubmitButton.onSubmit` for button-local follow-up. If both are supplied, both callbacks run.
+
+```tsx
+<FormField as='RadioGroupRoot' name='plan'>
+  <Radio value='free'><text>Free</text></Radio>
+  <Radio value='pro'><text>Pro</text></Radio>
+</FormField>
+<FormField as='TextArea' name='notes' />
+<FormField as='Switch' name='autoRenew'><SwitchThumb /></FormField>
+```
+
+Reference example: `apps/examples/Form/Basic`.
+
+## FAQ
+
+### Why did a conditional field disappear from the submitted object?
+
+Unmounting a `FormField` unregisters its name and removes that value. Keep the field mounted if its value must survive conditional visibility, or preserve it in application state.
+
+### Can arbitrary custom controls be passed through `as`?
+
+No. `FormField` supports only `Input`, `TextArea`, `RadioGroupRoot`, `Checkbox`, and `Switch`. Wire other controls to application state separately.
+
+### How do I reset the form?
+
+There is no imperative reset API. Remount `FormRoot` with a new key or manage the resettable values outside the component.
+
+## Sub components
+
+- `FormRoot`: Owns the value map and form-level callbacks.
+- `FormField`: Connects a supported control under a field name.
+- `FormSubmitButton`: A lynx-ui Button that submits the current values.
+- `FormContext`: Context export for advanced integrations.

--- a/packages/lynx-ui-radio-group/SKILL.md
+++ b/packages/lynx-ui-radio-group/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: lynx-ui-radio-group
+description: Build headless single-choice radio groups with controlled or uncontrolled value, group and item disabling, custom indicators, and state-aware styling.
+---
+
+# lynx-ui Radio Group SKILL
+
+Use `RadioGroupRoot`, `Radio`, and `RadioIndicator` when exactly one value from a set may be selected. Import them from `@lynx-js/lynx-ui` in OSS applications.
+
+## Core Capabilities
+
+- Supports controlled (`value`) and uncontrolled (`defaultValue`) selection.
+- Coordinates mutually exclusive `Radio` items by string value.
+- Disables either the whole group or individual items.
+- Conditionally renders custom indicator content for the selected item.
+- Exposes checked, active, and disabled classes for state-aware styling.
+
+## AI Coding Guide
+
+### Minimal Usable Example
+
+```tsx
+import { useState } from '@lynx-js/react'
+import { Radio, RadioGroupRoot, RadioIndicator } from '@lynx-js/lynx-ui'
+
+function PlanPicker() {
+  const [plan, setPlan] = useState('free')
+
+  return (
+    <RadioGroupRoot value={plan} onValueChange={setPlan}>
+      {['free', 'pro'].map(value => (
+        <Radio key={value} value={value} className='plan-option'>
+          <RadioIndicator className='plan-option__indicator'>
+            <view className='plan-option__dot' />
+          </RadioIndicator>
+          <text>{value}</text>
+        </Radio>
+      ))}
+    </RadioGroupRoot>
+  )
+}
+```
+
+### Recommended Prompt Formula
+
+> Choice data and stable values + controlled or uncontrolled mode + group/item disabled rules + indicator and row appearance + change behavior.
+
+## Use Cases & Best Practices
+
+- Give each `Radio` a unique, stable string `value`; selection is determined by equality with the root value.
+- In controlled mode, update `value` from `onValueChange`. Use `defaultValue` only when the group should own state.
+- `disabled` on `RadioGroupRoot` blocks every item; `disabled` on `Radio` blocks only that option.
+- Keep `Radio` inside `RadioGroupRoot`; the item and indicator depend on group context.
+- `RadioIndicator` mounts its children only for the selected item. Use `forceMount` for transitions or a persistent indicator shell.
+- Use `radioProps` for raw view behavior such as hit slop. Put the label inside `Radio` when the entire option row should be pressable.
+
+Reference examples: `apps/examples/RadioGroup/Basic` and `Disabled`.
+
+## FAQ
+
+### Why does the selected item revert after a tap?
+
+The group is controlled when `value` is present. Persist the value received by `onValueChange` and pass it back to the root.
+
+### Why is the indicator child missing on unselected items?
+
+Conditional mounting is intentional. Set `forceMount` and style with `ui-checked` if the child must remain mounted.
+
+### Can more than one item be selected?
+
+No. Use independent `Checkbox` components for multi-select behavior.
+
+## Sub components
+
+- `RadioGroupRoot`: Owns or receives the selected value.
+- `Radio`: A selectable item identified by its `value`.
+- `RadioIndicator`: The custom selected-state mark.

--- a/packages/lynx-ui-switch/SKILL.md
+++ b/packages/lynx-ui-switch/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: lynx-ui-switch
+description: Build headless controlled or uncontrolled Lynx switches with custom track and thumb composition, disabled behavior, render state, and state-aware styling.
+---
+
+# lynx-ui Switch SKILL
+
+Use `Switch` for an immediate boolean setting. It owns interaction semantics while the application supplies the track, thumb, and visual styling. Import from `@lynx-js/lynx-ui` in OSS applications.
+
+## Core Capabilities
+
+- Supports controlled (`checked`) and uncontrolled (`defaultChecked`) state.
+- Composes optional `SwitchTrack` and `SwitchThumb` visual slots.
+- Propagates checked, active, and disabled state to the root, track, and thumb.
+- Accepts render-function children for fully custom state-dependent content.
+- Passes raw Lynx view props, such as hit slop, through `switchProps`.
+
+## AI Coding Guide
+
+### Minimal Usable Example
+
+```tsx
+import { useState } from '@lynx-js/react'
+import { Switch, SwitchThumb, SwitchTrack } from '@lynx-js/lynx-ui'
+
+function NotificationsSwitch() {
+  const [checked, setChecked] = useState(true)
+
+  return (
+    <Switch className='setting-switch' checked={checked} onChange={setChecked}>
+      <SwitchTrack className='setting-switch__track' />
+      <SwitchThumb className='setting-switch__thumb' />
+    </Switch>
+  )
+}
+```
+
+### Recommended Prompt Formula
+
+> Setting meaning + controlled or uncontrolled state + dimensions + checked/pressed/disabled styling + hit area + change behavior.
+
+## Use Cases & Best Practices
+
+- Use `checked` with `onChange` when business state owns the value. Use `defaultChecked` for self-managed state.
+- Treat `Switch` as headless: define the root size, track appearance, thumb size, and checked translation in package-namespaced CSS.
+- Style state with `ui-checked`, `ui-active`, and `ui-disabled`; these classes are available on the root, track, and thumb.
+- Use `switchProps` for raw view props such as an expanded hit area. Avoid overriding the component's gesture bindings there.
+- Use a checkbox for multi-select or acknowledgement semantics. A switch represents a setting that takes effect immediately.
+
+```css
+.lynx-ui-settings__switch-thumb {
+  transform: translateX(3px);
+}
+
+.lynx-ui-settings__switch-thumb.ui-checked {
+  transform: translateX(23px);
+}
+```
+
+Reference examples: `apps/examples/Switch/Basic` and `Themed`.
+
+## FAQ
+
+### Why does a controlled switch snap back after tapping?
+
+`onChange` reports the next boolean but does not mutate the `checked` prop. Update the controlling state.
+
+### Does Switch provide default visuals?
+
+No product styling is assumed. Compose and style `SwitchTrack` and `SwitchThumb`, or render custom children from the state render function.
+
+### How do I make the touch target larger than the visible control?
+
+Pass the relevant raw view hit-slop props through `switchProps` while keeping visual styles on the component classes.
+
+## Sub components
+
+- `Switch`: Owns checked state and press behavior.
+- `SwitchTrack`: Optional background/decorative layer.
+- `SwitchThumb`: Optional movable handle.

--- a/tools/skill-lynx-ui/test/generator.test.ts
+++ b/tools/skill-lynx-ui/test/generator.test.ts
@@ -5,6 +5,7 @@
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { describe, expect, it } from 'vitest'
 
@@ -17,6 +18,33 @@ import {
   getExampleAppPaths,
   validateComponentRoutingManifest,
 } from '../generate-references.mjs'
+
+const packagesRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  'packages',
+)
+
+async function collectComponentSkillPaths() {
+  const entries = await fs.readdir(packagesRoot, { withFileTypes: true })
+  const skillPaths = await Promise.all(
+    entries
+      .filter(entry => entry.isDirectory() && entry.name.startsWith('lynx-ui-'))
+      .map(async entry => {
+        const skillPath = path.join(packagesRoot, entry.name, 'SKILL.md')
+        try {
+          await fs.access(skillPath)
+          return skillPath
+        } catch {
+          return undefined
+        }
+      }),
+  )
+
+  return skillPaths.filter(skillPath => skillPath !== undefined).sort()
+}
 
 describe('skill-lynx-ui generator helpers', () => {
   it('derives component slugs from package names', () => {
@@ -60,12 +88,16 @@ describe('skill-lynx-ui generator helpers', () => {
     expect(slugs).toContain('sheet')
     expect(slugs).toContain('slider')
     expect(slugs).toContain('swiper')
-    expect(slugs).toContain('checkbox')
     expect(slugs).not.toContain('presence')
-    expect(
-      components.find(component => component.slug === 'checkbox')?.skillPath,
-    )
-      .toBeUndefined()
+  })
+
+  it('discovers every component package that provides a skill', async () => {
+    const components = await collectIncludedComponents()
+    const discoveredSkillPaths = components
+      .flatMap(component => component.skillPath ?? [])
+      .sort()
+
+    expect(discoveredSkillPaths).toEqual(await collectComponentSkillPaths())
   })
 
   it('requires new documented components to be routed or excluded', () => {
@@ -118,9 +150,6 @@ describe('skill-lynx-ui generated output', () => {
         ).resolves.toBeTruthy()
       }
 
-      await expect(
-        fs.stat(path.join(tempRoot, 'references', 'components', 'checkbox')),
-      ).resolves.toBeTruthy()
       const lazyComponentApi = await fs.readFile(
         path.join(
           tempRoot,
@@ -146,17 +175,6 @@ describe('skill-lynx-ui generated output', () => {
       )
       expect(lazyComponentExamples).not.toContain('Origin:')
       expect(lazyComponentExamples).not.toContain('Source:')
-      await expect(
-        fs.stat(
-          path.join(
-            tempRoot,
-            'references',
-            'components',
-            'checkbox',
-            'guide.md',
-          ),
-        ),
-      ).rejects.toBeTruthy()
       await expect(fs.stat(path.join(tempRoot, 'examples'))).rejects
         .toBeTruthy()
     } finally {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Document Checkbox, Form, RadioGroup, and Switch usage guides in `lynx-ui`.
- Cover component states, composition, styling, and best practices.
- Align skill generator tests with the new guides.
- Declare a patch release for `@lynx-js/skill-lynx-ui`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->